### PR TITLE
Improve logout visibility and login cancel option

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../services/auth_service.dart';
 import 'play_screen.dart';
+import 'home_screen.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -20,7 +21,19 @@ class _LoginScreenState extends State<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
+      appBar: AppBar(
+        title: Text(_isLogin ? 'Se connecter' : "Créer un compte"),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: 'Annuler',
+          onPressed: () {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(builder: (_) => const HomeScreen()),
+            );
+          },
+        ),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -59,7 +59,28 @@ class _PlayScreenState extends State<PlayScreen> {
             centerTitle: true,
             actions: [
               IconButton(
-                icon: const Icon(Icons.logout),
+                icon: const Icon(Icons.emoji_events_outlined),
+                tooltip: 'Classement',
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const LeaderboardScreen()),
+                  );
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.palette_outlined),
+                tooltip: 'Réglages design',
+                onPressed: () async {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const DesignSettingsScreen()),
+                  );
+                  // pas besoin de reload : le bus pousse en live pendant l’édition
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.logout, color: Colors.white),
                 tooltip: 'Déconnexion',
                 onPressed: () async {
                   await FirebaseAuth.instance.signOut();
@@ -68,28 +89,6 @@ class _PlayScreenState extends State<PlayScreen> {
                     context,
                     MaterialPageRoute(builder: (_) => const LoginScreen()),
                   );
-                },
-              ),
-              IconButton(
-                icon: const Icon(Icons.emoji_events_outlined),
-                tooltip: 'Classement',
-                onPressed: () {
-                  Navigator.push(context, MaterialPageRoute(builder: (_) => const LeaderboardScreen()));
-                },
-              ),
-              IconButton(
-                icon: const Icon(Icons.palette_outlined),
-                tooltip: 'Réglages design',
-                onPressed: () async {
-                  await Navigator.push(context, MaterialPageRoute(builder: (_) => const DesignSettingsScreen()));
-                  // pas besoin de reload : le bus pousse en live pendant l’édition
-                },
-              ),
-              IconButton(
-                icon: const Icon(Icons.logout),
-                tooltip: 'Déconnexion',
-                onPressed: () async {
-                  await FirebaseAuth.instance.signOut();
                 },
               ),
             ],


### PR DESCRIPTION
## Summary
- Ensure logout icon on PlayScreen is clearly visible with white color and tooltip, and navigates to login after sign-out.
- Add a cancel/back button on LoginScreen to allow returning to the Home screen.

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9fd74a9c8323bbf2047d90b26151