### PR TITLE
Refactor chip selection into reusable widget

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -6,6 +6,7 @@ import '../services/scoring.dart';
 import '../models/training_history_entry.dart';
 import '../services/training_history_store.dart';
 import 'exam_full_screen.dart';
+import '../widgets/chip_selector.dart';
 
 class ChapterListScreen extends StatefulWidget {
   final String subjectName;
@@ -130,31 +131,23 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
                         children: [
                           const Text('Temps par question', style: TextStyle(fontWeight: FontWeight.w600)),
                           const SizedBox(height: 8),
-                          Wrap(
+                          ChipSelector<int>(
+                            options: _secondOptions,
+                            selected: _perQuestionSeconds,
+                            onSelected: (s) => setState(() => _perQuestionSeconds = s),
                             spacing: 8,
                             runSpacing: 8,
-                            children: _secondOptions.map((s) {
-                              final selected = _perQuestionSeconds == s;
-                              return ChoiceChip(
-                                label: Text('${s}s'),
-                                selected: selected,
-                                onSelected: (_) => setState(() => _perQuestionSeconds = s),
-                              );
-                            }).toList(),
+                            labelBuilder: (s) => '${s}s',
                           ),
                           const SizedBox(height: 16),
                           const Text('Nombre de questions', style: TextStyle(fontWeight: FontWeight.w600)),
                           const SizedBox(height: 8),
-                          Wrap(
+                          ChipSelector<int>(
+                            options: _countOptions,
+                            selected: _questionCount,
+                            onSelected: (n) => setState(() => _questionCount = n),
                             spacing: 8,
-                            children: _countOptions.map((n) {
-                              final selected = _questionCount == n;
-                              return ChoiceChip(
-                                label: Text('$n'),
-                                selected: selected,
-                                onSelected: (_) => setState(() => _questionCount = n),
-                              );
-                            }).toList(),
+                            labelBuilder: (n) => '$n',
                           ),
                           const SizedBox(height: 12),
                           Text('Questions dispo pour ce module : ${_pool.length}'),

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -7,6 +7,7 @@ import '../models/training_history_entry.dart';
 import '../services/training_history_store.dart';
 import 'exam_full_screen.dart';
 import '../services/leaderboard_hooks.dart';
+import '../widgets/chip_selector.dart';
 
 class TrainingQuickStartScreen extends StatefulWidget {
   const TrainingQuickStartScreen({super.key});
@@ -112,31 +113,23 @@ if (!mounted) return;
           children: [
             const Text('Temps par question', style: TextStyle(fontWeight: FontWeight.w700)),
             const SizedBox(height: 8),
-            Wrap(
+            ChipSelector<int>(
+              options: _secondOptions,
+              selected: _perQuestionSeconds,
+              onSelected: (s) => setState(() => _perQuestionSeconds = s),
               spacing: 8,
               runSpacing: 8,
-              children: _secondOptions.map((s) {
-                final selected = _perQuestionSeconds == s;
-                return ChoiceChip(
-                  label: Text('${s}s'),
-                  selected: selected,
-                  onSelected: (_) => setState(() => _perQuestionSeconds = s),
-                );
-              }).toList(),
+              labelBuilder: (s) => '${s}s',
             ),
             const SizedBox(height: 16),
             const Text('Nombre de questions', style: TextStyle(fontWeight: FontWeight.w700)),
             const SizedBox(height: 8),
-            Wrap(
+            ChipSelector<int>(
+              options: _countOptions,
+              selected: _questionCount,
+              onSelected: (n) => setState(() => _questionCount = n),
               spacing: 8,
-              children: _countOptions.map((n) {
-                final selected = _questionCount == n;
-                return ChoiceChip(
-                  label: Text('$n'),
-                  selected: selected,
-                  onSelected: (_) => setState(() => _questionCount = n),
-                );
-              }).toList(),
+              labelBuilder: (n) => '$n',
             ),
             const SizedBox(height: 16),
             Text('Temps total : $totalLabel', style: const TextStyle(fontWeight: FontWeight.w600)),

--- a/lib/widgets/chip_selector.dart
+++ b/lib/widgets/chip_selector.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class ChipSelector<T> extends StatelessWidget {
+  final List<T> options;
+  final T selected;
+  final ValueChanged<T> onSelected;
+  final double spacing;
+  final double runSpacing;
+  final String Function(T)? labelBuilder;
+
+  const ChipSelector({
+    super.key,
+    required this.options,
+    required this.selected,
+    required this.onSelected,
+    this.spacing = 8,
+    this.runSpacing = 0,
+    this.labelBuilder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: spacing,
+      runSpacing: runSpacing,
+      children: options.map((o) {
+        final isSelected = o == selected;
+        return ChoiceChip(
+          label: Text(labelBuilder?.call(o) ?? o.toString()),
+          selected: isSelected,
+          onSelected: (_) => onSelected(o),
+        );
+      }).toList(),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add generic `ChipSelector` widget for chip-based selection
- use `ChipSelector` in training quick start and chapter list screens

## Testing
- `dart format lib/widgets/chip_selector.dart lib/screens/training_quick_start.dart lib/screens/chapter_list_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af776f4fc88323872808eb474c425a