### PR TITLE
feat: add logout and leaderboard access

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -15,6 +15,7 @@ import 'exam_history_screen.dart';
 import 'leaderboard_screen.dart';
 import 'design_settings_screen.dart';
 import 'duel_screen.dart';
+import 'login_screen.dart';
 
 class PlayScreen extends StatefulWidget {
   const PlayScreen({super.key});
@@ -33,6 +34,16 @@ class _PlayScreenState extends State<PlayScreen> {
   Future<void> _seedFromPrefs() async {
     final cfg = await DesignPrefs.load();
     DesignBus.push(cfg);
+  }
+
+  Future<void> _signOut() async {
+    await FirebaseAuth.instance.signOut();
+    if (!mounted) return;
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
+      (route) => false,
+    );
   }
 
   @override
@@ -71,6 +82,11 @@ class _PlayScreenState extends State<PlayScreen> {
                   await Navigator.push(context, MaterialPageRoute(builder: (_) => const DesignSettingsScreen()));
                   // pas besoin de reload : le bus pousse en live pendant l’édition
                 },
+              ),
+              IconButton(
+                icon: const Icon(Icons.logout),
+                tooltip: 'Déconnexion',
+                onPressed: _signOut,
               ),
             ],
           ),

--- a/lib/screens/result_screen.dart
+++ b/lib/screens/result_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/question.dart';
+import 'leaderboard_screen.dart';
 
 class ResultScreen extends StatelessWidget {
   final List<Question> questions;
@@ -30,6 +31,17 @@ class ResultScreen extends StatelessWidget {
           for (int i = 0; i < questions.length; i++)
             _ResultTile(q: questions[i], selected: selectedAnswers[i], index: i + 1),
           const SizedBox(height: 16),
+          ElevatedButton.icon(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const LeaderboardScreen()),
+              );
+            },
+            icon: const Icon(Icons.emoji_events_outlined),
+            label: const Text('Voir le classement'),
+          ),
+          const SizedBox(height: 8),
           ElevatedButton.icon(
             onPressed: () => Navigator.of(context).pop(),
             icon: const Icon(Icons.home),


### PR DESCRIPTION
## Summary
- allow users to sign out via new logout button on the play screen
- link results screen to leaderboard so players can view rankings and other players' scores

## Testing
- ⚠️ `dart format lib/screens/play_screen.dart lib/screens/result_screen.dart` *(command not found)*
- ⚠️ `flutter analyze` *(command not found)*
- ⚠️ `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9c3ca79c8323b6cd8615296f8300