### PR TITLE
refactor leaderboard sorting

### DIFF
--- a/lib/services/leaderboard_store.dart
+++ b/lib/services/leaderboard_store.dart
@@ -7,12 +7,8 @@ class LeaderboardStore {
   static const _kKey = 'leaderboard_v1';
   static const int _maxEntries = 100;
 
-  static Future<void> add(LeaderboardEntry e) async {
-    final prefs = await SharedPreferences.getInstance();
-    final list = prefs.getStringList(_kKey) ?? <String>[];
-    list.add(json.encode(e.toJson()));
-    final entries = list.map((s) =>
-      LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>)).toList();
+  static List<LeaderboardEntry> _sortEntries(
+      List<LeaderboardEntry> entries) {
     entries.sort((a, b) {
       final p = b.percent.compareTo(a.percent);
       if (p != 0) return p;
@@ -20,24 +16,30 @@ class LeaderboardStore {
       if (d != 0) return d;
       return b.dateIso.compareTo(a.dateIso);
     });
-    final trimmed = entries.take(_maxEntries).toList();
-    final encoded = trimmed.map((e) => json.encode(e.toJson())).toList();
+    return entries.take(_maxEntries).toList();
+  }
+
+  static Future<void> add(LeaderboardEntry e) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_kKey) ?? <String>[];
+    list.add(json.encode(e.toJson()));
+    final entries = list
+        .map((s) =>
+            LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>))
+        .toList();
+    final sorted = _sortEntries(entries);
+    final encoded = sorted.map((e) => json.encode(e.toJson())).toList();
     await prefs.setStringList(_kKey, encoded);
   }
 
   static Future<List<LeaderboardEntry>> all() async {
     final prefs = await SharedPreferences.getInstance();
     final list = prefs.getStringList(_kKey) ?? <String>[];
-    final entries = list.map((s) =>
-      LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>)).toList();
-    entries.sort((a, b) {
-      final p = b.percent.compareTo(a.percent);
-      if (p != 0) return p;
-      final d = a.durationSec.compareTo(b.durationSec);
-      if (d != 0) return d;
-      return b.dateIso.compareTo(a.dateIso);
-    });
-    return entries;
+    final entries = list
+        .map((s) =>
+            LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>))
+        .toList();
+    return _sortEntries(entries);
   }
 
   static Future<void> clear() async {


### PR DESCRIPTION
## Summary
- centralize leaderboard sorting logic in a private `_sortEntries` helper
- reuse helper in `add` and `all` to maintain `_maxEntries` limit

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af775d0cb083238a97f0276a8d236d