### PR TITLE
Use authenticated user for competition scores

### DIFF
--- a/lib/models/leaderboard_entry.dart
+++ b/lib/models/leaderboard_entry.dart
@@ -1,19 +1,38 @@
 // lib/models/leaderboard_entry.dart
 class LeaderboardEntry {
-  final String name, mode, subject, chapter, dateIso;
+  final String userId, name, mode, subject, chapter, dateIso;
   final int total, correct, wrong, blank, durationSec;
   final double percent;
   const LeaderboardEntry({
-    required this.name, required this.mode, required this.subject, required this.chapter,
-    required this.total, required this.correct, required this.wrong, required this.blank,
-    required this.durationSec, required this.percent, required this.dateIso,
+    required this.userId,
+    required this.name,
+    required this.mode,
+    required this.subject,
+    required this.chapter,
+    required this.total,
+    required this.correct,
+    required this.wrong,
+    required this.blank,
+    required this.durationSec,
+    required this.percent,
+    required this.dateIso,
   });
   Map<String, dynamic> toJson() => {
-    'name': name,'mode': mode,'subject': subject,'chapter': chapter,'total': total,
-    'correct': correct,'wrong': wrong,'blank': blank,'durationSec': durationSec,
-    'percent': percent,'dateIso': dateIso,
+    'userId': userId,
+    'name': name,
+    'mode': mode,
+    'subject': subject,
+    'chapter': chapter,
+    'total': total,
+    'correct': correct,
+    'wrong': wrong,
+    'blank': blank,
+    'durationSec': durationSec,
+    'percent': percent,
+    'dateIso': dateIso,
   };
   factory LeaderboardEntry.fromJson(Map<String, dynamic> m) => LeaderboardEntry(
+    userId: (m['userId'] ?? '') as String,
     name: (m['name'] ?? '') as String,
     mode: (m['mode'] ?? 'training') as String,
     subject: (m['subject'] ?? '') as String,

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/leaderboard_entry.dart';
+import '../services/competition_service.dart';
+
+class DashboardScreen extends StatefulWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
+  LeaderboardEntry? _entry;
+  int? _rank;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      setState(() {
+        _loading = false;
+      });
+      return;
+    }
+    final entries = await CompetitionService().topEntries(limit: 1000);
+    final index = entries.indexWhere((e) => e.userId == uid);
+    if (!mounted) return;
+    setState(() {
+      _entry = index >= 0 ? entries[index] : null;
+      _rank = index >= 0 ? index + 1 : null;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mon dashboard')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _entry == null
+              ? const Center(child: Text('Aucune donnée de compétition'))
+              : Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Nom : ${_entry!.name}',
+                          style: Theme.of(context).textTheme.titleLarge),
+                      const SizedBox(height: 8),
+                      Text(
+                          'Score : ${_entry!.percent.toStringAsFixed(1)}% (${_entry!.correct}/${_entry!.total})'),
+                      const SizedBox(height: 8),
+                      if (_rank != null)
+                        Text('Classement global : $_rank'),
+                    ],
+                  ),
+                ),
+    );
+  }
+}

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/leaderboard_store.dart';
 import '../services/competition_service.dart';
+import 'dashboard_screen.dart';
 
 class LeaderboardScreen extends StatefulWidget {
   const LeaderboardScreen({super.key});
@@ -36,7 +37,10 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Classement'), actions:[IconButton(icon: const Icon(Icons.refresh), onPressed: _load)]),
+      appBar: AppBar(title: const Text('Classement'), actions:[
+        IconButton(icon: const Icon(Icons.person), onPressed: () { Navigator.push(context, MaterialPageRoute(builder: (_) => const DashboardScreen())); }),
+        IconButton(icon: const Icon(Icons.refresh), onPressed: _load)
+      ]),
       body: Column(children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(12,12,12,6),

--- a/lib/services/competition_service.dart
+++ b/lib/services/competition_service.dart
@@ -10,11 +10,11 @@ import '../models/leaderboard_entry.dart';
 class CompetitionService {
   final _col = FirebaseFirestore.instance.collection('competition_scores');
 
-  /// Sauvegarde un résultat de compétition.
+  /// Sauvegarde ou met à jour un résultat de compétition pour l'utilisateur.
   Future<void> saveEntry(LeaderboardEntry entry) async {
     final data = entry.toJson();
-    data['createdAt'] = FieldValue.serverTimestamp();
-    await _col.add(data);
+    data['updatedAt'] = FieldValue.serverTimestamp();
+    await _col.doc(entry.userId).set(data);
   }
 
   /// Récupère les meilleurs résultats (max 100 par défaut).


### PR DESCRIPTION
## Summary
- Track a unique `userId` on leaderboard entries
- Save competition scores per user and auto-use authenticated identity
- Add a simple dashboard screen showing personal ranking

## Testing
- `flutter test` *(command not found)*
- `dart test` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68afb6b3d2b48323984ec6f19e3c8e40