### PR TITLE
Add Firebase auth and basic player duels

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,10 @@
+import 'package:firebase_core/firebase_core.dart';
+
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform => const FirebaseOptions(
+        apiKey: 'YOUR_API_KEY',
+        appId: 'YOUR_APP_ID',
+        messagingSenderId: 'YOUR_SENDER_ID',
+        projectId: 'YOUR_PROJECT_ID',
+      );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'app/theme.dart';
+import 'firebase_options.dart';
 import 'screens/play_screen.dart';
+import 'screens/login_screen.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   runApp(const CivExamApp());
 }
 
@@ -16,7 +21,18 @@ class CivExamApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'CivExam',
       theme: buildAppTheme(),
-      home: const PlayScreen(), // ✅ démarre sur PlayScreen (dashboard)
+      home: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasData) {
+            return const PlayScreen();
+          }
+          return const LoginScreen();
+        },
+      ),
     );
   }
 }

--- a/lib/screens/duel_screen.dart
+++ b/lib/screens/duel_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../services/duel_service.dart';
+
+class DuelScreen extends StatefulWidget {
+  const DuelScreen({super.key});
+
+  @override
+  State<DuelScreen> createState() => _DuelScreenState();
+}
+
+class _DuelScreenState extends State<DuelScreen> {
+  final _service = DuelService();
+  String? _duelId;
+  final _joinController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Duels')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ElevatedButton(
+              onPressed: _createDuel,
+              child: const Text('Créer un duel'),
+            ),
+            if (_duelId != null)
+              Text('ID du duel: $_duelId'),
+            const SizedBox(height: 24),
+            TextField(
+              controller: _joinController,
+              decoration: const InputDecoration(labelText: 'ID duel à rejoindre'),
+            ),
+            ElevatedButton(
+              onPressed: _joinDuel,
+              child: const Text('Rejoindre'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _createDuel() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    final id = await _service.createDuel(user.uid);
+    setState(() => _duelId = id);
+  }
+
+  Future<void> _joinDuel() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    await _service.joinDuel(_joinController.text.trim(), user.uid);
+    setState(() => _duelId = _joinController.text.trim());
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../services/auth_service.dart';
+import 'play_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _auth = AuthService();
+  bool _isLogin = true;
+  String? _error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Mot de passe'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 12),
+            if (_error != null)
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _submit,
+              child: Text(_isLogin ? 'Connexion' : 'Inscription'),
+            ),
+            TextButton(
+              onPressed: () => setState(() => _isLogin = !_isLogin),
+              child: Text(_isLogin ? "Créer un compte" : 'Déjà inscrit ?'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _submit() async {
+    setState(() => _error = null);
+    try {
+      if (_isLogin) {
+        await _auth.signInWithEmail(
+          _emailController.text.trim(),
+          _passwordController.text.trim(),
+        );
+      } else {
+        await _auth.registerWithEmail(
+          _emailController.text.trim(),
+          _passwordController.text.trim(),
+        );
+      }
+      if (mounted) {
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(builder: (_) => const PlayScreen()),
+        );
+      }
+    } on FirebaseAuthException catch (e) {
+      setState(() => _error = e.message);
+    }
+  }
+}

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -13,6 +13,7 @@ import 'training_history_screen.dart';
 import 'exam_history_screen.dart';
 import 'leaderboard_screen.dart';
 import 'design_settings_screen.dart';
+import 'duel_screen.dart';
 
 class PlayScreen extends StatefulWidget {
   const PlayScreen({super.key});
@@ -207,6 +208,9 @@ class _PlayScreenState extends State<PlayScreen> {
             content: Text('• Entraînement : 5–10 s par question.\n• Concours ENA : difficulté = timing.\n• Par matière : révise par modules.\n• Historique : suis tes progrès.'),
           ),
         );
+        break;
+      case 6:
+        Navigator.push(context, MaterialPageRoute(builder: (_) => const DuelScreen()));
         break;
     }
   }
@@ -409,4 +413,5 @@ const _items = <_MenuItem>[
   _MenuItem('Historique examens', Icons.fact_check_rounded),
   _MenuItem("Historique entraînement", Icons.history_rounded),
   _MenuItem('Comment ça marche ?', Icons.info_rounded),
+  _MenuItem('Duels', Icons.sports_kabaddi),
 ];

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,19 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  Stream<User?> get authStateChanges => _auth.authStateChanges();
+
+  Future<UserCredential> signInWithEmail(String email, String password) {
+    return _auth.signInWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<UserCredential> registerWithEmail(String email, String password) {
+    return _auth.createUserWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<void> signOut() {
+    return _auth.signOut();
+  }
+}

--- a/lib/services/duel_service.dart
+++ b/lib/services/duel_service.dart
@@ -1,0 +1,22 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class DuelService {
+  final _duels = FirebaseFirestore.instance.collection('duels');
+
+  Future<String> createDuel(String userId) async {
+    final doc = await _duels.add({
+      'player1': userId,
+      'player2': null,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+    return doc.id;
+  }
+
+  Future<void> joinDuel(String duelId, String userId) async {
+    await _duels.doc(duelId).update({'player2': userId});
+  }
+
+  Stream<DocumentSnapshot<Map<String, dynamic>>> watchDuel(String duelId) {
+    return _duels.doc(duelId).snapshots();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,9 @@ dependencies:
     sdk: flutter
   shared_preferences: ^2.2.2
   flutter_svg: ^2.0.10
+  firebase_core: ^2.15.1
+  firebase_auth: ^4.9.0
+  cloud_firestore: ^4.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate Firebase core/auth/Firestore packages
- add login screen and auth service for email sign-in
- support creating and joining simple Firestore-based duels
- show duel entry from play screen and route based on auth state

## Testing
- `dart format lib/main.dart lib/screens/login_screen.dart lib/screens/duel_screen.dart lib/services/auth_service.dart lib/services/duel_service.dart lib/firebase_options.dart lib/screens/play_screen.dart pubspec.yaml` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af887daafc8323bc9283aa2636bd28