### PR TITLE
Auto adjust theme based on background palette

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -7,6 +7,9 @@ ThemeData buildAppTheme(DesignConfig cfg) {
   final accent = accentColor(cfg.bgPaletteName);
   final complement = complementaryColor(cfg.bgPaletteName);
   final brightness = cfg.darkMode ? Brightness.dark : Brightness.light;
+  final iconClr = cfg.useMono ? cfg.monoColor : accent;
+  final foreground =
+      textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
 
   final base = ThemeData(
     colorScheme: ColorScheme.fromSeed(
@@ -28,10 +31,11 @@ ThemeData buildAppTheme(DesignConfig cfg) {
 
   return base.copyWith(
     textTheme: textTheme,
-    iconTheme: IconThemeData(color: accent),
+    iconTheme: IconThemeData(color: iconClr),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
-      foregroundColor: accent,
+      foregroundColor: foreground,
+      iconTheme: IconThemeData(color: iconClr),
       elevation: 0,
       centerTitle: true,
     ),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -139,8 +139,9 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   }
 
   Widget _paletteChip(String name, bool selected) {
-    final colors = pastelColors(name, darkMode: _cfg.darkMode);
-    final textColor = textColorForPalette(name, darkMode: _cfg.darkMode);
+    final dark = paletteIsDark(name);
+    final colors = pastelColors(name, darkMode: dark);
+    final textColor = textColorForPalette(name, darkMode: dark);
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -150,8 +151,9 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
               ? _cfg.copyWith(
                   bgPaletteName: name,
                   monoColor: complementaryColor(name),
+                  darkMode: dark,
                 )
-              : _cfg.copyWith(bgPaletteName: name);
+              : _cfg.copyWith(bgPaletteName: name, darkMode: dark);
           _apply(updated);
         },
         child: Container(

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -95,6 +95,12 @@ Color textColorForPalette(String name, {bool darkMode = false}) {
   return brightness == Brightness.dark ? Colors.white : Colors.black;
 }
 
+/// Returns true if the palette's averaged color is dark enough to require
+/// light foreground content.
+bool paletteIsDark(String name) {
+  return textColorForPalette(name) == Colors.white;
+}
+
 /// Helper to get readable text color on top of any solid [color].
 Color onColor(Color color) =>
     ThemeData.estimateBrightnessForColor(color) == Brightness.dark


### PR DESCRIPTION
## Summary
- Detect palette brightness and update dark mode automatically
- Tint icons with mono color when monochrome mode enabled
- Use palette brightness to color app bar text and icons for contrast

## Testing
- `dart format lib/app/theme.dart lib/screens/design_settings_screen.dart lib/utils/palette_utils.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01fe080508323927ea9a1cba86e15