### PR TITLE
feat: expand design palettes and smart mono mode

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -46,7 +46,7 @@ ThemeData buildAppTheme(DesignConfig cfg) {
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        shape: const RoundedRectangleBorder(borderRadius: BorderRadius.zero),
         backgroundColor: complement,
         foregroundColor: onColor(complement),
       ),

--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -30,7 +30,7 @@ class DesignConfig {
 
   const DesignConfig({
     // Thème fond
-    this.bgPaletteName = 'blue',
+    this.bgPaletteName = 'offWhite',
     this.waveEnabled = true,
     this.bgGradient = true,
     this.darkMode = false,
@@ -103,7 +103,7 @@ class DesignConfig {
     final double tileSize = (map['tileIconSize'] ?? svgSize).toDouble();
 
     return DesignConfig(
-      bgPaletteName: map['bgPaletteName'] ?? 'blue',
+      bgPaletteName: map['bgPaletteName'] ?? 'offWhite',
       waveEnabled: (map['waveEnabled'] ?? true) as bool,
       bgGradient: (map['bgGradient'] ?? true) as bool,
       glassBlur: (map['glassBlur'] ?? 18.0).toDouble(),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -48,13 +48,19 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
             spacing: 8,
             runSpacing: 8,
             children: [
-              _paletteChip('red', _cfg.bgPaletteName == 'red'),
-              _paletteChip('orange', _cfg.bgPaletteName == 'orange'),
-              _paletteChip('yellow', _cfg.bgPaletteName == 'yellow'),
-              _paletteChip('green', _cfg.bgPaletteName == 'green'),
-              _paletteChip('blue', _cfg.bgPaletteName == 'blue'),
-              _paletteChip('indigo', _cfg.bgPaletteName == 'indigo'),
-              _paletteChip('violet', _cfg.bgPaletteName == 'violet'),
+              _paletteChip('offWhite', _cfg.bgPaletteName == 'offWhite'),
+              _paletteChip('lightGrey', _cfg.bgPaletteName == 'lightGrey'),
+              _paletteChip('darkGrey', _cfg.bgPaletteName == 'darkGrey'),
+              _paletteChip('pastelBlue', _cfg.bgPaletteName == 'pastelBlue'),
+              _paletteChip('powderPink', _cfg.bgPaletteName == 'powderPink'),
+              _paletteChip('lightGreen', _cfg.bgPaletteName == 'lightGreen'),
+              _paletteChip('softYellow', _cfg.bgPaletteName == 'softYellow'),
+              _paletteChip('midnightBlue', _cfg.bgPaletteName == 'midnightBlue'),
+              _paletteChip('anthracite', _cfg.bgPaletteName == 'anthracite'),
+              _paletteChip('blueIndigo', _cfg.bgPaletteName == 'blueIndigo'),
+              _paletteChip('violetRose', _cfg.bgPaletteName == 'violetRose'),
+              _paletteChip('mintTurquoise', _cfg.bgPaletteName == 'mintTurquoise'),
+              _paletteChip('deepBlack', _cfg.bgPaletteName == 'deepBlack'),
             ],
           ),
           const SizedBox(height: 16),
@@ -74,16 +80,15 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
           SwitchListTile(
             title: const Text('Icônes monochromes'),
             value: _cfg.useMono,
-            onChanged: (v) => _apply(_cfg.copyWith(useMono: v)),
-          ),
-          if (_cfg.useMono)
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              children: _iconColorsForPalette(_cfg.bgPaletteName)
-                  .map((c) => _colorChip(c, _cfg.monoColor == c))
-                  .toList(),
+            onChanged: (v) => _apply(
+              _cfg.copyWith(
+                useMono: v,
+                monoColor: v
+                    ? complementaryColor(_cfg.bgPaletteName)
+                    : _cfg.monoColor,
+              ),
             ),
+          ),
           const Divider(height: 32),
 
           const Text('Verre (glassmorphism)', style: TextStyle(fontWeight: FontWeight.bold)),
@@ -140,7 +145,15 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
       color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(20),
-        onTap: () => _apply(_cfg.copyWith(bgPaletteName: name)),
+        onTap: () {
+          final updated = _cfg.useMono
+              ? _cfg.copyWith(
+                  bgPaletteName: name,
+                  monoColor: complementaryColor(name),
+                )
+              : _cfg.copyWith(bgPaletteName: name);
+          _apply(updated);
+        },
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           decoration: BoxDecoration(
@@ -158,22 +171,6 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
           child: Text(name, style: TextStyle(color: textColor)),
         ),
       ),
-    );
-  }
-
-  List<Color> _iconColorsForPalette(String name) {
-    return [accentColor(name), complementaryColor(name)];
-  }
-
-  Widget _colorChip(Color color, bool selected) {
-    final brightness = ThemeData.estimateBrightnessForColor(color);
-    return ChoiceChip(
-      label: const SizedBox(width: 24, height: 24),
-      selected: selected,
-      selectedColor: color,
-      backgroundColor: color,
-      checkmarkColor: brightness == Brightness.dark ? Colors.white : Colors.black,
-      onSelected: (_) => _apply(_cfg.copyWith(monoColor: color)),
     );
   }
 

--- a/lib/screens/theme_selection_screen.dart
+++ b/lib/screens/theme_selection_screen.dart
@@ -37,7 +37,13 @@ class _ThemeSelectionScreenState extends State<ThemeSelectionScreen> {
   }
 
   Future<void> _select(String name) async {
-    await _apply(_cfg.copyWith(bgPaletteName: name));
+    final updated = _cfg.useMono
+        ? _cfg.copyWith(
+            bgPaletteName: name,
+            monoColor: complementaryColor(name),
+          )
+        : _cfg.copyWith(bgPaletteName: name);
+    await _apply(updated);
   }
 
   @override
@@ -51,8 +57,21 @@ class _ThemeSelectionScreenState extends State<ThemeSelectionScreen> {
             spacing: 8,
             runSpacing: 8,
             children: [
-              for (final name in
-                  ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'])
+              for (final name in [
+                'offWhite',
+                'lightGrey',
+                'darkGrey',
+                'pastelBlue',
+                'powderPink',
+                'lightGreen',
+                'softYellow',
+                'midnightBlue',
+                'anthracite',
+                'blueIndigo',
+                'violetRose',
+                'mintTurquoise',
+                'deepBlack',
+              ])
                 _paletteChip(name, _cfg.bgPaletteName == name),
             ],
           ),

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -3,34 +3,75 @@ import 'package:flutter/material.dart';
 /// Utilities for design palettes and contrast helpers
 Color accentColor(String name) {
   switch (name) {
-    case 'red':
-      return const Color(0xFFE53935);
-    case 'orange':
-      return const Color(0xFFFB8C00);
-    case 'yellow':
-      return const Color(0xFFFDD835);
-    case 'green':
-      return const Color(0xFF43A047);
-    case 'blue':
-      return const Color(0xFF1E88E5);
-    case 'indigo':
-      return const Color(0xFF3949AB);
-    case 'violet':
-      return const Color(0xFF8E24AA);
+    case 'offWhite':
+      return const Color(0xFFF5F5F5);
+    case 'lightGrey':
+      return const Color(0xFFEAEAEA);
+    case 'darkGrey':
+      return const Color(0xFF2C2C2C);
+    case 'pastelBlue':
+      return const Color(0xFFA8DADC);
+    case 'powderPink':
+      return const Color(0xFFF7CAD0);
+    case 'lightGreen':
+      return const Color(0xFFB7E4C7);
+    case 'softYellow':
+      return const Color(0xFFFFE66D);
+    case 'midnightBlue':
+      return const Color(0xFF1E1E2F);
+    case 'anthracite':
+      return const Color(0xFF2B2B2B);
+    case 'blueIndigo':
+      return const Color(0xFF2193B0);
+    case 'violetRose':
+      return const Color(0xFF7F00FF);
+    case 'mintTurquoise':
+      return const Color(0xFF43CEA2);
+    case 'deepBlack':
+      return const Color(0xFF121212);
     default:
-      return const Color(0xFF1E88E5);
+      return const Color(0xFFF5F5F5);
   }
 }
 
 /// Returns two pastel variants of the accent color for gradient backgrounds.
 List<Color> pastelColors(String name, {bool darkMode = false}) {
-  final accent = accentColor(name);
-  final hsl = HSLColor.fromColor(accent);
-  final light1 = darkMode ? 0.25 : 0.85;
-  final light2 = darkMode ? 0.35 : 0.95;
-  final c1 = hsl.withLightness(light1).toColor();
-  final c2 = hsl.withLightness(light2).toColor();
-  return [c1, c2];
+  switch (name) {
+    case 'offWhite':
+      return const [Color(0xFFF5F5F5), Color(0xFFF5F5F5)];
+    case 'lightGrey':
+      return const [Color(0xFFEAEAEA), Color(0xFFEAEAEA)];
+    case 'darkGrey':
+      return const [Color(0xFF2C2C2C), Color(0xFF2C2C2C)];
+    case 'pastelBlue':
+      return const [Color(0xFFA8DADC), Color(0xFFA8DADC)];
+    case 'powderPink':
+      return const [Color(0xFFF7CAD0), Color(0xFFF7CAD0)];
+    case 'lightGreen':
+      return const [Color(0xFFB7E4C7), Color(0xFFB7E4C7)];
+    case 'softYellow':
+      return const [Color(0xFFFFE66D), Color(0xFFFFE66D)];
+    case 'midnightBlue':
+      return const [Color(0xFF1E1E2F), Color(0xFF1E1E2F)];
+    case 'anthracite':
+      return const [Color(0xFF2B2B2B), Color(0xFF2B2B2B)];
+    case 'blueIndigo':
+      return const [Color(0xFF2193B0), Color(0xFF6DD5ED)];
+    case 'violetRose':
+      return const [Color(0xFF7F00FF), Color(0xFFE100FF)];
+    case 'mintTurquoise':
+      return const [Color(0xFF43CEA2), Color(0xFF185A9D)];
+    case 'deepBlack':
+      return const [Color(0xFF121212), Color(0xFF121212)];
+    default:
+      final accent = accentColor(name);
+      final hsl = HSLColor.fromColor(accent);
+      final light1 = darkMode ? 0.25 : 0.85;
+      final light2 = darkMode ? 0.35 : 0.95;
+      final c1 = hsl.withLightness(light1).toColor();
+      final c2 = hsl.withLightness(light2).toColor();
+      return [c1, c2];
+  }
 }
 
 /// Complementary color used for buttons to stand out from the background.


### PR DESCRIPTION
## Summary
- add new solid and gradient design palettes
- introduce smart monochrome icons based on background
- square default buttons for improved contrast

## Testing
- `dart format lib/app/theme.dart lib/models/design_config.dart lib/screens/design_settings_screen.dart lib/screens/theme_selection_screen.dart lib/utils/palette_utils.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d6abbdc8323af13ec89658c83fe