### PR TITLE
feat: apply global design theme to screens

### DIFF
--- a/lib/screens/exam_history_screen.dart
+++ b/lib/screens/exam_history_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/exam_history_entry.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
 import '../services/history_store.dart';
 
 class ExamHistoryScreen extends StatefulWidget {
@@ -50,81 +52,103 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Historique des examens'),
-        actions: [
-          if (_items.isNotEmpty)
-            IconButton(
-              onPressed: _clearAll,
-              icon: const Icon(Icons.delete_forever),
-              tooltip: 'Effacer l’historique',
-            )
-        ],
-      ),
-      body: _items.isEmpty
-          ? const Center(child: Text('Aucun examen enregistré pour le moment.'))
-          : ListView.builder(
-              itemCount: _items.length,
-              itemBuilder: (context, i) {
-                final e = _items[i];
-                final weak = e.weakSubjects();
-                Color chipBg;
-                String chipText;
-                if (e.abandoned) {
-                  chipBg = Colors.orange.shade200;
-                  chipText = 'Abandonné';
-                } else if (e.success) {
-                  chipBg = Colors.green.shade200;
-                  chipText = 'Réussi';
-                } else {
-                  chipBg = Colors.red.shade200;
-                  chipText = 'Échoué';
-                }
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final cs = Theme.of(context).colorScheme;
+        return Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar: AppBar(
+            title: const Text('Historique des examens'),
+            actions: [
+              if (_items.isNotEmpty)
+                IconButton(
+                  onPressed: _clearAll,
+                  icon: const Icon(Icons.delete_forever),
+                  tooltip: 'Effacer l’historique',
+                )
+            ],
+          ),
+          body: _items.isEmpty
+              ? const Center(
+                  child: Text('Aucun examen enregistré pour le moment.'))
+              : ListView.builder(
+                  itemCount: _items.length,
+                  itemBuilder: (context, i) {
+                    final e = _items[i];
+                    final weak = e.weakSubjects();
+                    Color chipBg;
+                    String chipText;
+                    if (e.abandoned) {
+                      chipBg = cs.tertiaryContainer;
+                      chipText = 'Abandonné';
+                    } else if (e.success) {
+                      chipBg = cs.primaryContainer;
+                      chipText = 'Réussi';
+                    } else {
+                      chipBg = cs.errorContainer;
+                      chipText = 'Échoué';
+                    }
 
-                return Card(
-                  margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                  child: Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
+                    return Card(
+                      margin: const EdgeInsets.symmetric(
+                          horizontal: 12, vertical: 6),
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Expanded(child: Text('Examen du ${_fmt(e.date)}', style: const TextStyle(fontWeight: FontWeight.w700))),
-                            Chip(label: Text(chipText), backgroundColor: chipBg),
+                            Row(
+                              children: [
+                                Expanded(
+                                    child: Text('Examen du ${_fmt(e.date)}',
+                                        style: const TextStyle(
+                                            fontWeight: FontWeight.w700))),
+                                Chip(
+                                    label: Text(chipText),
+                                    backgroundColor: chipBg),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+                            Text('Total pondéré : ${e.totalPondere}',
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.w600)),
+                            const Divider(height: 16),
+                            const Text('Détails par matière :',
+                                style: TextStyle(fontWeight: FontWeight.w600)),
+                            const SizedBox(height: 4),
+                            for (final s in e.scoresBruts.keys) ...[
+                              Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Expanded(child: Text(s)),
+                                  Text(
+                                      'Brut ${e.scoresBruts[s]} • Pondéré ${e.scoresPonderes[s]}'),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                      '(${e.correctBySubject[s]}/${e.totalBySubject[s]})'),
+                                ],
+                              ),
+                              const SizedBox(height: 4),
+                            ],
+                            if (weak.isNotEmpty) ...[
+                              const Divider(height: 16),
+                              Text(
+                                'À renforcer : ${weak.join(', ')}',
+                                style: TextStyle(
+                                    color: cs.tertiary,
+                                    fontWeight: FontWeight.w600),
+                              ),
+                            ],
                           ],
                         ),
-                        const SizedBox(height: 6),
-                        Text('Total pondéré : ${e.totalPondere}', style: const TextStyle(fontWeight: FontWeight.w600)),
-                        const Divider(height: 16),
-                        const Text('Détails par matière :', style: TextStyle(fontWeight: FontWeight.w600)),
-                        const SizedBox(height: 4),
-                        for (final s in e.scoresBruts.keys) ...[
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Expanded(child: Text(s)),
-                              Text('Brut ${e.scoresBruts[s]} • Pondéré ${e.scoresPonderes[s]}'),
-                              const SizedBox(width: 8),
-                              Text('(${e.correctBySubject[s]}/${e.totalBySubject[s]})'),
-                            ],
-                          ),
-                          const SizedBox(height: 4),
-                        ],
-                        if (weak.isNotEmpty) ...[
-                          const Divider(height: 16),
-                          Text(
-                            'À renforcer : ${weak.join(', ')}',
-                            style: TextStyle(color: Colors.orange.shade700, fontWeight: FontWeight.w600),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                );
-              },
-            ),
+                      ),
+                    );
+                  },
+                ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/exam_screen.dart
+++ b/lib/screens/exam_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import '../models/question.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
 import 'result_screen.dart';
 import '../services/history_service.dart';
 
@@ -91,62 +93,79 @@ class _ExamScreenState extends State<ExamScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final q = widget.questions[index];
-    return WillPopScope(
-      onWillPop: () async => false,
-      child: Scaffold(
-        appBar: AppBar(
-          title: Text('Examen ${index + 1}/${widget.questions.length}'),
-          actions: [
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              child: Chip(
-                label: Text(_formatTime(remaining), style: const TextStyle(fontWeight: FontWeight.bold)),
-                backgroundColor: Colors.redAccent.shade100,
-              ),
-            )
-          ],
-        ),
-        body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Text(q.question, style: Theme.of(context).textTheme.titleLarge),
-                const SizedBox(height: 16),
-                Expanded(
-                  child: ListView.separated(
-                    itemCount: q.choices.length,
-                    separatorBuilder: (_, __) => const SizedBox(height: 8),
-                    itemBuilder: (_, i) {
-                      final isSelected = selected == i;
-                      return InkWell(
-                        onTap: () => _select(i),
-                        child: Container(
-                          padding: const EdgeInsets.all(12),
-                          decoration: BoxDecoration(
-                            color: isSelected ? Colors.blue.shade100 : Colors.grey.shade200,
-                            borderRadius: BorderRadius.circular(12),
-                            border: Border.all(color: Colors.grey.shade300),
-                          ),
-                          child: Text(q.choices[i]),
-                        ),
-                      );
-                    },
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final q = widget.questions[index];
+        final cs = Theme.of(context).colorScheme;
+        return WillPopScope(
+          onWillPop: () async => false,
+          child: Scaffold(
+            backgroundColor: Colors.transparent,
+            appBar: AppBar(
+              title: Text('Examen ${index + 1}/${widget.questions.length}'),
+              actions: [
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  child: Chip(
+                    label: Text(_formatTime(remaining),
+                        style: const TextStyle(fontWeight: FontWeight.bold)),
+                    backgroundColor: cs.errorContainer,
                   ),
-                ),
-                const SizedBox(height: 12),
-                ElevatedButton.icon(
-                  onPressed: _next,
-                  icon: Icon(index < widget.questions.length - 1 ? Icons.arrow_forward : Icons.flag),
-                  label: Text(index < widget.questions.length - 1 ? 'Suivant' : 'Terminer'),
                 )
               ],
             ),
+            body: SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(q.question,
+                        style: Theme.of(context).textTheme.titleLarge),
+                    const SizedBox(height: 16),
+                    Expanded(
+                      child: ListView.separated(
+                        itemCount: q.choices.length,
+                        separatorBuilder: (_, __) =>
+                            const SizedBox(height: 8),
+                        itemBuilder: (_, i) {
+                          final isSelected = selected == i;
+                          return InkWell(
+                            onTap: () => _select(i),
+                            child: Container(
+                              padding: const EdgeInsets.all(12),
+                              decoration: BoxDecoration(
+                                color: isSelected
+                                    ? cs.primaryContainer
+                                    : cs.surfaceVariant,
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(color: cs.outline),
+                              ),
+                              child: Text(q.choices[i]),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    ElevatedButton.icon(
+                      onPressed: _next,
+                      icon: Icon(index < widget.questions.length - 1
+                          ? Icons.arrow_forward
+                          : Icons.flag),
+                      label: Text(index < widget.questions.length - 1
+                          ? 'Suivant'
+                          : 'Terminer'),
+                    )
+                  ],
+                ),
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../services/auth_service.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
 import 'play_screen.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -30,62 +32,77 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              TextFormField(
-                controller: _emailController,
-                decoration: const InputDecoration(labelText: 'Email'),
-                validator: (value) =>
-                    value == null || value.trim().isEmpty ? 'Email requis' : null,
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final errorStyle = TextStyle(color: Theme.of(context).colorScheme.error);
+        return Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar:
+              AppBar(title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextFormField(
+                    controller: _emailController,
+                    decoration: const InputDecoration(labelText: 'Email'),
+                    validator: (value) => value == null ||
+                            value.trim().isEmpty
+                        ? 'Email requis'
+                        : null,
+                  ),
+                  if (!_isLogin)
+                    TextFormField(
+                      controller: _nameController,
+                      decoration: const InputDecoration(labelText: 'Nom'),
+                      validator: (value) {
+                        if (!_isLogin &&
+                            (value == null || value.trim().isEmpty)) {
+                          return 'Nom requis';
+                        }
+                        return null;
+                      },
+                    ),
+                  TextFormField(
+                    controller: _passwordController,
+                    decoration:
+                        const InputDecoration(labelText: 'Mot de passe'),
+                    obscureText: true,
+                    validator: (value) => value == null ||
+                            value.trim().isEmpty
+                        ? 'Mot de passe requis'
+                        : null,
+                  ),
+                  const SizedBox(height: 12),
+                  if (_error != null)
+                    Text(_error!, style: errorStyle),
+                  const SizedBox(height: 12),
+                  ElevatedButton(
+                    onPressed: _isLoading ? null : _submit,
+                    child: _isLoading
+                        ? const SizedBox(
+                            width: 24,
+                            height: 24,
+                            child:
+                                CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Text(_isLogin ? 'Connexion' : 'Inscription'),
+                  ),
+                  TextButton(
+                    onPressed: () => setState(() => _isLogin = !_isLogin),
+                    child: Text(
+                        _isLogin ? "Créer un compte" : 'Déjà inscrit ?'),
+                  )
+                ],
               ),
-              if (!_isLogin)
-                TextFormField(
-                  controller: _nameController,
-                  decoration: const InputDecoration(labelText: 'Nom'),
-                  validator: (value) {
-                    if (!_isLogin && (value == null || value.trim().isEmpty)) {
-                      return 'Nom requis';
-                    }
-                    return null;
-                  },
-                ),
-              TextFormField(
-                controller: _passwordController,
-                decoration: const InputDecoration(labelText: 'Mot de passe'),
-                obscureText: true,
-                validator: (value) => value == null || value.trim().isEmpty
-                    ? 'Mot de passe requis'
-                    : null,
-              ),
-              const SizedBox(height: 12),
-              if (_error != null)
-                Text(_error!, style: const TextStyle(color: Colors.red)),
-              const SizedBox(height: 12),
-              ElevatedButton(
-                onPressed: _isLoading ? null : _submit,
-                child: _isLoading
-                    ? const SizedBox(
-                        width: 24,
-                        height: 24,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : Text(_isLogin ? 'Connexion' : 'Inscription'),
-              ),
-              TextButton(
-                onPressed: () => setState(() => _isLogin = !_isLogin),
-                child: Text(_isLogin ? "Créer un compte" : 'Déjà inscrit ?'),
-              )
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 

--- a/lib/screens/official_intro_screen.dart
+++ b/lib/screens/official_intro_screen.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import '../services/scoring.dart';
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
 import 'multi_exam_flow.dart';
 
 class OfficialIntroScreen extends StatefulWidget {
@@ -44,92 +46,114 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Concours officiel — Consignes')),
-      body: Stack(
-        children: [
-          ListView(
-            padding: const EdgeInsets.all(16),
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final overlayTextColor = Theme.of(context).colorScheme.onSurface;
+        return Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar:
+              AppBar(title: const Text('Concours officiel — Consignes')),
+          body: Stack(
             children: [
-              const Text(
-                'Simulation du concours ENA (pré‑sélection)',
-                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
-              ),
-              const SizedBox(height: 8),
-              const Text(
-                'Vous allez enchaîner 4 épreuves :\n'
-                '1) Culture Générale (Côte d’Ivoire)\n'
-                '2) Aptitude Verbale (Vocabulaire & règles)\n'
-                '3) Organisation & Logique (Classements & déductions)\n'
-                '4) Aptitude Numérique (Bases & proportionnalité)\n',
-              ),
-              const SizedBox(height: 12),
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: const [
-                      Text('Durée & barème', style: TextStyle(fontWeight: FontWeight.w600)),
-                      SizedBox(height: 6),
-                      Text('• Durée : 60 minutes par épreuve (total ~4h).'),
-                      Text('• Barème : +1 bonne, 0 blanc, −1 mauvaise (barème négatif).'),
-                      Text('• Coefficient : ×2 par épreuve (pondération finale).'),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 8),
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: const [
-                      Text('Règles', style: TextStyle(fontWeight: FontWeight.w600)),
-                      SizedBox(height: 6),
-                      Text('• Une fois le chrono lancé, vous ne pouvez pas revenir en arrière.'),
-                      Text('• À la fin du temps, l’épreuve est automatiquement soumise.'),
-                      Text('• Évitez de quitter l’app pendant une épreuve.'),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(height: 8),
-              Row(
+              ListView(
+                padding: const EdgeInsets.all(16),
                 children: [
-                  Checkbox(
-                    value: _accepted,
-                    onChanged: (v) => setState(() => _accepted = v ?? false),
+                  const Text(
+                    'Simulation du concours ENA (pré‑sélection)',
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
                   ),
-                  const Expanded(child: Text('Je comprends les règles et je suis prêt(e) à commencer.')),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'Vous allez enchaîner 4 épreuves :\n'
+                    '1) Culture Générale (Côte d’Ivoire)\n'
+                    '2) Aptitude Verbale (Vocabulaire & règles)\n'
+                    '3) Organisation & Logique (Classements & déductions)\n'
+                    '4) Aptitude Numérique (Bases & proportionnalité)\n',
+                  ),
+                  const SizedBox(height: 12),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: const [
+                          Text('Durée & barème',
+                              style: TextStyle(fontWeight: FontWeight.w600)),
+                          SizedBox(height: 6),
+                          Text('• Durée : 60 minutes par épreuve (total ~4h).'),
+                          Text(
+                              '• Barème : +1 bonne, 0 blanc, −1 mauvaise (barème négatif).'),
+                          Text(
+                              '• Coefficient : ×2 par épreuve (pondération finale).'),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: const [
+                          Text('Règles',
+                              style: TextStyle(fontWeight: FontWeight.w600)),
+                          SizedBox(height: 6),
+                          Text(
+                              '• Une fois le chrono lancé, vous ne pouvez pas revenir en arrière.'),
+                          Text(
+                              '• À la fin du temps, l’épreuve est automatiquement soumise.'),
+                          Text('• Évitez de quitter l’app pendant une épreuve.'),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Checkbox(
+                        value: _accepted,
+                        onChanged: (v) =>
+                            setState(() => _accepted = v ?? false),
+                      ),
+                      const Expanded(
+                          child: Text(
+                              'Je comprends les règles et je suis prêt(e) à commencer.')),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      onPressed:
+                          _accepted && !_starting ? _startCountdown : null,
+                      icon: const Icon(Icons.flag),
+                      label:
+                          const Text('Démarrer la simulation officielle'),
+                    ),
+                  ),
                 ],
               ),
-              const SizedBox(height: 12),
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton.icon(
-                  onPressed: _accepted && !_starting ? _startCountdown : null,
-                  icon: const Icon(Icons.flag),
-                  label: const Text('Démarrer la simulation officielle'),
-                ),
-              ),
-            ],
-          ),
-          if (_starting)
-            Positioned.fill(
-              child: Container(
-                color: Colors.black.withOpacity(0.6),
-                child: Center(
-                  child: Text(
-                    '$_count',
-                    style: const TextStyle(fontSize: 96, color: Colors.white, fontWeight: FontWeight.bold),
+              if (_starting)
+                Positioned.fill(
+                  child: Container(
+                    color: Colors.black.withOpacity(0.6),
+                    child: Center(
+                      child: Text(
+                        '$_count',
+                        style: TextStyle(
+                            fontSize: 96,
+                            color: overlayTextColor,
+                            fontWeight: FontWeight.bold),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ),
-        ],
-      ),
+            ],
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- integrate DesignBus ValueListenableBuilder across miscellaneous screens
- replace hard-coded colors with theme color scheme
- use transparent Scaffold backgrounds to expose DesignBackground

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0487463c48323b54a0c61b2321df3