### PR TITLE
Use soft two-color gradients

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -11,13 +11,13 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF37478F), Color(0xFF6C7BD0)],
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [Color(0xFF5C6BB7), Color(0xFF6C7BD0)],
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+            ),
           ),
-        ),
         child: SafeArea(
           child: Padding(
             padding: const EdgeInsets.all(16),

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -355,7 +355,7 @@ class _IconBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final gradientColors = useMono
         ? [monoColor.withOpacity(0.15), monoColor.withOpacity(0.35)]
-        : const [Color(0xFFFFB25E), Color(0xFFFF7A00)];
+        : const [Color(0xFF5C6BB7), Color(0xFF6C7BD0)];
     final iconColor = useMono ? monoColor : Colors.white;
     return Container(
       height: size,
@@ -382,19 +382,19 @@ class _MenuItem {
 
 const _items = <_MenuItem>[
   _MenuItem("S'entraîner", Icons.play_circle_fill_rounded,
-      [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
+      [Color(0xFF5C6BB7), Color(0xFF6C7BD0)]),
   _MenuItem('Concours ENA', Icons.school_rounded,
-      [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
+      [Color(0xFF4A90E2), Color(0xFF5A9AE5)]),
   _MenuItem('Par matière', Icons.menu_book_rounded,
-      [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
+      [Color(0xFF5FBF72), Color(0xFF66BB6A)]),
   _MenuItem('Historique examens', Icons.fact_check_rounded,
-      [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
+      [Color(0xFF9D3FB2), Color(0xFFA84ABD)]),
   _MenuItem("Historique entraînement", Icons.history_rounded,
-      [Color(0xFFFF7043), Color(0xFFD84315)]),
+      [Color(0xFF5E8CD1), Color(0xFF6B99D5)]),
   _MenuItem('Comment ça marche ?', Icons.info_rounded,
-      [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
+      [Color(0xFF1FB5C6), Color(0xFF26C6DA)]),
   _MenuItem('Compétition', Icons.sports_kabaddi,
-      [Color(0xFFFFEE58), Color(0xFFFDD835)]),
+      [Color(0xFF4AAAE0), Color(0xFF55B3E3)]),
   _MenuItem('Classement', Icons.emoji_events_outlined,
-      [Color(0xFFEC407A), Color(0xFFD81B60)]),
+      [Color(0xFF8662C5), Color(0xFF9270C8)]),
 ];

--- a/lib/screens/splash_animated.dart
+++ b/lib/screens/splash_animated.dart
@@ -55,7 +55,7 @@ class _SplashAnimatedState extends State<SplashAnimated>
           gradient: LinearGradient(
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
-            colors: [Color(0xFF3A4CC5), Color(0xFF6C8BF5), Color(0xFF7BD3EA)],
+            colors: [Color(0xFF4B60CC), Color(0xFF5A6ED6)],
           ),
         ),
         child: Center(

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -86,12 +86,12 @@ class _SubjectItem {
 }
 
 const _subjectItems = <_SubjectItem>[
-  _SubjectItem(Icons.public, [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
-  _SubjectItem(Icons.gavel, [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
-  _SubjectItem(Icons.bar_chart, [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
-  _SubjectItem(Icons.functions, [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
-  _SubjectItem(Icons.menu_book, [Color(0xFFFF7043), Color(0xFFD84315)]),
-  _SubjectItem(Icons.extension, [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
+  _SubjectItem(Icons.public, [Color(0xFF5C6BB7), Color(0xFF6C7BD0)]),
+  _SubjectItem(Icons.gavel, [Color(0xFF4A90E2), Color(0xFF5A9AE5)]),
+  _SubjectItem(Icons.bar_chart, [Color(0xFF5FBF72), Color(0xFF66BB6A)]),
+  _SubjectItem(Icons.functions, [Color(0xFF9D3FB2), Color(0xFFA84ABD)]),
+  _SubjectItem(Icons.menu_book, [Color(0xFF5E8CD1), Color(0xFF6B99D5)]),
+  _SubjectItem(Icons.extension, [Color(0xFF1FB5C6), Color(0xFF26C6DA)]),
 ];
 
 class _GlassTile extends StatefulWidget {

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -4,107 +4,57 @@ import 'package:flutter/material.dart';
 List<Color> paletteFromName(String name) {
   switch (name) {
     case 'midnight':
-      // Soft steel blue toward deep navy
-      return const [Color(0xFFB0C4DE), Color(0xFF2C5364)];
+      // Soft steel blue pair for a gentle gradient
+      return const [Color(0xFFB0C4DE), Color(0xFFA5BAD6)];
     case 'forest':
-      // Gentle green center fading to dark forest edge
-      return const [Color(0xFFDDEED7), Color(0xFF2F7336)];
+      // Gentle green tones kept very close
+      return const [Color(0xFFDDEED7), Color(0xFFD2E3CC)];
     case 'ocean':
-      // Pale aqua center to deep ocean blue
-      return const [Color(0xFFD7F2F3), Color(0xFF1A2980)];
+      // Pale aqua shades for a subtle sea breeze
+      return const [Color(0xFFD7F2F3), Color(0xFFCDE9F0)];
     case 'purple':
-      // Light lavender center to rich purple edge
-      return const [Color(0xFFE6DAF5), Color(0xFF2A0845)];
+      // Light lavender pair
+      return const [Color(0xFFE6DAF5), Color(0xFFDCD0EF)];
     case 'lavender':
-      // Almost white lavender to muted periwinkle
-      return const [Color(0xFFF2ECFF), Color(0xFF8CA6DB)];
+      // Almost white lavender to muted periwinkle, softened
+      return const [Color(0xFFF2ECFF), Color(0xFFE8E1FA)];
     case 'steel':
-      // Soft grey center to charcoal edge
-      return const [Color(0xFFE5E7EA), Color(0xFF414345)];
+      // Subtle grey duo
+      return const [Color(0xFFE5E7EA), Color(0xFFDADCE0)];
     case 'coffee':
-      // Creamy center to dark coffee edge
-      return const [Color(0xFFEAD7C4), Color(0xFF603813)];
+      // Neutral greys to avoid warm tones
+      return const [Color(0xFFE0E0E0), Color(0xFFD0D0D0)];
     case 'fireOcean':
-      // Fire Ocean palette
-      return const [
-        Color(0xFF780000),
-        Color(0xFFC1121F),
-        Color(0xFFFDF0D5),
-        Color(0xFF003049),
-        Color(0xFF669BBC),
-      ];
+      // Cool blue pair
+      return const [Color(0xFF3A4CC5), Color(0xFF4557CA)];
     case 'refreshingSummer':
-      return const [
-        Color(0xFF8ECAE6),
-        Color(0xFF219EBC),
-        Color(0xFF023047),
-        Color(0xFFFFB703),
-        Color(0xFFFB8500),
-      ];
+      // Soft turquoise shades
+      return const [Color(0xFF8ECAE6), Color(0xFF7EBFDD)];
     case 'oliveGardenFeast':
-      return const [
-        Color(0xFF606C38),
-        Color(0xFF283618),
-        Color(0xFFFEFAE0),
-        Color(0xFFDDA15E),
-        Color(0xFFBC6C25),
-      ];
+      // Muted greens close together
+      return const [Color(0xFF606C38), Color(0xFF6A7642)];
     case 'oceanBleuSerenity':
-      return const [
-        Color(0xFF03045E),
-        Color(0xFF023E8A),
-        Color(0xFF0077B6),
-        Color(0xFF0096C7),
-        Color(0xFF00B4D8),
-        Color(0xFF48CAE4),
-        Color(0xFF90E0EF),
-        Color(0xFFADE8F4),
-        Color(0xFFCAF0F8),
-      ];
+      // Calm ocean blues
+      return const [Color(0xFF0077B6), Color(0xFF008BC0)];
     case 'softPink':
-      return const [
-        Color(0xFFFFE5EC),
-        Color(0xFFFFC2D1),
-        Color(0xFFFFB3C6),
-        Color(0xFFFF8FAB),
-        Color(0xFFFB6F92),
-      ];
+      // Cool pastel purples
+      return const [Color(0xFFE6DAF5), Color(0xFFDAD0EF)];
     case 'oceanBreeze':
-      return const [
-        Color(0xFF03045E),
-        Color(0xFF0077B6),
-        Color(0xFF00B4D8),
-        Color(0xFF90E0EF),
-        Color(0xFFCAF0F8),
-      ];
+      // Breezy light blues
+      return const [Color(0xFF00B4D8), Color(0xFF23C2E3)];
     case 'softSand':
-      return const [
-        Color(0xFFEDEDE9),
-        Color(0xFFD6CCC2),
-        Color(0xFFF5EBE0),
-        Color(0xFFE3D5CA),
-        Color(0xFFD5BDAF),
-      ];
+      // Neutral soft greys
+      return const [Color(0xFFE5E5E5), Color(0xFFDADADA)];
     case 'beachSunset':
-      return const [
-        Color(0xFFBEE9E8),
-        Color(0xFF62B6CB),
-        Color(0xFF1B4965),
-        Color(0xFFCAE9FF),
-        Color(0xFF5FA8D3),
-      ];
+      // Gentle seaside blues
+      return const [Color(0xFFBEE9E8), Color(0xFFC7EEF0)];
     case 'slateGrayContrast':
-      return const [
-        Color(0xFFFF6700),
-        Color(0xFFEBEBEB),
-        Color(0xFFC0C0C0),
-        Color(0xFF3A6EA5),
-        Color(0xFF004E98),
-      ];
+      // Slate blue duo
+      return const [Color(0xFF3A6EA5), Color(0xFF4678AD)];
     case 'blueRoyal':
     default:
-      // Subtle light blue center to royal blue edge
-      return const [Color(0xFFE1E6F2), Color(0xFF0D1E42)];
+      // Subtle light blue pair
+      return const [Color(0xFFDDE3F0), Color(0xFFE1E6F2)];
   }
 }
 


### PR DESCRIPTION
## Summary
- simplify all palettes to two close cool colors to avoid harsh gradients
- update home, subject, play, and splash screens to use soft two-color gradients

## Testing
- `dart format lib/utils/palette_utils.dart lib/screens/home_screen.dart lib/screens/subject_list_screen.dart lib/screens/play_screen.dart lib/screens/splash_animated.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afe2a2a17c8323880e418d87e62a79