### PR TITLE
Fix missing kPrimaryBlue constant in exam screen

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -159,7 +159,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 CircleAvatar(
-                  backgroundColor: kPrimaryBlue,
+                  backgroundColor: Theme.of(context).colorScheme.primary,
                   foregroundColor: Colors.white,
                   child: Text('${i + 1}'),
                 ),


### PR DESCRIPTION
## Summary
- Use theme primary color instead of undefined kPrimaryBlue for question number avatar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b014fdc0648323b92a84094172a075