### PR TITLE
Log ENA question load failures

### DIFF
--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -10,6 +10,7 @@
 // -----------------------------------------------------------------------------
 
 import 'dart:convert';
+import 'package:flutter/foundation.dart' show debugPrint, kDebugMode;
 import 'package:flutter/services.dart' show rootBundle;
 import '../models/question.dart';
 
@@ -44,11 +45,14 @@ class QuestionLoader {
             return out;
           }
         }
-      } catch (_) {
+      } catch (e) {
+        if (kDebugMode) {
+          debugPrint('Failed to load ENA questions from $path: $e');
+        }
         // on passe au fichier suivant
       }
     }
-    throw Exception('Aucune banque de questions valide trouvée (ENA). Vérifiez les assets déclarés dans pubspec.yaml.');
+    throw Exception('Aucune banque de questions ENA n\'a pu être chargée. Veuillez vérifier votre installation.');
   }
 
   /// Convertit `difficulty` (texte/entier) en entier 1..3


### PR DESCRIPTION
## Summary
- log failing ENA question JSON paths using `debugPrint` when loading errors occur
- present a user-friendly message if no question bank can be loaded

## Testing
- `dart format lib/services/question_loader.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af7766674c8323a49502fd64fcc675