### PR TITLE
Remove deprecated registrar usage in flutter_windowmanager plugin

### DIFF
--- a/third_party/flutter_windowmanager/android/src/main/java/io/adaptant/labs/flutter_windowmanager/FlutterWindowManagerPlugin.java
+++ b/third_party/flutter_windowmanager/android/src/main/java/io/adaptant/labs/flutter_windowmanager/FlutterWindowManagerPlugin.java
@@ -14,7 +14,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** FlutterWindowManagerPlugin */
 public class FlutterWindowManagerPlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
@@ -22,16 +21,6 @@ public class FlutterWindowManagerPlugin implements MethodCallHandler, FlutterPlu
 
   @SuppressWarnings("unused")
   public FlutterWindowManagerPlugin() { }
-
-  private FlutterWindowManagerPlugin(Activity activity) {
-    this.activity = activity;
-  }
-
-  /** Plugin registration. */
-  @Deprecated
-  public static void registerWith(Registrar registrar) {
-    new FlutterWindowManagerPlugin(registrar.activity()).registerWith(registrar.messenger());
-  }
 
   private void registerWith(BinaryMessenger binaryMessenger) {
     final MethodChannel channel = new MethodChannel(binaryMessenger, "flutter_windowmanager");


### PR DESCRIPTION
## Summary
- Drop obsolete `PluginRegistry.Registrar` import and registration method in `flutter_windowmanager` plugin
- Rely solely on the v2 embedding for plugin initialization

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc7c22a9c83238457a3babc32e156