### PR TITLE
Add logout button and leaderboard access

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -15,6 +15,7 @@ import 'exam_history_screen.dart';
 import 'leaderboard_screen.dart';
 import 'design_settings_screen.dart';
 import 'duel_screen.dart';
+import 'login_screen.dart';
 
 class PlayScreen extends StatefulWidget {
   const PlayScreen({super.key});
@@ -57,6 +58,18 @@ class _PlayScreenState extends State<PlayScreen> {
             title: const Text('CivExam'),
             centerTitle: true,
             actions: [
+              IconButton(
+                icon: const Icon(Icons.logout),
+                tooltip: 'Déconnexion',
+                onPressed: () async {
+                  await FirebaseAuth.instance.signOut();
+                  if (!mounted) return;
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(builder: (_) => const LoginScreen()),
+                  );
+                },
+              ),
               IconButton(
                 icon: const Icon(Icons.emoji_events_outlined),
                 tooltip: 'Classement',

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/question.dart';
+import 'leaderboard_screen.dart';
 
 class ResultScreen extends StatelessWidget {
   final List<Question> questions;
@@ -30,6 +31,17 @@ class ResultScreen extends StatelessWidget {
           for (int i = 0; i < questions.length; i++)
             _ResultTile(q: questions[i], selected: selectedAnswers[i], index: i + 1),
           const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const LeaderboardScreen()),
+              );
+            },
+            icon: const Icon(Icons.emoji_events),
+            label: const Text('Voir le classement'),
+          ),
+          const SizedBox(height: 8),
           ElevatedButton.icon(
             onPressed: () => Navigator.of(context).pop(),
             icon: const Icon(Icons.home),


### PR DESCRIPTION
## Summary
- add a logout action in the main play screen app bar
- allow viewing the leaderboard from the results screen

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9c3ca79c8323b6cd8615296f8300