### PR TITLE
feat: strengthen anti-cheat for competition mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
             android:launchMode="singleTop"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
+            android:resizeableActivity="false"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">

--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -47,6 +47,7 @@ class _CompetitionScreenState extends State<CompetitionScreen> {
           duration: const Duration(minutes: 5),
           scoring: const ExamScoring(correct: 1, wrong: -1, blank: 0),
           title: 'Mode Compétition',
+          antiCheat: true,
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   firebase_core: ^2.15.1
   firebase_auth: ^4.9.0
   cloud_firestore: ^4.9.0
+  wakelock_plus: ^1.1.1
+  flutter_windowmanager: ^0.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add anti-cheat protections to ExamFullScreen with orientation lock, secure flag, wakelock and lifecycle monitoring
- enable secure full-screen competition mode and disable back navigation
- disallow multi-window on Android and add required dependencies

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc8a9d74832382bda6120a87a3f5