### PR TITLE
feat: apply dynamic design theme across app

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -11,7 +11,7 @@ ThemeData buildAppTheme() {
       brightness: Brightness.light,
     ),
     useMaterial3: true,
-    scaffoldBackgroundColor: kSurface,
+    scaffoldBackgroundColor: Colors.transparent,
   );
 
   final textTheme = base.textTheme.copyWith(
@@ -26,9 +26,9 @@ ThemeData buildAppTheme() {
   return base.copyWith(
     textTheme: textTheme,
     appBarTheme: const AppBarTheme(
-      backgroundColor: kSurface,
-      foregroundColor: Colors.black87,
-      elevation: 0.5,
+      backgroundColor: Colors.transparent,
+      foregroundColor: Colors.white,
+      elevation: 0,
       centerTitle: true,
     ),
     cardTheme: CardThemeData(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,10 +5,15 @@ import 'app/theme.dart';
 import 'firebase_options.dart';
 import 'screens/play_screen.dart';
 import 'screens/login_screen.dart';
+import 'services/design_prefs.dart';
+import 'services/design_bus.dart';
+import 'widgets/design_background.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  final cfg = await DesignPrefs.load();
+  DesignBus.push(cfg);
   runApp(const CivExamApp());
 }
 
@@ -21,6 +26,7 @@ class CivExamApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'CivExam',
       theme: buildAppTheme(),
+      builder: (context, child) => DesignBackground(child: child ?? const SizedBox()),
       home: StreamBuilder<User?>(
         stream: FirebaseAuth.instance.authStateChanges(),
         builder: (context, snapshot) {

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -51,6 +51,16 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
               _paletteChip('midnight', _cfg.bgPaletteName == 'midnight'),
               _paletteChip('sunset', _cfg.bgPaletteName == 'sunset'),
               _paletteChip('forest', _cfg.bgPaletteName == 'forest'),
+              _paletteChip('ocean', _cfg.bgPaletteName == 'ocean'),
+              _paletteChip('fire', _cfg.bgPaletteName == 'fire'),
+              _paletteChip('purple', _cfg.bgPaletteName == 'purple'),
+              _paletteChip('pink', _cfg.bgPaletteName == 'pink'),
+              _paletteChip('emerald', _cfg.bgPaletteName == 'emerald'),
+              _paletteChip('candy', _cfg.bgPaletteName == 'candy'),
+              _paletteChip('steel', _cfg.bgPaletteName == 'steel'),
+              _paletteChip('coffee', _cfg.bgPaletteName == 'coffee'),
+              _paletteChip('gold', _cfg.bgPaletteName == 'gold'),
+              _paletteChip('lavender', _cfg.bgPaletteName == 'lavender'),
             ],
           ),
           const SizedBox(height: 16),
@@ -141,6 +151,26 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
         return const [Colors.white, Color(0xFFFF9966), Color(0xFFFF5E62)];
       case 'forest':
         return const [Colors.white, Color(0xFF2F7336), Color(0xFFAAFFA9)];
+      case 'ocean':
+        return const [Colors.white, Color(0xFF1A2980), Color(0xFF26D0CE)];
+      case 'fire':
+        return const [Colors.white, Color(0xFFFF512F), Color(0xFFF09819)];
+      case 'purple':
+        return const [Colors.white, Color(0xFF2A0845), Color(0xFF6441A5)];
+      case 'pink':
+        return const [Colors.white, Color(0xFFFF9A9E), Color(0xFFFAD0C4)];
+      case 'emerald':
+        return const [Colors.white, Color(0xFF00B09B), Color(0xFF96C93D)];
+      case 'candy':
+        return const [Colors.white, Color(0xFFF857A6), Color(0xFFFF5858)];
+      case 'steel':
+        return const [Colors.white, Color(0xFF232526), Color(0xFF414345)];
+      case 'coffee':
+        return const [Colors.white, Color(0xFF603813), Color(0xFFB29F94)];
+      case 'gold':
+        return const [Colors.white, Color(0xFFF6D365), Color(0xFFFDA085)];
+      case 'lavender':
+        return const [Colors.white, Color(0xFFB993D6), Color(0xFF8CA6DB)];
       case 'blueRoyal':
       default:
         return const [Colors.white, Color(0xFF37478F), Color(0xFF0D1E42)];

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import '../models/design_config.dart';
-import '../services/design_prefs.dart';
 import '../services/design_bus.dart';
 
 import 'training_quick_start.dart';
@@ -25,23 +24,10 @@ class PlayScreen extends StatefulWidget {
 
 class _PlayScreenState extends State<PlayScreen> {
   @override
-  void initState() {
-    super.initState();
-    // Seed initial depuis les prefs (ensuite le bus prend le relais en live)
-    _seedFromPrefs();
-  }
-
-  Future<void> _seedFromPrefs() async {
-    final cfg = await DesignPrefs.load();
-    DesignBus.push(cfg);
-  }
-
-  @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<DesignConfig>(
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
-        final List<Color> bg = _paletteFromName(cfg.bgPaletteName);
         final user = FirebaseAuth.instance.currentUser;
         final name = user?.displayName ?? user?.email;
         final welcomeText = name != null && name.isNotEmpty
@@ -94,40 +80,12 @@ class _PlayScreenState extends State<PlayScreen> {
               ),
             ],
           ),
-          body: Stack(
-            children: [
-              Positioned.fill(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: bg,
-                    ),
-                  ),
-                ),
-              ),
-              if (cfg.waveEnabled)
-                Positioned.fill(
-                  child: IgnorePointer(
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        gradient: RadialGradient(
-                          center: const Alignment(0.0, -0.6),
-                          radius: 1.0,
-                          colors: [Colors.white.withOpacity(0.08), Colors.transparent],
-                          stops: const [0.0, 1.0],
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              SafeArea(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
                       _GlassCard(
                         blur: cfg.glassBlur,
                         backgroundOpacity: cfg.glassBgOpacity,
@@ -160,53 +118,40 @@ class _PlayScreenState extends State<PlayScreen> {
                         ),
                       ),
                       const SizedBox(height: 18),
-                      Expanded(
-                        child: GridView.builder(
-                          physics: const BouncingScrollPhysics(),
-                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: 2,
-                            crossAxisSpacing: 14,
-                            mainAxisSpacing: 14,
-                            childAspectRatio: 1.05,
-                          ),
-                          itemCount: _items.length,
-                          itemBuilder: (context, i) {
-                            final item = _items[i];
-                            return _GlassTile(
-                              title: item.title,
-                              icon: item.icon,
-                              blur: cfg.glassBlur,
-                              bgOpacity: cfg.glassBgOpacity,
-                              borderOpacity: cfg.glassBorderOpacity,
-                              iconSize: cfg.tileIconSize,
-                              centerContent: cfg.tileCenter,
-                              useMono: cfg.useMono,
-                              monoColor: cfg.monoColor,
-                              onTap: () => _navigate(context, i),
-                            );
-                          },
-                        ),
+                  Expanded(
+                    child: GridView.builder(
+                      physics: const BouncingScrollPhysics(),
+                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 2,
+                        crossAxisSpacing: 14,
+                        mainAxisSpacing: 14,
+                        childAspectRatio: 1.05,
                       ),
-                    ],
+                      itemCount: _items.length,
+                      itemBuilder: (context, i) {
+                        final item = _items[i];
+                        return _GlassTile(
+                          title: item.title,
+                          icon: item.icon,
+                          blur: cfg.glassBlur,
+                          bgOpacity: cfg.glassBgOpacity,
+                          borderOpacity: cfg.glassBorderOpacity,
+                          iconSize: cfg.tileIconSize,
+                          centerContent: cfg.tileCenter,
+                          useMono: cfg.useMono,
+                          monoColor: cfg.monoColor,
+                          onTap: () => _navigate(context, i),
+                        );
+                      },
+                    ),
                   ),
-                ),
+                ],
               ),
-            ],
+            ),
           ),
         );
       },
     );
-  }
-
-  List<Color> _paletteFromName(String name) {
-    switch (name) {
-      case 'blueAqua':  return const [Color(0xFF3A4CC5), Color(0xFF6C8BF5)];
-      case 'midnight':  return const [Color(0xFF0F2027), Color(0xFF2C5364)];
-      case 'sunset':    return const [Color(0xFFFF5E62), Color(0xFFFF9966)];
-      case 'forest':    return const [Color(0xFF2F7336), Color(0xFFAAFFA9)];
-      case 'blueRoyal':
-      default:          return const [Color(0xFF0D1E42), Color(0xFF37478F)];
-    }
   }
 
   void _navigate(BuildContext context, int index) {

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
+
+/// Widget that paints the dynamic gradient background and optional wave effect
+/// based on [DesignConfig]. It listens to [DesignBus] for live updates so that
+/// theme changes from the design settings propagate to all pages.
+class DesignBackground extends StatelessWidget {
+  const DesignBackground({super.key, required this.child});
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final colors = _paletteFromName(cfg.bgPaletteName);
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: colors,
+            ),
+          ),
+          child: Stack(
+            children: [
+              if (cfg.waveEnabled)
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: RadialGradient(
+                          center: const Alignment(0.0, -0.6),
+                          radius: 1.0,
+                          colors: [
+                            Colors.white.withOpacity(0.08),
+                            Colors.transparent,
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              child,
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  List<Color> _paletteFromName(String name) {
+    switch (name) {
+      case 'blueAqua':
+        return const [Color(0xFF3A4CC5), Color(0xFF6C8BF5)];
+      case 'midnight':
+        return const [Color(0xFF0F2027), Color(0xFF2C5364)];
+      case 'sunset':
+        return const [Color(0xFFFF5E62), Color(0xFFFF9966)];
+      case 'forest':
+        return const [Color(0xFF2F7336), Color(0xFFAAFFA9)];
+      case 'ocean':
+        return const [Color(0xFF1A2980), Color(0xFF26D0CE)];
+      case 'fire':
+        return const [Color(0xFFFF512F), Color(0xFFF09819)];
+      case 'purple':
+        return const [Color(0xFF2A0845), Color(0xFF6441A5)];
+      case 'pink':
+        return const [Color(0xFFFF9A9E), Color(0xFFFAD0C4)];
+      case 'emerald':
+        return const [Color(0xFF00B09B), Color(0xFF96C93D)];
+      case 'candy':
+        return const [Color(0xFFF857A6), Color(0xFFFF5858)];
+      case 'steel':
+        return const [Color(0xFF232526), Color(0xFF414345)];
+      case 'coffee':
+        return const [Color(0xFF603813), Color(0xFFB29F94)];
+      case 'gold':
+        return const [Color(0xFFF6D365), Color(0xFFFDA085)];
+      case 'lavender':
+        return const [Color(0xFFB993D6), Color(0xFF8CA6DB)];
+      case 'blueRoyal':
+      default:
+        return const [Color(0xFF0D1E42), Color(0xFF37478F)];
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- load persisted design configuration at startup and broadcast via DesignBus
- wrap all screens with DesignBackground for live gradient/wave background
- add ten new color palettes to design settings

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68afcae8e01c832388a25eb7c72240ff