### PR TITLE
test: add QuestionLoader parsing tests

### DIFF
--- a/test/question_loader_test.dart
+++ b/test/question_loader_test.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:civexam_app/services/question_loader.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  ByteData _stringToByteData(String value) {
+    final list = utf8.encode(value);
+    final buffer = Uint8List.fromList(list).buffer;
+    return ByteData.view(buffer);
+  }
+
+  void mockAssets(Map<String, String> assets) {
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (message) async {
+      final key = utf8.decode(message!.buffer.asUint8List());
+      final asset = assets[key];
+      if (asset == null) return null;
+      return _stringToByteData(asset);
+    });
+  }
+
+  tearDown(() {
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', null);
+  });
+
+  test('parses new schema correctly', () async {
+    mockAssets({
+      'assets/questions/civexam_questions_ena_core.json': '[{"id":"Q1","concours":"ENA","subject":"CG","chapter":"Intro","difficulty":3,"question":"Nouvelle?","choices":["A","B"],"answerIndex":1}]'
+    });
+
+    final questions = await QuestionLoader.loadENA();
+    expect(questions, hasLength(1));
+    final q = questions.first;
+    expect(q.id, 'Q1');
+    expect(q.concours, 'ENA');
+    expect(q.difficulty, 3);
+    expect(q.answerIndex, 1);
+  });
+
+  test('parses legacy schema correctly', () async {
+    mockAssets({
+      'assets/questions/civexam_questions_ena_core.json': '[{"subject":"CG","chapter":"Intro","difficulty":"moyen","question":"Legacy?","choices":["A","B"],"answerIndex":"0"}]'
+    });
+
+    final questions = await QuestionLoader.loadENA();
+    expect(questions, hasLength(1));
+    final q = questions.first;
+    expect(q.id, 'CG-INTRO-1');
+    expect(q.concours, 'ENA');
+    expect(q.difficulty, 2);
+    expect(q.answerIndex, 0);
+  });
+
+  test('throws when assets missing', () async {
+    mockAssets({});
+
+    await expectLater(QuestionLoader.loadENA(), throwsException);
+  });
+}


### PR DESCRIPTION
## Summary
- add tests to verify QuestionLoader handles new and legacy JSON schemas
- cover missing asset scenario

## Testing
- `flutter test test/question_loader_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af777523688323bcd11684156bb1d2