### PR TITLE
Navigate to PlayScreen after login/register

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../services/auth_service.dart';
+import 'play_screen.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -107,6 +108,11 @@ class _LoginScreenState extends State<LoginScreen> {
           _nameController.text.trim(),
         );
       }
+      if (!mounted) return;
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const PlayScreen()),
+      );
     } on FirebaseAuthException catch (e) {
       if (mounted) setState(() => _error = e.message);
     } catch (e) {


### PR DESCRIPTION
## Summary
- Import `PlayScreen` in `login_screen.dart`
- After successful email sign-in or registration, check `mounted` and navigate to `PlayScreen`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa84932b883239e84ce4e52469544