### PR TITLE
Add configurable linear background palettes

### DIFF
--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -10,6 +10,7 @@ class DesignConfig {
   // Thème fond
   final String bgPaletteName;
   final bool waveEnabled;
+  final bool bgGradient;
 
   // Verre
   final double glassBlur;
@@ -30,6 +31,7 @@ class DesignConfig {
     // Thème fond
     this.bgPaletteName = 'midnight',
     this.waveEnabled = true,
+    this.bgGradient = true,
     // Verre
     this.glassBlur = 18.0,
     this.glassBgOpacity = 0.16,
@@ -47,6 +49,7 @@ class DesignConfig {
   DesignConfig copyWith({
     String? bgPaletteName,
     bool? waveEnabled,
+    bool? bgGradient,
     double? glassBlur,
     double? glassBgOpacity,
     double? glassBorderOpacity,
@@ -60,6 +63,7 @@ class DesignConfig {
     return DesignConfig(
       bgPaletteName: bgPaletteName ?? this.bgPaletteName,
       waveEnabled: waveEnabled ?? this.waveEnabled,
+      bgGradient: bgGradient ?? this.bgGradient,
       glassBlur: glassBlur ?? this.glassBlur,
       glassBgOpacity: glassBgOpacity ?? this.glassBgOpacity,
       glassBorderOpacity: glassBorderOpacity ?? this.glassBorderOpacity,
@@ -75,6 +79,7 @@ class DesignConfig {
   Map<String, dynamic> toJson() => {
     'bgPaletteName': bgPaletteName,
     'waveEnabled': waveEnabled,
+    'bgGradient': bgGradient,
     'glassBlur': glassBlur,
     'glassBgOpacity': glassBgOpacity,
     'glassBorderOpacity': glassBorderOpacity,
@@ -95,6 +100,7 @@ class DesignConfig {
     return DesignConfig(
       bgPaletteName: map['bgPaletteName'] ?? 'midnight',
       waveEnabled: (map['waveEnabled'] ?? true) as bool,
+      bgGradient: (map['bgGradient'] ?? true) as bool,
       glassBlur: (map['glassBlur'] ?? 18.0).toDouble(),
       glassBgOpacity: (map['glassBgOpacity'] ?? 0.16).toDouble(),
       glassBorderOpacity: (map['glassBorderOpacity'] ?? 0.22).toDouble(),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -56,7 +56,22 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
               _paletteChip('steel', _cfg.bgPaletteName == 'steel'),
               _paletteChip('coffee', _cfg.bgPaletteName == 'coffee'),
               _paletteChip('blueRoyal', _cfg.bgPaletteName == 'blueRoyal'),
+              _paletteChip('fireOcean', _cfg.bgPaletteName == 'fireOcean'),
+              _paletteChip('refreshingSummer', _cfg.bgPaletteName == 'refreshingSummer'),
+              _paletteChip('oliveGardenFeast', _cfg.bgPaletteName == 'oliveGardenFeast'),
+              _paletteChip('oceanBleuSerenity', _cfg.bgPaletteName == 'oceanBleuSerenity'),
+              _paletteChip('softPink', _cfg.bgPaletteName == 'softPink'),
+              _paletteChip('oceanBreeze', _cfg.bgPaletteName == 'oceanBreeze'),
+              _paletteChip('softSand', _cfg.bgPaletteName == 'softSand'),
+              _paletteChip('beachSunset', _cfg.bgPaletteName == 'beachSunset'),
+              _paletteChip('slateGrayContrast', _cfg.bgPaletteName == 'slateGrayContrast'),
             ],
+          ),
+          const SizedBox(height: 16),
+          SwitchListTile(
+            title: const Text('Fond dégradé'),
+            value: _cfg.bgGradient,
+            onChanged: (v) => _apply(_cfg.copyWith(bgGradient: v)),
           ),
           const SizedBox(height: 16),
           SwitchListTile(
@@ -137,19 +152,7 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   }
 
   List<Color> _iconColorsForPalette(String name) {
-    final palette = paletteFromName(name);
-    Color complement(Color c) =>
-        Color.fromARGB(255, 255 - c.red, 255 - c.green, 255 - c.blue);
-    final c1 = complement(palette[0]);
-    final c2 = complement(palette.length > 1 ? palette[1] : palette[0]);
-    final avg = Color.fromARGB(
-      255,
-      ((palette[0].red + palette[1].red) / 2).round(),
-      ((palette[0].green + palette[1].green) / 2).round(),
-      ((palette[0].blue + palette[1].blue) / 2).round(),
-    );
-    final c3 = complement(avg);
-    return [Colors.black, Colors.white, c1, c2, c3];
+    return paletteFromName(name);
   }
 
   Widget _colorChip(Color color, bool selected) {

--- a/lib/services/design_prefs.dart
+++ b/lib/services/design_prefs.dart
@@ -13,6 +13,7 @@ class DesignPrefs {
   static const _kBdOp    = 'design_glassBorderOpacity';
   static const _kWave    = 'design_waveEnabled';
   static const _kBgPal   = 'design_bgPaletteName'; // NEW
+  static const _kBgGrad  = 'design_bgGradient';
 
   static Future<DesignConfig> load() async {
     final p = await SharedPreferences.getInstance();
@@ -26,6 +27,7 @@ class DesignPrefs {
       glassBorderOpacity: p.getDouble(_kBdOp) ?? const DesignConfig().glassBorderOpacity,
       waveEnabled: p.getBool(_kWave) ?? const DesignConfig().waveEnabled,
       bgPaletteName: p.getString(_kBgPal) ?? const DesignConfig().bgPaletteName,
+      bgGradient: p.getBool(_kBgGrad) ?? const DesignConfig().bgGradient,
     );
   }
 
@@ -40,5 +42,6 @@ class DesignPrefs {
     await p.setDouble(_kBdOp, cfg.glassBorderOpacity);
     await p.setBool(_kWave, cfg.waveEnabled);
     await p.setString(_kBgPal, cfg.bgPaletteName);
+    await p.setBool(_kBgGrad, cfg.bgGradient);
   }
 }

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -24,6 +24,83 @@ List<Color> paletteFromName(String name) {
     case 'coffee':
       // Creamy center to dark coffee edge
       return const [Color(0xFFEAD7C4), Color(0xFF603813)];
+    case 'fireOcean':
+      // Fire Ocean palette
+      return const [
+        Color(0xFF780000),
+        Color(0xFFC1121F),
+        Color(0xFFFDF0D5),
+        Color(0xFF003049),
+        Color(0xFF669BBC),
+      ];
+    case 'refreshingSummer':
+      return const [
+        Color(0xFF8ECAE6),
+        Color(0xFF219EBC),
+        Color(0xFF023047),
+        Color(0xFFFFB703),
+        Color(0xFFFB8500),
+      ];
+    case 'oliveGardenFeast':
+      return const [
+        Color(0xFF606C38),
+        Color(0xFF283618),
+        Color(0xFFFEFAE0),
+        Color(0xFFDDA15E),
+        Color(0xFFBC6C25),
+      ];
+    case 'oceanBleuSerenity':
+      return const [
+        Color(0xFF03045E),
+        Color(0xFF023E8A),
+        Color(0xFF0077B6),
+        Color(0xFF0096C7),
+        Color(0xFF00B4D8),
+        Color(0xFF48CAE4),
+        Color(0xFF90E0EF),
+        Color(0xFFADE8F4),
+        Color(0xFFCAF0F8),
+      ];
+    case 'softPink':
+      return const [
+        Color(0xFFFFE5EC),
+        Color(0xFFFFC2D1),
+        Color(0xFFFFB3C6),
+        Color(0xFFFF8FAB),
+        Color(0xFFFB6F92),
+      ];
+    case 'oceanBreeze':
+      return const [
+        Color(0xFF03045E),
+        Color(0xFF0077B6),
+        Color(0xFF00B4D8),
+        Color(0xFF90E0EF),
+        Color(0xFFCAF0F8),
+      ];
+    case 'softSand':
+      return const [
+        Color(0xFFEDEDE9),
+        Color(0xFFD6CCC2),
+        Color(0xFFF5EBE0),
+        Color(0xFFE3D5CA),
+        Color(0xFFD5BDAF),
+      ];
+    case 'beachSunset':
+      return const [
+        Color(0xFFBEE9E8),
+        Color(0xFF62B6CB),
+        Color(0xFF1B4965),
+        Color(0xFFCAE9FF),
+        Color(0xFF5FA8D3),
+      ];
+    case 'slateGrayContrast':
+      return const [
+        Color(0xFFFF6700),
+        Color(0xFFEBEBEB),
+        Color(0xFFC0C0C0),
+        Color(0xFF3A6EA5),
+        Color(0xFF004E98),
+      ];
     case 'blueRoyal':
     default:
       // Subtle light blue center to royal blue edge

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -16,17 +16,16 @@ class DesignBackground extends StatelessWidget {
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
         final baseColors = paletteFromName(cfg.bgPaletteName);
-        final gradientColors = [
-          Color.lerp(baseColors.first, Colors.white, 0.35)!,
-          baseColors.last,
-        ];
         return DecoratedBox(
           decoration: BoxDecoration(
-            gradient: RadialGradient(
-              center: Alignment.center,
-              radius: 1.0,
-              colors: gradientColors,
-            ),
+            gradient: cfg.bgGradient
+                ? LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: baseColors,
+                  )
+                : null,
+            color: cfg.bgGradient ? null : baseColors.first,
           ),
           child: Stack(
             children: [


### PR DESCRIPTION
## Summary
- add multiple new color palettes
- allow linear gradient or solid backgrounds based on palette
- use palette colors for mono icon selection and persist gradient choice

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afdf7dbefc83239b3da860ec7a99e6