### PR TITLE
Add tile tile size and center design preferences

### DIFF
--- a/lib/services/design_prefs.dart
+++ b/lib/services/design_prefs.dart
@@ -15,21 +15,26 @@ class DesignPrefs {
   static const _kBgPal   = 'design_bgPaletteName'; // NEW
   static const _kBgGrad  = 'design_bgGradient';
   static const _kDark    = 'design_darkMode';
+  static const _kTileSize = 'design_tileIconSize';
+  static const _kTileCtr  = 'design_tileCenter';
 
   static Future<DesignConfig> load() async {
     final p = await SharedPreferences.getInstance();
-    return DesignConfig(
-      useMono: p.getBool(_kUseMono) ?? const DesignConfig().useMono,
-      iconSetName: p.getString(_kIconSet) ?? const DesignConfig().iconSetName,
-      svgIconSize: p.getDouble(_kSvgSize) ?? const DesignConfig().svgIconSize,
-      monoColor: Color(p.getInt(_kMonoCol) ?? const DesignConfig().monoColor.value),
-      glassBlur: p.getDouble(_kBlur) ?? const DesignConfig().glassBlur,
-      glassBgOpacity: p.getDouble(_kBgOp) ?? const DesignConfig().glassBgOpacity,
-      glassBorderOpacity: p.getDouble(_kBdOp) ?? const DesignConfig().glassBorderOpacity,
-      waveEnabled: p.getBool(_kWave) ?? const DesignConfig().waveEnabled,
-      bgPaletteName: p.getString(_kBgPal) ?? const DesignConfig().bgPaletteName,
-      bgGradient: p.getBool(_kBgGrad) ?? const DesignConfig().bgGradient,
-      darkMode: p.getBool(_kDark) ?? const DesignConfig().darkMode,
+    const base = DesignConfig();
+    return base.copyWith(
+      useMono: p.getBool(_kUseMono) ?? base.useMono,
+      iconSetName: p.getString(_kIconSet) ?? base.iconSetName,
+      svgIconSize: p.getDouble(_kSvgSize) ?? base.svgIconSize,
+      monoColor: Color(p.getInt(_kMonoCol) ?? base.monoColor.value),
+      glassBlur: p.getDouble(_kBlur) ?? base.glassBlur,
+      glassBgOpacity: p.getDouble(_kBgOp) ?? base.glassBgOpacity,
+      glassBorderOpacity: p.getDouble(_kBdOp) ?? base.glassBorderOpacity,
+      waveEnabled: p.getBool(_kWave) ?? base.waveEnabled,
+      bgPaletteName: p.getString(_kBgPal) ?? base.bgPaletteName,
+      bgGradient: p.getBool(_kBgGrad) ?? base.bgGradient,
+      darkMode: p.getBool(_kDark) ?? base.darkMode,
+      tileIconSize: p.getDouble(_kTileSize) ?? base.tileIconSize,
+      tileCenter: p.getBool(_kTileCtr) ?? base.tileCenter,
     );
   }
 
@@ -46,5 +51,7 @@ class DesignPrefs {
     await p.setString(_kBgPal, cfg.bgPaletteName);
     await p.setBool(_kBgGrad, cfg.bgGradient);
     await p.setBool(_kDark, cfg.darkMode);
+    await p.setDouble(_kTileSize, cfg.tileIconSize);
+    await p.setBool(_kTileCtr, cfg.tileCenter);
   }
 }

--- a/test/design_prefs_test.dart
+++ b/test/design_prefs_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:civexam_app/services/design_prefs.dart';
+import 'package:civexam_app/models/design_config.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('load reads tile preferences', () async {
+    SharedPreferences.setMockInitialValues({
+      'design_tileIconSize': 80.0,
+      'design_tileCenter': false,
+    });
+
+    final cfg = await DesignPrefs.load();
+    expect(cfg.tileIconSize, 80.0);
+    expect(cfg.tileCenter, false);
+  });
+
+  test('save writes tile preferences', () async {
+    SharedPreferences.setMockInitialValues({});
+    const cfg = DesignConfig(tileIconSize: 90.0, tileCenter: false);
+
+    await DesignPrefs.save(cfg);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getDouble('design_tileIconSize'), 90.0);
+    expect(prefs.getBool('design_tileCenter'), false);
+  });
+}


### PR DESCRIPTION
## Summary
- persist new tile design settings: icon size and center flag
- test saving and loading of these preferences

## Testing
- `flutter test` *(fails: PlatformException channel-error; Expected: 'CG-INTRO-1', Actual: 'Q1'; Expected: throws <Exception> but got [Question])*

------
https://chatgpt.com/codex/tasks/task_e_68b04870951883238190d3199eb7a849