### PR TITLE
Fix window manager plugin for Flutter 3

### DIFF
--- a/third_party/flutter_windowmanager/android/src/main/java/io/adaptant/labs/flutter_windowmanager/FlutterWindowManagerPlugin.java
+++ b/third_party/flutter_windowmanager/android/src/main/java/io/adaptant/labs/flutter_windowmanager/FlutterWindowManagerPlugin.java
@@ -14,7 +14,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** FlutterWindowManagerPlugin */
 public class FlutterWindowManagerPlugin implements MethodCallHandler, FlutterPlugin, ActivityAware {
@@ -25,12 +24,6 @@ public class FlutterWindowManagerPlugin implements MethodCallHandler, FlutterPlu
 
   private FlutterWindowManagerPlugin(Activity activity) {
     this.activity = activity;
-  }
-
-  /** Plugin registration. */
-  @Deprecated
-  public static void registerWith(Registrar registrar) {
-    new FlutterWindowManagerPlugin(registrar.activity()).registerWith(registrar.messenger());
   }
 
   private void registerWith(BinaryMessenger binaryMessenger) {


### PR DESCRIPTION
## Summary
- remove deprecated PluginRegistry.Registrar import
- drop old registerWith(Registrar) method in window manager plugin

## Testing
- `flutter --version` *(fails: command not found)*
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68afc7c22a9c83238457a3babc32e156