### PR TITLE
feat: adapt theme colors to palette

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -7,6 +7,9 @@ ThemeData buildAppTheme(DesignConfig cfg) {
   final accent = accentColor(cfg.bgPaletteName);
   final complement = complementaryColor(cfg.bgPaletteName);
   final brightness = cfg.darkMode ? Brightness.dark : Brightness.light;
+  final textColor =
+      textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
+  final iconColor = cfg.useMono ? cfg.monoColor : textColor;
 
   final base = ThemeData(
     colorScheme: ColorScheme.fromSeed(
@@ -17,21 +20,29 @@ ThemeData buildAppTheme(DesignConfig cfg) {
     scaffoldBackgroundColor: Colors.transparent,
   );
 
-  final textTheme = base.textTheme.copyWith(
-    headlineLarge: base.textTheme.headlineLarge?.copyWith(fontWeight: FontWeight.w700),
-    headlineMedium: base.textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.w700),
-    headlineSmall: base.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
-    titleLarge: base.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
-    bodyLarge: base.textTheme.bodyLarge?.copyWith(height: 1.3),
-    bodyMedium: base.textTheme.bodyMedium?.copyWith(height: 1.3),
-  );
+  final textTheme = base.textTheme
+      .copyWith(
+        headlineLarge:
+            base.textTheme.headlineLarge?.copyWith(fontWeight: FontWeight.w700),
+        headlineMedium:
+            base.textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.w700),
+        headlineSmall:
+            base.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
+        titleLarge:
+            base.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+        bodyLarge: base.textTheme.bodyLarge?.copyWith(height: 1.3),
+        bodyMedium: base.textTheme.bodyMedium?.copyWith(height: 1.3),
+      )
+      .apply(bodyColor: textColor, displayColor: textColor);
 
   return base.copyWith(
     textTheme: textTheme,
-    iconTheme: IconThemeData(color: accent),
+    iconTheme: IconThemeData(color: iconColor),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
-      foregroundColor: accent,
+      foregroundColor: textColor,
+      iconTheme: IconThemeData(color: iconColor),
+      actionsIconTheme: IconThemeData(color: iconColor),
       elevation: 0,
       centerTitle: true,
     ),


### PR DESCRIPTION
## Summary
- derive text and icon colors from chosen palette and mode
- tint icons with complementary color in monochrome mode
- apply palette-aware colors to app bar and text theme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01fe080508323927ea9a1cba86e15