### PR TITLE
Add anti-cheat measures for competition mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:resizeableActivity="false">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,9 @@ dependencies:
   firebase_core: ^2.15.1
   firebase_auth: ^4.9.0
   cloud_firestore: ^4.9.0
+  wakelock_plus: ^1.1.1
+  flutter_windowmanager: ^0.2.0
+  safe_device: ^1.3.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- enforce device integrity checks before starting competition mode
- lock orientation, secure screen, disable back/selection, and penalize app switching during competition exams
- prevent split-screen usage on Android

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc8a9d74832382bda6120a87a3f5