### PR TITLE
Remove duplicate user welcome variables in PlayScreen

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -43,16 +43,9 @@ class _PlayScreenState extends State<PlayScreen> {
         final List<Color> bg = _paletteFromName(cfg.bgPaletteName);
         final user = FirebaseAuth.instance.currentUser;
         final name = user?.displayName ?? user?.email;
-        final welcomeText = name != null
+        final welcomeText = name != null && name.isNotEmpty
             ? 'Bienvenue $name 👋  •  Choisis un mode'
             : 'Bienvenue 👋  •  Choisis un mode';
-
-        final user = FirebaseAuth.instance.currentUser;
-        final name = user?.displayName ?? user?.email;
-        final welcomeText =
-            name != null && name.isNotEmpty
-                ? 'Bienvenue $name 👋  •  Choisis un mode'
-                : 'Bienvenue 👋  •  Choisis un mode';
 
         return Scaffold(
           extendBody: true,


### PR DESCRIPTION
## Summary
- remove duplicate user/name/welcomeText declarations in `PlayScreen`'s `ValueListenableBuilder`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9a6abf2c83239dc51d0669c3eda8