### PR TITLE
feat: add professional palettes and adaptive icon theme

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -7,6 +7,8 @@ ThemeData buildAppTheme(DesignConfig cfg) {
   final accent = accentColor(cfg.bgPaletteName);
   final complement = complementaryColor(cfg.bgPaletteName);
   final brightness = cfg.darkMode ? Brightness.dark : Brightness.light;
+  final textColor =
+      textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
 
   final base = ThemeData(
     colorScheme: ColorScheme.fromSeed(
@@ -17,21 +19,27 @@ ThemeData buildAppTheme(DesignConfig cfg) {
     scaffoldBackgroundColor: Colors.transparent,
   );
 
-  final textTheme = base.textTheme.copyWith(
-    headlineLarge: base.textTheme.headlineLarge?.copyWith(fontWeight: FontWeight.w700),
-    headlineMedium: base.textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.w700),
-    headlineSmall: base.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
-    titleLarge: base.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
-    bodyLarge: base.textTheme.bodyLarge?.copyWith(height: 1.3),
-    bodyMedium: base.textTheme.bodyMedium?.copyWith(height: 1.3),
-  );
+  final textTheme = base.textTheme
+      .apply(bodyColor: textColor, displayColor: textColor)
+      .copyWith(
+        headlineLarge:
+            base.textTheme.headlineLarge?.copyWith(fontWeight: FontWeight.w700),
+        headlineMedium:
+            base.textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.w700),
+        headlineSmall:
+            base.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
+        titleLarge:
+            base.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+        bodyLarge: base.textTheme.bodyLarge?.copyWith(height: 1.3),
+        bodyMedium: base.textTheme.bodyMedium?.copyWith(height: 1.3),
+      );
 
   return base.copyWith(
     textTheme: textTheme,
-    iconTheme: IconThemeData(color: accent),
+    iconTheme: IconThemeData(color: textColor, size: cfg.tileIconSize),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
-      foregroundColor: accent,
+      foregroundColor: textColor,
       elevation: 0,
       centerTitle: true,
     ),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -33,6 +33,10 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
     'violetRose',
     'mintTurquoise',
     'deepBlack',
+    'sereneBlue',
+    'forestGreen',
+    'deepIndigo',
+    'royalViolet',
   ];
 
   static const Map<String, String> _paletteLabels = {
@@ -48,6 +52,10 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
     'violetRose': 'Violet',
     'mintTurquoise': 'Turquoise',
     'deepBlack': 'Noir profond',
+    'sereneBlue': 'Bleu sérieux',
+    'forestGreen': 'Vert forêt',
+    'deepIndigo': 'Indigo profond',
+    'royalViolet': 'Violet royal',
   };
 
   @override

--- a/lib/screens/theme_selection_screen.dart
+++ b/lib/screens/theme_selection_screen.dart
@@ -71,6 +71,10 @@ class _ThemeSelectionScreenState extends State<ThemeSelectionScreen> {
                 'violetRose',
                 'mintTurquoise',
                 'deepBlack',
+                'sereneBlue',
+                'forestGreen',
+                'deepIndigo',
+                'royalViolet',
               ])
                 _paletteChip(name, _cfg.bgPaletteName == name),
             ],

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -29,6 +29,14 @@ Color accentColor(String name) {
       return const Color(0xFF43CEA2);
     case 'deepBlack':
       return const Color(0xFF121212);
+    case 'sereneBlue':
+      return const Color(0xFF1A73E8);
+    case 'forestGreen':
+      return const Color(0xFF2E7D32);
+    case 'deepIndigo':
+      return const Color(0xFF283593);
+    case 'royalViolet':
+      return const Color(0xFF6A1B9A);
     default:
       return const Color(0xFFF5F5F5);
   }
@@ -63,6 +71,14 @@ List<Color> pastelColors(String name, {bool darkMode = false}) {
       return const [Color(0xFF43CEA2), Color(0xFF185A9D)];
     case 'deepBlack':
       return const [Color(0xFF121212), Color(0xFF121212)];
+    case 'sereneBlue':
+      return const [Color(0xFF1A73E8), Color(0xFF64B5F6)];
+    case 'forestGreen':
+      return const [Color(0xFF2E7D32), Color(0xFF81C784)];
+    case 'deepIndigo':
+      return const [Color(0xFF283593), Color(0xFF5C6BC0)];
+    case 'royalViolet':
+      return const [Color(0xFF6A1B9A), Color(0xFFBA68C8)];
     default:
       final accent = accentColor(name);
       final hsl = HSLColor.fromColor(accent);


### PR DESCRIPTION
## Summary
- add sereneBlue, forestGreen, deepIndigo and royalViolet palettes with matching gradients
- derive text and icon colors from background for better contrast and scalable icons
- expose new palettes in design settings and theme selection screens

## Testing
- `dart format lib/utils/palette_utils.dart lib/app/theme.dart lib/screens/design_settings_screen.dart lib/screens/theme_selection_screen.dart` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b04c3d93448323b9fda1103aab65ee