### PR TITLE
feat: add customizable rainbow themes

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -1,17 +1,24 @@
 import 'package:flutter/material.dart';
 
-const Color kPrimaryBlue = Color(0xFF37478F);
-const Color kPrimaryBlueLight = Color(0xFF6C7BD0);
-const Color kSurface = Colors.white;
+import '../models/design_config.dart';
+import '../utils/palette_utils.dart';
 
-ThemeData buildAppTheme() {
+/// Builds the application [ThemeData] based on the selected palette in
+/// [DesignConfig]. The theme adapts to light/dark modes and ensures
+/// complementary button colors with readable text.
+ThemeData buildAppTheme(DesignConfig cfg, Brightness brightness) {
+  final vivid = vividColorForPalette(cfg.bgPaletteName);
+  final pastel = pastelColorForPalette(cfg.bgPaletteName, brightness: brightness);
+  final complement = complementaryOf(vivid);
+  final buttonText = contrastingText(complement);
+
   final base = ThemeData(
     colorScheme: ColorScheme.fromSeed(
-      seedColor: kPrimaryBlue,
-      brightness: Brightness.light,
+      seedColor: vivid,
+      brightness: brightness,
     ),
     useMaterial3: true,
-    scaffoldBackgroundColor: Colors.transparent,
+    scaffoldBackgroundColor: pastel,
   );
 
   final textTheme = base.textTheme.copyWith(
@@ -25,12 +32,13 @@ ThemeData buildAppTheme() {
 
   return base.copyWith(
     textTheme: textTheme,
-    appBarTheme: const AppBarTheme(
-      backgroundColor: Colors.transparent,
-      foregroundColor: Colors.white,
+    appBarTheme: AppBarTheme(
+      backgroundColor: pastel,
+      foregroundColor: vivid,
       elevation: 0,
       centerTitle: true,
     ),
+    iconTheme: IconThemeData(color: vivid),
     cardTheme: CardThemeData(
       elevation: 1,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
@@ -41,6 +49,8 @@ ThemeData buildAppTheme() {
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
+        backgroundColor: complement,
+        foregroundColor: buttonText,
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'screens/login_screen.dart';
 import 'services/design_prefs.dart';
 import 'services/design_bus.dart';
 import 'widgets/design_background.dart';
+import 'models/design_config.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -22,23 +23,30 @@ class CivExamApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'CivExam',
-      theme: buildAppTheme(),
-      builder: (context, child) => DesignBackground(child: child ?? const SizedBox()),
-      home: StreamBuilder<User?>(
-        stream: FirebaseAuth.instance.authStateChanges(),
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.waiting) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (snapshot.hasData) {
-            return const PlayScreen();
-          }
-          return const LoginScreen();
-        },
-      ),
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        return MaterialApp(
+          debugShowCheckedModeBanner: false,
+          title: 'CivExam',
+          theme: buildAppTheme(cfg, Brightness.light),
+          darkTheme: buildAppTheme(cfg, Brightness.dark),
+          themeMode: ThemeMode.system,
+          builder: (context, child) => DesignBackground(child: child ?? const SizedBox()),
+          home: StreamBuilder<User?>(
+            stream: FirebaseAuth.instance.authStateChanges(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (snapshot.hasData) {
+                return const PlayScreen();
+              }
+              return const LoginScreen();
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -14,6 +14,7 @@ import 'training_history_screen.dart';
 import 'exam_history_screen.dart';
 import 'leaderboard_screen.dart';
 import 'design_settings_screen.dart';
+import 'theme_picker_screen.dart';
 import 'competition_screen.dart';
 import 'login_screen.dart';
 
@@ -64,6 +65,13 @@ class _PlayScreenState extends State<PlayScreen> {
                 tooltip: 'Classement',
                 onPressed: () {
                   Navigator.push(context, MaterialPageRoute(builder: (_) => const LeaderboardScreen()));
+                },
+              ),
+              IconButton(
+                icon: const Icon(Icons.color_lens_outlined),
+                tooltip: 'Choisir un thème',
+                onPressed: () {
+                  Navigator.push(context, MaterialPageRoute(builder: (_) => const ThemePickerScreen()));
                 },
               ),
               IconButton(

--- a/lib/screens/theme_picker_screen.dart
+++ b/lib/screens/theme_picker_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
+import '../services/design_prefs.dart';
+import '../utils/palette_utils.dart';
+
+class ThemePickerScreen extends StatefulWidget {
+  const ThemePickerScreen({super.key});
+
+  @override
+  State<ThemePickerScreen> createState() => _ThemePickerScreenState();
+}
+
+class _ThemePickerScreenState extends State<ThemePickerScreen> {
+  DesignConfig _cfg = const DesignConfig();
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final c = await DesignPrefs.load();
+    if (!mounted) return;
+    setState(() => _cfg = c);
+  }
+
+  Future<void> _apply(String name) async {
+    final c = _cfg.copyWith(bgPaletteName: name);
+    setState(() => _cfg = c);
+    DesignBus.push(c);
+    await DesignPrefs.save(c);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final palettes = ['red','orange','yellow','green','blue','indigo','violet'];
+    return Scaffold(
+      appBar: AppBar(title: const Text('Choisir un thème')),
+      body: Center(
+        child: Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: palettes.map((p) => _paletteChip(p)).toList(),
+        ),
+      ),
+    );
+  }
+
+  Widget _paletteChip(String name) {
+    final colors = pastelPaletteFromName(name, brightness: Theme.of(context).brightness);
+    final vivid = vividColorForPalette(name);
+    final selected = _cfg.bgPaletteName == name;
+    return GestureDetector(
+      onTap: () => _apply(name),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(colors: colors),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: selected ? vivid : Colors.transparent, width: 2),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.palette, color: vivid),
+            const SizedBox(width: 6),
+            Text(name, style: TextStyle(color: vivid)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -38,3 +38,43 @@ Color textColorForPalette(String name) {
   final brightness = ThemeData.estimateBrightnessForColor(avg);
   return brightness == Brightness.dark ? Colors.white : Colors.black;
 }
+
+/// Returns a saturated "vivid" color for the palette.
+Color vividColorForPalette(String name) {
+  return paletteFromName(name).first;
+}
+
+/// Computes a pastel variant of [color] depending on [brightness]. The pastel
+/// is simply the same hue with a much higher lightness in light mode and a
+/// lower one in dark mode.
+Color _pastelize(Color color, Brightness brightness) {
+  final hsl = HSLColor.fromColor(color);
+  final lightness = brightness == Brightness.dark ? 0.20 : 0.85;
+  return hsl.withLightness(lightness).toColor();
+}
+
+/// Returns a list of pastel colors for the palette, to be used for backgrounds
+/// and gradients.
+List<Color> pastelPaletteFromName(String name, {Brightness brightness = Brightness.light}) {
+  final base = paletteFromName(name);
+  return base.map((c) => _pastelize(c, brightness)).toList();
+}
+
+/// Returns the pastel color associated with [name].
+Color pastelColorForPalette(String name, {Brightness brightness = Brightness.light}) {
+  return pastelPaletteFromName(name, brightness: brightness).last;
+}
+
+/// Computes a complementary color for the given [color].
+Color complementaryOf(Color color) {
+  final hsl = HSLColor.fromColor(color);
+  return hsl.withHue((hsl.hue + 180.0) % 360.0).toColor();
+}
+
+/// Chooses an appropriate text color (black or white) that contrasts with the
+/// [background] color.
+Color contrastingText(Color background) {
+  return ThemeData.estimateBrightnessForColor(background) == Brightness.dark
+      ? Colors.white
+      : Colors.black;
+}

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -15,9 +15,8 @@ class DesignBackground extends StatelessWidget {
     return ValueListenableBuilder<DesignConfig>(
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
-        final baseColors = paletteFromName(cfg.bgPaletteName);
-        final textColor = textColorForPalette(cfg.bgPaletteName);
-        final buttonFg = textColor == Colors.white ? Colors.black : Colors.white;
+        final brightness = Theme.of(context).brightness;
+        final baseColors = pastelPaletteFromName(cfg.bgPaletteName, brightness: brightness);
 
         return DecoratedBox(
           decoration: BoxDecoration(
@@ -30,37 +29,27 @@ class DesignBackground extends StatelessWidget {
                 : null,
             color: cfg.bgGradient ? null : baseColors.first,
           ),
-          child: Theme(
-            data: Theme.of(context).copyWith(
-              elevatedButtonTheme: ElevatedButtonThemeData(
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: textColor,
-                  foregroundColor: buttonFg,
-                ),
-              ),
-            ),
-            child: Stack(
-              children: [
-                if (cfg.waveEnabled)
-                  Positioned.fill(
-                    child: IgnorePointer(
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          gradient: RadialGradient(
-                            center: const Alignment(0.0, -0.6),
-                            radius: 1.0,
-                            colors: [
-                              Colors.white.withOpacity(0.08),
-                              Colors.transparent,
-                            ],
-                          ),
+          child: Stack(
+            children: [
+              if (cfg.waveEnabled)
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        gradient: RadialGradient(
+                          center: const Alignment(0.0, -0.6),
+                          radius: 1.0,
+                          colors: [
+                            Colors.white.withOpacity(0.08),
+                            Colors.transparent,
+                          ],
                         ),
                       ),
                     ),
                   ),
-                child,
-              ],
-            ),
+                ),
+              child,
+            ],
           ),
         );
       },


### PR DESCRIPTION
## Summary
- add rainbow palette utilities to derive pastel, vivid and complementary colors
- apply selected theme across app with light/dark support and complementary buttons
- add "Choisir un thème" screen and entry point from play screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b012daf08883239dbc9d5f43d3f679