### PR TITLE
feat: add customizable rainbow themes

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
+import '../models/design_config.dart';
+import '../utils/palette_utils.dart';
 
-const Color kPrimaryBlue = Color(0xFF37478F);
-const Color kPrimaryBlueLight = Color(0xFF6C7BD0);
-const Color kSurface = Colors.white;
+/// Builds the global [ThemeData] based on the chosen palette and mode.
+ThemeData buildAppTheme(DesignConfig cfg) {
+  final accent = accentColor(cfg.bgPaletteName);
+  final complement = complementaryColor(cfg.bgPaletteName);
+  final brightness = cfg.darkMode ? Brightness.dark : Brightness.light;
 
-ThemeData buildAppTheme() {
   final base = ThemeData(
     colorScheme: ColorScheme.fromSeed(
-      seedColor: kPrimaryBlue,
-      brightness: Brightness.light,
+      seedColor: accent,
+      brightness: brightness,
     ),
     useMaterial3: true,
     scaffoldBackgroundColor: Colors.transparent,
@@ -25,9 +28,10 @@ ThemeData buildAppTheme() {
 
   return base.copyWith(
     textTheme: textTheme,
-    appBarTheme: const AppBarTheme(
+    iconTheme: IconThemeData(color: accent),
+    appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
-      foregroundColor: Colors.white,
+      foregroundColor: accent,
       elevation: 0,
       centerTitle: true,
     ),
@@ -43,6 +47,8 @@ ThemeData buildAppTheme() {
       style: ElevatedButton.styleFrom(
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        backgroundColor: complement,
+        foregroundColor: onColor(complement),
       ),
     ),
     inputDecorationTheme: InputDecorationTheme(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'screens/login_screen.dart';
 import 'services/design_prefs.dart';
 import 'services/design_bus.dart';
 import 'widgets/design_background.dart';
+import 'models/design_config.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -22,23 +23,29 @@ class CivExamApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'CivExam',
-      theme: buildAppTheme(),
-      builder: (context, child) => DesignBackground(child: child ?? const SizedBox()),
-      home: StreamBuilder<User?>(
-        stream: FirebaseAuth.instance.authStateChanges(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasData) {
-            return const PlayScreen();
-          }
-          return const LoginScreen();
-        },
-      ),
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        return MaterialApp(
+          debugShowCheckedModeBanner: false,
+          title: 'CivExam',
+          theme: buildAppTheme(cfg),
+          builder: (context, child) =>
+              DesignBackground(child: child ?? const SizedBox()),
+          home: StreamBuilder<User?>(
+            stream: FirebaseAuth.instance.authStateChanges(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (snapshot.hasData) {
+                return const PlayScreen();
+              }
+              return const LoginScreen();
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -11,6 +11,7 @@ class DesignConfig {
   final String bgPaletteName;
   final bool waveEnabled;
   final bool bgGradient;
+  final bool darkMode; // mode sombre activé ?
 
   // Verre
   final double glassBlur;
@@ -32,6 +33,7 @@ class DesignConfig {
     this.bgPaletteName = 'blue',
     this.waveEnabled = true,
     this.bgGradient = true,
+    this.darkMode = false,
     // Verre
     this.glassBlur = 18.0,
     this.glassBgOpacity = 0.16,
@@ -50,6 +52,7 @@ class DesignConfig {
     String? bgPaletteName,
     bool? waveEnabled,
     bool? bgGradient,
+    bool? darkMode,
     double? glassBlur,
     double? glassBgOpacity,
     double? glassBorderOpacity,
@@ -64,6 +67,7 @@ class DesignConfig {
       bgPaletteName: bgPaletteName ?? this.bgPaletteName,
       waveEnabled: waveEnabled ?? this.waveEnabled,
       bgGradient: bgGradient ?? this.bgGradient,
+      darkMode: darkMode ?? this.darkMode,
       glassBlur: glassBlur ?? this.glassBlur,
       glassBgOpacity: glassBgOpacity ?? this.glassBgOpacity,
       glassBorderOpacity: glassBorderOpacity ?? this.glassBorderOpacity,
@@ -85,6 +89,7 @@ class DesignConfig {
     'glassBorderOpacity': glassBorderOpacity,
     'tileIconSize': tileIconSize,
     'tileCenter': tileCenter,
+    'darkMode': darkMode,
     // Legacy
     'useMono': useMono,
     'iconSetName': iconSetName,
@@ -106,6 +111,7 @@ class DesignConfig {
       glassBorderOpacity: (map['glassBorderOpacity'] ?? 0.22).toDouble(),
       tileIconSize: tileSize,
       tileCenter: (map['tileCenter'] ?? true) as bool,
+      darkMode: (map['darkMode'] ?? false) as bool,
       useMono: (map['useMono'] ?? false) as bool,
       iconSetName: map['iconSetName'] ?? 'default',
       svgIconSize: svgSize,

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -134,8 +134,8 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   }
 
   Widget _paletteChip(String name, bool selected) {
-    final colors = paletteFromName(name);
-    final textColor = textColorForPalette(name);
+    final colors = pastelColors(name, darkMode: _cfg.darkMode);
+    final textColor = textColorForPalette(name, darkMode: _cfg.darkMode);
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -162,7 +162,7 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   }
 
   List<Color> _iconColorsForPalette(String name) {
-    return paletteFromName(name);
+    return [accentColor(name), complementaryColor(name)];
   }
 
   Widget _colorChip(Color color, bool selected) {

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -13,7 +13,7 @@ import 'subject_list_screen.dart';
 import 'training_history_screen.dart';
 import 'exam_history_screen.dart';
 import 'leaderboard_screen.dart';
-import 'design_settings_screen.dart';
+import 'theme_selection_screen.dart';
 import 'competition_screen.dart';
 import 'login_screen.dart';
 
@@ -34,7 +34,8 @@ class _PlayScreenState extends State<PlayScreen> {
         final welcomeText = name != null && name.isNotEmpty
             ? 'Bienvenue $name 👋  •  Choisis un mode'
             : 'Bienvenue 👋  •  Choisis un mode';
-        final textColor = textColorForPalette(cfg.bgPaletteName);
+        final textColor =
+            textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
 
         return Scaffold(
           extendBody: true,
@@ -68,10 +69,13 @@ class _PlayScreenState extends State<PlayScreen> {
               ),
               IconButton(
                 icon: const Icon(Icons.palette_outlined),
-                tooltip: 'Réglages design',
+                tooltip: 'Choisir un thème',
                 onPressed: () async {
-                  await Navigator.push(context, MaterialPageRoute(builder: (_) => const DesignSettingsScreen()));
-                  // pas besoin de reload : le bus pousse en live pendant l’édition
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const ThemeSelectionScreen()),
+                  );
                 },
               ),
             ],

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -18,7 +18,8 @@ class SubjectListScreen extends StatelessWidget {
     return ValueListenableBuilder<DesignConfig>(
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
-        final textColor = textColorForPalette(cfg.bgPaletteName);
+        final textColor =
+            textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
         return Scaffold(
           extendBody: true,
           extendBodyBehindAppBar: true,

--- a/lib/screens/theme_selection_screen.dart
+++ b/lib/screens/theme_selection_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
+import '../services/design_prefs.dart';
+import '../utils/palette_utils.dart';
+
+/// Simple screen that lets the user choose among the 7 rainbow palettes
+/// and toggle light/dark mode. The choice is persisted via [DesignPrefs]
+/// and pushed through [DesignBus] for live updates.
+class ThemeSelectionScreen extends StatefulWidget {
+  const ThemeSelectionScreen({super.key});
+
+  @override
+  State<ThemeSelectionScreen> createState() => _ThemeSelectionScreenState();
+}
+
+class _ThemeSelectionScreenState extends State<ThemeSelectionScreen> {
+  DesignConfig _cfg = const DesignConfig();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final c = await DesignPrefs.load();
+    if (!mounted) return;
+    setState(() => _cfg = c);
+    DesignBus.push(c);
+  }
+
+  Future<void> _apply(DesignConfig c) async {
+    setState(() => _cfg = c);
+    DesignBus.push(c);
+    await DesignPrefs.save(c);
+  }
+
+  Future<void> _select(String name) async {
+    await _apply(_cfg.copyWith(bgPaletteName: name));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Choisir un thème')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final name in
+                  ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'])
+                _paletteChip(name, _cfg.bgPaletteName == name),
+            ],
+          ),
+          const SizedBox(height: 16),
+          SwitchListTile(
+            title: const Text('Mode sombre'),
+            value: _cfg.darkMode,
+            onChanged: (v) => _apply(_cfg.copyWith(darkMode: v)),
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Terminer'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _paletteChip(String name, bool selected) {
+    final colors = pastelColors(name, darkMode: _cfg.darkMode);
+    final textColor = textColorForPalette(name, darkMode: _cfg.darkMode);
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: () => _select(name),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+              colors: colors,
+            ),
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: selected ? textColor : Colors.transparent,
+              width: 2,
+            ),
+          ),
+          child: Text(name, style: TextStyle(color: textColor)),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/design_prefs.dart
+++ b/lib/services/design_prefs.dart
@@ -14,6 +14,7 @@ class DesignPrefs {
   static const _kWave    = 'design_waveEnabled';
   static const _kBgPal   = 'design_bgPaletteName'; // NEW
   static const _kBgGrad  = 'design_bgGradient';
+  static const _kDark    = 'design_darkMode';
 
   static Future<DesignConfig> load() async {
     final p = await SharedPreferences.getInstance();
@@ -28,6 +29,7 @@ class DesignPrefs {
       waveEnabled: p.getBool(_kWave) ?? const DesignConfig().waveEnabled,
       bgPaletteName: p.getString(_kBgPal) ?? const DesignConfig().bgPaletteName,
       bgGradient: p.getBool(_kBgGrad) ?? const DesignConfig().bgGradient,
+      darkMode: p.getBool(_kDark) ?? const DesignConfig().darkMode,
     );
   }
 
@@ -43,5 +45,6 @@ class DesignPrefs {
     await p.setBool(_kWave, cfg.waveEnabled);
     await p.setString(_kBgPal, cfg.bgPaletteName);
     await p.setBool(_kBgGrad, cfg.bgGradient);
+    await p.setBool(_kDark, cfg.darkMode);
   }
 }

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -1,33 +1,48 @@
 import 'package:flutter/material.dart';
 
-/// Utilities for design palettes and text contrast
-List<Color> paletteFromName(String name) {
+/// Utilities for design palettes and contrast helpers
+Color accentColor(String name) {
   switch (name) {
     case 'red':
-      return const [Color(0xFFD32F2F), Color(0xFFF44336)];
+      return const Color(0xFFE53935);
     case 'orange':
-      return const [Color(0xFFF57C00), Color(0xFFFF9800)];
+      return const Color(0xFFFB8C00);
     case 'yellow':
-      return const [Color(0xFFFBC02D), Color(0xFFFFEB3B)];
+      return const Color(0xFFFDD835);
     case 'green':
-      return const [Color(0xFF388E3C), Color(0xFF66BB6A)];
+      return const Color(0xFF43A047);
     case 'blue':
-      return const [Color(0xFF1976D2), Color(0xFF42A5F5)];
+      return const Color(0xFF1E88E5);
     case 'indigo':
-      return const [Color(0xFF303F9F), Color(0xFF5C6BC0)];
+      return const Color(0xFF3949AB);
     case 'violet':
-      return const [Color(0xFF8E24AA), Color(0xFFAB47BC)];
+      return const Color(0xFF8E24AA);
     default:
-      // Fallback to blue palette if name is unknown
-      return const [Color(0xFF1976D2), Color(0xFF42A5F5)];
+      return const Color(0xFF1E88E5);
   }
 }
 
-/// Returns [Colors.white] or [Colors.black] depending on the average
-/// brightness of the palette.
-Color textColorForPalette(String name) {
-  final colors = paletteFromName(name);
-  // Average the palette colors
+/// Returns two pastel variants of the accent color for gradient backgrounds.
+List<Color> pastelColors(String name, {bool darkMode = false}) {
+  final accent = accentColor(name);
+  final hsl = HSLColor.fromColor(accent);
+  final light1 = darkMode ? 0.25 : 0.85;
+  final light2 = darkMode ? 0.35 : 0.95;
+  final c1 = hsl.withLightness(light1).toColor();
+  final c2 = hsl.withLightness(light2).toColor();
+  return [c1, c2];
+}
+
+/// Complementary color used for buttons to stand out from the background.
+Color complementaryColor(String name) {
+  final accent = accentColor(name);
+  final hsl = HSLColor.fromColor(accent);
+  return hsl.withHue((hsl.hue + 180.0) % 360).toColor();
+}
+
+/// Returns [Colors.white] or [Colors.black] depending on the background brightness.
+Color textColorForPalette(String name, {bool darkMode = false}) {
+  final colors = pastelColors(name, darkMode: darkMode);
   int r = 0, g = 0, b = 0;
   for (final c in colors) {
     r += c.red;
@@ -38,3 +53,9 @@ Color textColorForPalette(String name) {
   final brightness = ThemeData.estimateBrightnessForColor(avg);
   return brightness == Brightness.dark ? Colors.white : Colors.black;
 }
+
+/// Helper to get readable text color on top of any solid [color].
+Color onColor(Color color) =>
+    ThemeData.estimateBrightnessForColor(color) == Brightness.dark
+        ? Colors.white
+        : Colors.black;

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -15,9 +15,8 @@ class DesignBackground extends StatelessWidget {
     return ValueListenableBuilder<DesignConfig>(
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
-        final baseColors = paletteFromName(cfg.bgPaletteName);
-        final textColor = textColorForPalette(cfg.bgPaletteName);
-        final buttonFg = textColor == Colors.white ? Colors.black : Colors.white;
+        final baseColors =
+            pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode);
 
         return DecoratedBox(
           decoration: BoxDecoration(
@@ -30,37 +29,27 @@ class DesignBackground extends StatelessWidget {
                 : null,
             color: cfg.bgGradient ? null : baseColors.first,
           ),
-          child: Theme(
-            data: Theme.of(context).copyWith(
-              elevatedButtonTheme: ElevatedButtonThemeData(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: textColor,
-                  foregroundColor: buttonFg,
-                ),
-              ),
-            ),
-            child: Stack(
-              children: [
-                if (cfg.waveEnabled)
-                  Positioned.fill(
-                    child: IgnorePointer(
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          gradient: RadialGradient(
-                            center: const Alignment(0.0, -0.6),
-                            radius: 1.0,
-                            colors: [
-                              Colors.white.withOpacity(0.08),
-                              Colors.transparent,
-                            ],
-                          ),
+          child: Stack(
+            children: [
+              if (cfg.waveEnabled)
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: RadialGradient(
+                          center: const Alignment(0.0, -0.6),
+                          radius: 1.0,
+                          colors: [
+                            Colors.white.withOpacity(0.08),
+                            Colors.transparent,
+                          ],
                         ),
                       ),
                     ),
                   ),
-                child,
-              ],
-            ),
+                ),
+              child,
+            ],
           ),
         );
       },


### PR DESCRIPTION
## Summary
- support dynamic themes with 7 rainbow palettes and light/dark mode
- apply palette colors across app elements with complementary buttons and vivid icons
- add theme selection screen with persistent settings

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b012daf08883239dbc9d5f43d3f679