### PR TITLE
fix: update card theme type for theme data

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -31,7 +31,7 @@ ThemeData buildAppTheme() {
       elevation: 0.5,
       centerTitle: true,
     ),
-    cardTheme: CardTheme(
+    cardTheme: CardThemeData(
       elevation: 1,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       margin: const EdgeInsets.symmetric(vertical: 6, horizontal: 0),


### PR DESCRIPTION
## Summary
- replace deprecated `CardTheme` usage with `CardThemeData`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afae9ce2008323b389f513f284e0ed