### PR TITLE
feat: tone down palettes and lighten gradients

### DIFF
--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -143,12 +143,13 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
     Color complement(Color c) =>
         Color.fromARGB(255, 255 - c.red, 255 - c.green, 255 - c.blue);
     final c1 = complement(palette[0]);
-    final c2 = complement(palette.length > 1 ? palette[1] : palette[0]);
+    final second = palette.length > 1 ? palette[1] : palette[0];
+    final c2 = complement(second);
     final avg = Color.fromARGB(
       255,
-      ((palette[0].red + palette[1].red) / 2).round(),
-      ((palette[0].green + palette[1].green) / 2).round(),
-      ((palette[0].blue + palette[1].blue) / 2).round(),
+      ((palette[0].red + second.red) / 2).round(),
+      ((palette[0].green + second.green) / 2).round(),
+      ((palette[0].blue + second.blue) / 2).round(),
     );
     final c3 = complement(avg);
     return [Colors.black, Colors.white, c1, c2, c3];

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -4,20 +4,20 @@ import 'package:flutter/material.dart';
 List<Color> paletteFromName(String name) {
   switch (name) {
     case 'coteIvoire':
-      // Inspired by the Ivorian flag (orange/green) with lighter shades
-      return const [Color(0xFFFF8C00), Color(0xFF00C851)];
+      // Muted beige echoing Côte d'Ivoire's tones (no gradient)
+      return const [Color(0xFFD2B48C)];
     case 'senegal':
-      // Green to red gradient reflecting Senegal's flag
-      return const [Color(0xFF00853F), Color(0xFFEF2B2D)];
+      // Subdued olive inspired by Senegal's flag (no gradient)
+      return const [Color(0xFF556B2F)];
     case 'ghana':
-      // Red to dark green taken from Ghana's flag colours
-      return const [Color(0xFFE21B1B), Color(0xFF006B3F)];
+      // Earthy brown referencing Ghana's colours (no gradient)
+      return const [Color(0xFF8B4513)];
     case 'nigeria':
-      // Dual greens reminiscent of Nigeria's flag
-      return const [Color(0xFF008751), Color(0xFFA7FF83)];
+      // Calm sea green reflecting Nigeria's flag (no gradient)
+      return const [Color(0xFF2E8B57)];
     case 'kenya':
-      // Kenyan flag tones with warm red and deep green
-      return const [Color(0xFFBB1919), Color(0xFF006600)];
+      // Warm brown hinting at Kenya's palette (no gradient)
+      return const [Color(0xFF6B4423)];
     case 'blueAqua':
       return const [Color(0xFF3A4CC5), Color(0xFF6C8BF5)];
     case 'midnight':

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -16,14 +16,24 @@ class DesignBackground extends StatelessWidget {
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
         final colors = paletteFromName(cfg.bgPaletteName);
-        return DecoratedBox(
-          decoration: BoxDecoration(
+        final BoxDecoration decoration;
+        if (colors.length == 1) {
+          decoration = BoxDecoration(color: colors.first);
+        } else {
+          decoration = BoxDecoration(
             gradient: RadialGradient(
               center: Alignment.center,
               radius: 1.0,
-              colors: colors,
+              colors: [
+                // Center is lighter for a soft gradient
+                Colors.lerp(colors[0], Colors.white, 0.3)!,
+                colors[1],
+              ],
             ),
-          ),
+          );
+        }
+        return DecoratedBox(
+          decoration: decoration,
           child: Stack(
             children: [
               if (cfg.waveEnabled)


### PR DESCRIPTION
## Summary
- make flag-based palettes solid, subdued colors
- lighten gradient center for softer look
- handle single-color palettes in design settings

## Testing
- `flutter format lib/utils/palette_utils.dart lib/widgets/design_background.dart lib/screens/design_settings_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afdae255908323a5bab11e26098bd0