### PR TITLE
Fix ConfettiWidget controller parameter usage

### DIFF
--- a/lib/widgets/leaderboard_save_dialog.dart
+++ b/lib/widgets/leaderboard_save_dialog.dart
@@ -47,7 +47,7 @@ Future<void> showSaveScoreDialog({
             Align(
               alignment: Alignment.topCenter,
               child: ConfettiWidget(
-                controller: controller,
+                confettiController: controller,
                 blastDirectionality: BlastDirectionality.explosive,
                 shouldLoop: false,
               ),


### PR DESCRIPTION
## Summary
- fix compilation by using `confettiController` with `ConfettiWidget`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc5c234e883238a3871d3d9300d39