### PR TITLE
Secure competition mode with anti-cheating measures

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:resizeableActivity="false">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -47,6 +47,7 @@ class _CompetitionScreenState extends State<CompetitionScreen> {
           duration: const Duration(minutes: 5),
           scoring: const ExamScoring(correct: 1, wrong: -1, blank: 0),
           title: 'Mode Compétition',
+          competitionMode: true,
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   firebase_core: ^2.15.1
   firebase_auth: ^4.9.0
   cloud_firestore: ^4.9.0
+  wakelock_plus: ^1.6.0
+  flutter_windowmanager: ^0.2.0
+  device_info_plus: ^10.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- enforce immersive portrait exam environment with wakelock and FLAG_SECURE
- block back navigation, copy/paste, and split-screen during competition
- track app pauses with escalating penalties and basic emulator detection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc8a9d74832382bda6120a87a3f5