### PR TITLE
Fix wakelock_plus dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   firebase_core: ^2.15.1
   firebase_auth: ^4.9.0
   cloud_firestore: ^4.9.0
-  wakelock_plus: ^1.6.0
+  wakelock_plus: ^1.3.2
   flutter_windowmanager: ^0.2.0
   device_info_plus: ^10.0.0
 


### PR DESCRIPTION
## Summary
- downgrade wakelock_plus dependency to ^1.3.2 so pub can resolve

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68afbe7353008323b3c7223312410940