### PR TITLE
Use radial backgrounds and add subject grid

### DIFF
--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/design_config.dart';
 import '../services/design_prefs.dart';
 import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
 
 class DesignSettingsScreen extends StatefulWidget {
   const DesignSettingsScreen({super.key});
@@ -52,6 +53,11 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
               _paletteChip('ghana', _cfg.bgPaletteName == 'ghana'),
               _paletteChip('nigeria', _cfg.bgPaletteName == 'nigeria'),
               _paletteChip('kenya', _cfg.bgPaletteName == 'kenya'),
+              _paletteChip('midnight', _cfg.bgPaletteName == 'midnight'),
+              _paletteChip('sunset', _cfg.bgPaletteName == 'sunset'),
+              _paletteChip('forest', _cfg.bgPaletteName == 'forest'),
+              _paletteChip('ocean', _cfg.bgPaletteName == 'ocean'),
+              _paletteChip('purple', _cfg.bgPaletteName == 'purple'),
             ],
           ),
           const SizedBox(height: 16),
@@ -133,49 +139,19 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   }
 
   List<Color> _iconColorsForPalette(String name) {
-    switch (name) {
-      case 'coteIvoire':
-        return const [Colors.white, Color(0xFFFF8C00), Color(0xFF00C851)];
-      case 'senegal':
-        return const [Colors.white, Color(0xFF00853F), Color(0xFFEF2B2D)];
-      case 'ghana':
-        return const [Colors.white, Color(0xFFE21B1B), Color(0xFF006B3F)];
-      case 'nigeria':
-        return const [Colors.white, Color(0xFF008751), Color(0xFFA7FF83)];
-      case 'kenya':
-        return const [Colors.white, Color(0xFFBB1919), Color(0xFF006600)];
-      case 'blueAqua':
-        return const [Colors.white, Color(0xFF6C8BF5), Color(0xFF3A4CC5)];
-      case 'midnight':
-        return const [Colors.white, Color(0xFF2C5364), Color(0xFF0F2027)];
-      case 'sunset':
-        return const [Colors.white, Color(0xFFFF9966), Color(0xFFFF5E62)];
-      case 'forest':
-        return const [Colors.white, Color(0xFF2F7336), Color(0xFFAAFFA9)];
-      case 'ocean':
-        return const [Colors.white, Color(0xFF1A2980), Color(0xFF26D0CE)];
-      case 'fire':
-        return const [Colors.white, Color(0xFFFF512F), Color(0xFFF09819)];
-      case 'purple':
-        return const [Colors.white, Color(0xFF2A0845), Color(0xFF6441A5)];
-      case 'pink':
-        return const [Colors.white, Color(0xFFFF9A9E), Color(0xFFFAD0C4)];
-      case 'emerald':
-        return const [Colors.white, Color(0xFF00B09B), Color(0xFF96C93D)];
-      case 'candy':
-        return const [Colors.white, Color(0xFFF857A6), Color(0xFFFF5858)];
-      case 'steel':
-        return const [Colors.white, Color(0xFF232526), Color(0xFF414345)];
-      case 'coffee':
-        return const [Colors.white, Color(0xFF603813), Color(0xFFB29F94)];
-      case 'gold':
-        return const [Colors.white, Color(0xFFF6D365), Color(0xFFFDA085)];
-      case 'lavender':
-        return const [Colors.white, Color(0xFFB993D6), Color(0xFF8CA6DB)];
-      case 'blueRoyal':
-      default:
-        return const [Colors.white, Color(0xFF37478F), Color(0xFF0D1E42)];
-    }
+    final palette = paletteFromName(name);
+    Color complement(Color c) =>
+        Color.fromARGB(255, 255 - c.red, 255 - c.green, 255 - c.blue);
+    final c1 = complement(palette[0]);
+    final c2 = complement(palette.length > 1 ? palette[1] : palette[0]);
+    final avg = Color.fromARGB(
+      255,
+      ((palette[0].red + palette[1].red) / 2).round(),
+      ((palette[0].green + palette[1].green) / 2).round(),
+      ((palette[0].blue + palette[1].blue) / 2).round(),
+    );
+    final c3 = complement(avg);
+    return [Colors.black, Colors.white, c1, c2, c3];
   }
 
   Widget _colorChip(Color color, bool selected) {

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -1,5 +1,9 @@
+import 'dart:ui' show ImageFilter;
 import 'package:flutter/material.dart';
 import '../data/ena_taxonomy.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
 import 'chapter_list_screen.dart';
 
 /// Liste des matières ENA
@@ -11,31 +15,232 @@ class SubjectListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Modules ENA')),
-      body: ListView.builder(
-        itemCount: subjectsENA.length,
-        itemBuilder: (context, index) {
-          final subject = subjectsENA[index];
-          return ListTile(
-            title: Text(subject.name),
-            subtitle: Text('${subject.chapters.length} chapitres'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () {
-              // Navigation vers la liste/écran de chapitres pour cette matière
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => ChapterListScreen(
-                    subjectName: subject.name,
-                    // Par défaut : premier chapitre ; l'écran de chapitres peut ignorer ce champ
-                    chapterName: subject.chapters.isNotEmpty ? subject.chapters.first.name : '',
-                  ),
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final textColor = textColorForPalette(cfg.bgPaletteName);
+        return Scaffold(
+          extendBody: true,
+          extendBodyBehindAppBar: true,
+          backgroundColor: Colors.transparent,
+          appBar: AppBar(
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            foregroundColor: textColor,
+            title: const Text('Modules ENA'),
+          ),
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: GridView.builder(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  crossAxisSpacing: 14,
+                  mainAxisSpacing: 14,
+                  childAspectRatio: 1.05,
                 ),
-              );
-            },
-          );
-        },
+                itemCount: subjectsENA.length,
+                itemBuilder: (context, index) {
+                  final subject = subjectsENA[index];
+                  final item = _subjectItems[index];
+                  return _GlassTile(
+                    title: subject.name,
+                    icon: item.icon,
+                    gradientColors: item.gradientColors,
+                    blur: cfg.glassBlur,
+                    bgOpacity: cfg.glassBgOpacity,
+                    borderOpacity: cfg.glassBorderOpacity,
+                    iconSize: cfg.tileIconSize,
+                    centerContent: cfg.tileCenter,
+                    useMono: cfg.useMono,
+                    monoColor: cfg.monoColor,
+                    textColor: textColor,
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => ChapterListScreen(
+                            subjectName: subject.name,
+                            chapterName: subject.chapters.isNotEmpty
+                                ? subject.chapters.first.name
+                                : '',
+                          ),
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SubjectItem {
+  final IconData icon;
+  final List<Color> gradientColors;
+  const _SubjectItem(this.icon, this.gradientColors);
+}
+
+const _subjectItems = <_SubjectItem>[
+  _SubjectItem(Icons.public, [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
+  _SubjectItem(Icons.gavel, [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
+  _SubjectItem(Icons.bar_chart, [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
+  _SubjectItem(Icons.functions, [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
+  _SubjectItem(Icons.menu_book, [Color(0xFFFF7043), Color(0xFFD84315)]),
+  _SubjectItem(Icons.extension, [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
+];
+
+class _GlassTile extends StatefulWidget {
+  const _GlassTile({
+    required this.title,
+    required this.icon,
+    required this.gradientColors,
+    required this.onTap,
+    required this.blur,
+    required this.bgOpacity,
+    required this.borderOpacity,
+    required this.iconSize,
+    required this.centerContent,
+    required this.useMono,
+    required this.monoColor,
+    required this.textColor,
+  });
+  final String title;
+  final IconData icon;
+  final List<Color> gradientColors;
+  final VoidCallback onTap;
+  final double blur;
+  final double bgOpacity;
+  final double borderOpacity;
+  final double iconSize;
+  final bool centerContent;
+  final bool useMono;
+  final Color monoColor;
+  final Color textColor;
+
+  @override
+  State<_GlassTile> createState() => _GlassTileState();
+}
+
+class _GlassTileState extends State<_GlassTile> {
+  bool _pressed = false;
+  @override
+  Widget build(BuildContext context) {
+    final gradientColors = widget.useMono
+        ? [
+            widget.monoColor.withOpacity(0.15),
+            widget.monoColor.withOpacity(0.35)
+          ]
+        : widget.gradientColors;
+
+    final iconColor = widget.useMono ? widget.monoColor : Colors.white;
+
+    final iconBadge = Container(
+      height: widget.iconSize,
+      width: widget.iconSize,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: gradientColors,
+        ),
+        border: Border.all(color: Colors.white.withOpacity(0.25)),
+      ),
+      child: Icon(widget.icon, size: widget.iconSize * 0.58, color: iconColor),
+    );
+
+    final title = Text(
+      widget.title,
+      textAlign: widget.centerContent ? TextAlign.center : TextAlign.left,
+      style: TextStyle(
+        fontSize: 20,
+        height: 1.15,
+        fontWeight: FontWeight.w800,
+        color: widget.textColor,
+      ),
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapCancel: () => setState(() => _pressed = false),
+      onTapUp: (_) => setState(() => _pressed = false),
+      onTap: widget.onTap,
+      child: AnimatedScale(
+        duration: const Duration(milliseconds: 110),
+        curve: Curves.easeOut,
+        scale: _pressed ? 0.98 : 1.0,
+        child: _GlassCard(
+          blur: widget.blur,
+          backgroundOpacity: widget.bgOpacity,
+          borderOpacity: widget.borderOpacity,
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            child: widget.centerContent
+                ? Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      iconBadge,
+                      const SizedBox(height: 12),
+                      title,
+                    ],
+                  )
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Align(alignment: Alignment.topLeft, child: iconBadge),
+                      const Spacer(),
+                      title,
+                    ],
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GlassCard extends StatelessWidget {
+  const _GlassCard({
+    required this.child,
+    this.blur = 16,
+    this.backgroundOpacity = 0.16,
+    this.borderOpacity = 0.22,
+  });
+  final Widget child;
+  final double blur;
+  final double backgroundOpacity;
+  final double borderOpacity;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(22),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Colors.white.withOpacity(backgroundOpacity + 0.05),
+                Colors.white.withOpacity(backgroundOpacity),
+              ],
+            ),
+            border: Border.all(
+                color: Colors.white.withOpacity(borderOpacity), width: 1.2),
+            borderRadius: BorderRadius.circular(22),
+          ),
+          child: child,
+        ),
       ),
     );
   }

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -18,9 +18,9 @@ class DesignBackground extends StatelessWidget {
         final colors = paletteFromName(cfg.bgPaletteName);
         return DecoratedBox(
           decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
+            gradient: RadialGradient(
+              center: Alignment.center,
+              radius: 1.0,
               colors: colors,
             ),
           ),


### PR DESCRIPTION
## Summary
- switch design background to radial gradients
- add 10 background palette choices with complementary icon colors
- redesign subject selection with grid tiles and icons

## Testing
- `flutter format lib/widgets/design_background.dart lib/screens/design_settings_screen.dart lib/screens/subject_list_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afd80985788323b201c452537897ea