### PR TITLE
Adapt text and icons to background palette

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
 
 import 'training_quick_start.dart';
 import 'multi_exam_flow.dart';
@@ -33,6 +34,7 @@ class _PlayScreenState extends State<PlayScreen> {
         final welcomeText = name != null && name.isNotEmpty
             ? 'Bienvenue $name 👋  •  Choisis un mode'
             : 'Bienvenue 👋  •  Choisis un mode';
+        final textColor = textColorForPalette(cfg.bgPaletteName);
 
         return Scaffold(
           extendBody: true,
@@ -41,6 +43,7 @@ class _PlayScreenState extends State<PlayScreen> {
           appBar: AppBar(
             backgroundColor: Colors.transparent,
             elevation: 0,
+            foregroundColor: textColor,
             title: const Text('CivExam'),
             centerTitle: true,
             actions: [
@@ -106,10 +109,10 @@ class _PlayScreenState extends State<PlayScreen> {
                                   welcomeText,
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
-                                  style: const TextStyle(
+                                  style: TextStyle(
                                     fontSize: 16,
                                     fontWeight: FontWeight.w600,
-                                    color: Colors.white,
+                                    color: textColor,
                                   ),
                                 ),
                               ),
@@ -133,6 +136,7 @@ class _PlayScreenState extends State<PlayScreen> {
                         return _GlassTile(
                           title: item.title,
                           icon: item.icon,
+                          gradientColors: item.gradientColors,
                           blur: cfg.glassBlur,
                           bgOpacity: cfg.glassBgOpacity,
                           borderOpacity: cfg.glassBorderOpacity,
@@ -140,6 +144,7 @@ class _PlayScreenState extends State<PlayScreen> {
                           centerContent: cfg.tileCenter,
                           useMono: cfg.useMono,
                           monoColor: cfg.monoColor,
+                          textColor: textColor,
                           onTap: () => _navigate(context, i),
                         );
                       },
@@ -195,6 +200,7 @@ class _GlassTile extends StatefulWidget {
   const _GlassTile({
     required this.title,
     required this.icon,
+    required this.gradientColors,
     required this.onTap,
     required this.blur,
     required this.bgOpacity,
@@ -203,9 +209,11 @@ class _GlassTile extends StatefulWidget {
     required this.centerContent,
     required this.useMono,
     required this.monoColor,
+    required this.textColor,
   });
   final String title;
   final IconData icon;
+  final List<Color> gradientColors;
   final VoidCallback onTap;
   final double blur;
   final double bgOpacity;
@@ -214,6 +222,7 @@ class _GlassTile extends StatefulWidget {
   final bool centerContent;
   final bool useMono;
   final Color monoColor;
+  final Color textColor;
 
   @override
   State<_GlassTile> createState() => _GlassTileState();
@@ -228,10 +237,7 @@ class _GlassTileState extends State<_GlassTile> {
             widget.monoColor.withOpacity(0.15),
             widget.monoColor.withOpacity(0.35)
           ]
-        : [
-            Colors.orange.shade300.withOpacity(0.85),
-            Colors.orange.shade600.withOpacity(0.90)
-          ];
+        : widget.gradientColors;
 
     final iconColor = widget.useMono ? widget.monoColor : Colors.white;
 
@@ -253,11 +259,11 @@ class _GlassTileState extends State<_GlassTile> {
     final title = Text(
       widget.title,
       textAlign: widget.centerContent ? TextAlign.center : TextAlign.left,
-      style: const TextStyle(
+      style: TextStyle(
         fontSize: 20,
         height: 1.15,
         fontWeight: FontWeight.w800,
-        color: Colors.white,
+        color: widget.textColor,
       ),
       maxLines: 2,
       overflow: TextOverflow.ellipsis,
@@ -377,16 +383,25 @@ class _IconBadge extends StatelessWidget {
 class _MenuItem {
   final String title;
   final IconData icon;
-  const _MenuItem(this.title, this.icon);
+  final List<Color> gradientColors;
+  const _MenuItem(this.title, this.icon, this.gradientColors);
 }
 
 const _items = <_MenuItem>[
-  _MenuItem("S'entraîner", Icons.play_circle_fill_rounded),
-  _MenuItem('Concours ENA', Icons.school_rounded),
-  _MenuItem('Par matière', Icons.menu_book_rounded),
-  _MenuItem('Historique examens', Icons.fact_check_rounded),
-  _MenuItem("Historique entraînement", Icons.history_rounded),
-  _MenuItem('Comment ça marche ?', Icons.info_rounded),
-  _MenuItem('Compétition', Icons.sports_kabaddi),
-  _MenuItem('Classement', Icons.emoji_events_outlined),
+  _MenuItem("S'entraîner", Icons.play_circle_fill_rounded,
+      [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
+  _MenuItem('Concours ENA', Icons.school_rounded,
+      [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
+  _MenuItem('Par matière', Icons.menu_book_rounded,
+      [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
+  _MenuItem('Historique examens', Icons.fact_check_rounded,
+      [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
+  _MenuItem("Historique entraînement", Icons.history_rounded,
+      [Color(0xFFFF7043), Color(0xFFD84315)]),
+  _MenuItem('Comment ça marche ?', Icons.info_rounded,
+      [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
+  _MenuItem('Compétition', Icons.sports_kabaddi,
+      [Color(0xFFFFEE58), Color(0xFFFDD835)]),
+  _MenuItem('Classement', Icons.emoji_events_outlined,
+      [Color(0xFFEC407A), Color(0xFFD81B60)]),
 ];

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Utilities for design palettes and text contrast
+List<Color> paletteFromName(String name) {
+  switch (name) {
+    case 'blueAqua':
+      return const [Color(0xFF3A4CC5), Color(0xFF6C8BF5)];
+    case 'midnight':
+      return const [Color(0xFF0F2027), Color(0xFF2C5364)];
+    case 'sunset':
+      return const [Color(0xFFFF5E62), Color(0xFFFF9966)];
+    case 'forest':
+      return const [Color(0xFF2F7336), Color(0xFFAAFFA9)];
+    case 'ocean':
+      return const [Color(0xFF1A2980), Color(0xFF26D0CE)];
+    case 'fire':
+      return const [Color(0xFFFF512F), Color(0xFFF09819)];
+    case 'purple':
+      return const [Color(0xFF2A0845), Color(0xFF6441A5)];
+    case 'pink':
+      return const [Color(0xFFFF9A9E), Color(0xFFFAD0C4)];
+    case 'emerald':
+      return const [Color(0xFF00B09B), Color(0xFF96C93D)];
+    case 'candy':
+      return const [Color(0xFFF857A6), Color(0xFFFF5858)];
+    case 'steel':
+      return const [Color(0xFF232526), Color(0xFF414345)];
+    case 'coffee':
+      return const [Color(0xFF603813), Color(0xFFB29F94)];
+    case 'gold':
+      return const [Color(0xFFF6D365), Color(0xFFFDA085)];
+    case 'lavender':
+      return const [Color(0xFFB993D6), Color(0xFF8CA6DB)];
+    case 'blueRoyal':
+    default:
+      return const [Color(0xFF0D1E42), Color(0xFF37478F)];
+  }
+}
+
+/// Returns [Colors.white] or [Colors.black] depending on the average
+/// brightness of the palette.
+Color textColorForPalette(String name) {
+  final colors = paletteFromName(name);
+  // Average the palette colors
+  int r = 0, g = 0, b = 0;
+  for (final c in colors) {
+    r += c.red;
+    g += c.green;
+    b += c.blue;
+  }
+  final avg = Color.fromARGB(255, r ~/ colors.length, g ~/ colors.length, b ~/ colors.length);
+  final brightness = ThemeData.estimateBrightnessForColor(avg);
+  return brightness == Brightness.dark ? Colors.white : Colors.black;
+}

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
 
 /// Widget that paints the dynamic gradient background and optional wave effect
 /// based on [DesignConfig]. It listens to [DesignBus] for live updates so that
@@ -14,7 +15,7 @@ class DesignBackground extends StatelessWidget {
     return ValueListenableBuilder<DesignConfig>(
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
-        final colors = _paletteFromName(cfg.bgPaletteName);
+        final colors = paletteFromName(cfg.bgPaletteName);
         return DecoratedBox(
           decoration: BoxDecoration(
             gradient: LinearGradient(
@@ -50,40 +51,6 @@ class DesignBackground extends StatelessWidget {
     );
   }
 
-  List<Color> _paletteFromName(String name) {
-    switch (name) {
-      case 'blueAqua':
-        return const [Color(0xFF3A4CC5), Color(0xFF6C8BF5)];
-      case 'midnight':
-        return const [Color(0xFF0F2027), Color(0xFF2C5364)];
-      case 'sunset':
-        return const [Color(0xFFFF5E62), Color(0xFFFF9966)];
-      case 'forest':
-        return const [Color(0xFF2F7336), Color(0xFFAAFFA9)];
-      case 'ocean':
-        return const [Color(0xFF1A2980), Color(0xFF26D0CE)];
-      case 'fire':
-        return const [Color(0xFFFF512F), Color(0xFFF09819)];
-      case 'purple':
-        return const [Color(0xFF2A0845), Color(0xFF6441A5)];
-      case 'pink':
-        return const [Color(0xFFFF9A9E), Color(0xFFFAD0C4)];
-      case 'emerald':
-        return const [Color(0xFF00B09B), Color(0xFF96C93D)];
-      case 'candy':
-        return const [Color(0xFFF857A6), Color(0xFFFF5858)];
-      case 'steel':
-        return const [Color(0xFF232526), Color(0xFF414345)];
-      case 'coffee':
-        return const [Color(0xFF603813), Color(0xFFB29F94)];
-      case 'gold':
-        return const [Color(0xFFF6D365), Color(0xFFFDA085)];
-      case 'lavender':
-        return const [Color(0xFFB993D6), Color(0xFF8CA6DB)];
-      case 'blueRoyal':
-      default:
-        return const [Color(0xFF0D1E42), Color(0xFF37478F)];
-    }
-  }
+  // Palette resolution moved to palette_utils.dart
 }
 


### PR DESCRIPTION
## Summary
- centralize palette definitions and compute readable text color
- apply dynamic text color to play screen and app bar
- use colorful icon gradients per category when monochrome is off

## Testing
- `dart format lib/utils/palette_utils.dart lib/widgets/design_background.dart lib/screens/play_screen.dart` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcf86d22883238faadd13cb1b9450