### PR TITLE
Add logout option and leaderboard menu

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -72,6 +72,13 @@ class _PlayScreenState extends State<PlayScreen> {
                   // pas besoin de reload : le bus pousse en live pendant l’édition
                 },
               ),
+              IconButton(
+                icon: const Icon(Icons.logout),
+                tooltip: 'Déconnexion',
+                onPressed: () async {
+                  await FirebaseAuth.instance.signOut();
+                },
+              ),
             ],
           ),
           body: Stack(
@@ -217,6 +224,9 @@ class _PlayScreenState extends State<PlayScreen> {
         break;
       case 6:
         Navigator.push(context, MaterialPageRoute(builder: (_) => const DuelScreen()));
+        break;
+      case 7:
+        Navigator.push(context, MaterialPageRoute(builder: (_) => const LeaderboardScreen()));
         break;
     }
   }
@@ -420,4 +430,5 @@ const _items = <_MenuItem>[
   _MenuItem("Historique entraînement", Icons.history_rounded),
   _MenuItem('Comment ça marche ?', Icons.info_rounded),
   _MenuItem('Duels', Icons.sports_kabaddi),
+  _MenuItem('Classement', Icons.emoji_events_outlined),
 ];


### PR DESCRIPTION
## Summary
- Add sign-out action to PlayScreen app bar
- Expose ranking screen via new "Classement" menu tile

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9c3ca79c8323b6cd8615296f8300