### PR TITLE
feat: unify blue theme with scalable icons

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -6,6 +6,9 @@ import '../utils/palette_utils.dart';
 ThemeData buildAppTheme(DesignConfig cfg) {
   final accent = accentColor(cfg.bgPaletteName);
   final complement = complementaryColor(cfg.bgPaletteName);
+  final accentHsl = HSLColor.fromColor(accent);
+  final iconColor =
+      accentHsl.withLightness((accentHsl.lightness * 0.7).clamp(0.0, 1.0)).toColor();
   final brightness = cfg.darkMode ? Brightness.dark : Brightness.light;
   final textColor =
       textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
@@ -36,7 +39,7 @@ ThemeData buildAppTheme(DesignConfig cfg) {
 
   return base.copyWith(
     textTheme: textTheme,
-    iconTheme: IconThemeData(color: textColor, size: cfg.tileIconSize),
+    iconTheme: IconThemeData(color: iconColor, size: cfg.tileIconSize),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
       foregroundColor: textColor,

--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -30,7 +30,7 @@ class DesignConfig {
 
   const DesignConfig({
     // Thème fond
-    this.bgPaletteName = 'offWhite',
+    this.bgPaletteName = 'sereneBlue',
     this.waveEnabled = true,
     this.bgGradient = true,
     this.darkMode = false,

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -21,41 +21,19 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
 
   // Palettes proposées (tons épurés et contrastes soignés)
   static const List<String> _palettes = [
-    'offWhite',
-    'lightGrey',
     'pastelBlue',
-    'powderPink',
-    'lightGreen',
-    'softYellow',
     'midnightBlue',
-    'anthracite',
     'blueIndigo',
-    'violetRose',
-    'mintTurquoise',
-    'deepBlack',
     'sereneBlue',
-    'forestGreen',
     'deepIndigo',
-    'royalViolet',
   ];
 
   static const Map<String, String> _paletteLabels = {
-    'offWhite': 'Blanc cassé',
-    'lightGrey': 'Gris clair',
     'pastelBlue': 'Bleu pastel',
-    'powderPink': 'Rose poudré',
-    'lightGreen': 'Vert doux',
-    'softYellow': 'Jaune pâle',
     'midnightBlue': 'Bleu nuit',
-    'anthracite': 'Anthracite',
     'blueIndigo': 'Indigo',
-    'violetRose': 'Violet',
-    'mintTurquoise': 'Turquoise',
-    'deepBlack': 'Noir profond',
     'sereneBlue': 'Bleu sérieux',
-    'forestGreen': 'Vert forêt',
     'deepIndigo': 'Indigo profond',
-    'royalViolet': 'Violet royal',
   };
 
   @override
@@ -65,7 +43,11 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   }
 
   Future<void> _load() async {
-    final c = await DesignPrefs.load();
+    var c = await DesignPrefs.load();
+    if (!_palettes.contains(c.bgPaletteName)) {
+      c = c.copyWith(bgPaletteName: _palettes.first);
+      await DesignPrefs.save(c);
+    }
     if (!mounted) return;
     setState(() => _cfg = c);
     // Propager l'état actuel pour les autres widgets.
@@ -113,11 +95,6 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
             title: const Text('Mode sombre'),
             value: _cfg.darkMode,
             onChanged: (v) => _apply(_cfg.copyWith(darkMode: v)),
-          ),
-          SwitchListTile(
-            title: const Text('Fond dégradé'),
-            value: _cfg.bgGradient,
-            onChanged: (v) => _apply(_cfg.copyWith(bgGradient: v)),
           ),
           const Divider(height: 32),
 
@@ -195,8 +172,8 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
                 label: 'Taille icône (px)',
                 value: _cfg.tileIconSize,
                 min: 36,
-                max: 76,
-                divisions: 40,
+                max: 100,
+                divisions: 64,
                 onChanged: (v) =>
                     _apply(_cfg.copyWith(tileIconSize: v)),
               ),

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -1,4 +1,4 @@
-import 'dart:ui' show ImageFilter;
+import 'dart:ui' show ImageFilter, HSLColor;
 import 'package:flutter/material.dart';
 import '../data/ena_taxonomy.dart';
 import '../models/design_config.dart';
@@ -20,6 +20,9 @@ class SubjectListScreen extends StatelessWidget {
       builder: (context, cfg, _) {
         final textColor =
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
+        final accent = accentColor(cfg.bgPaletteName);
+        final badgeGradient =
+            pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode);
         return Scaffold(
           extendBody: true,
           extendBodyBehindAppBar: true,
@@ -47,7 +50,8 @@ class SubjectListScreen extends StatelessWidget {
                   return _GlassTile(
                     title: subject.name,
                     icon: item.icon,
-                    gradientColors: item.gradientColors,
+                    gradientColors: badgeGradient,
+                    accentColor: accent,
                     blur: cfg.glassBlur,
                     bgOpacity: cfg.glassBgOpacity,
                     borderOpacity: cfg.glassBorderOpacity,
@@ -82,17 +86,16 @@ class SubjectListScreen extends StatelessWidget {
 
 class _SubjectItem {
   final IconData icon;
-  final List<Color> gradientColors;
-  const _SubjectItem(this.icon, this.gradientColors);
+  const _SubjectItem(this.icon);
 }
 
 const _subjectItems = <_SubjectItem>[
-  _SubjectItem(Icons.public, [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
-  _SubjectItem(Icons.gavel, [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
-  _SubjectItem(Icons.bar_chart, [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
-  _SubjectItem(Icons.functions, [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
-  _SubjectItem(Icons.menu_book, [Color(0xFFFF7043), Color(0xFFD84315)]),
-  _SubjectItem(Icons.extension, [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
+  _SubjectItem(Icons.public),
+  _SubjectItem(Icons.gavel),
+  _SubjectItem(Icons.bar_chart),
+  _SubjectItem(Icons.functions),
+  _SubjectItem(Icons.menu_book),
+  _SubjectItem(Icons.extension),
 ];
 
 class _GlassTile extends StatefulWidget {
@@ -100,6 +103,7 @@ class _GlassTile extends StatefulWidget {
     required this.title,
     required this.icon,
     required this.gradientColors,
+    required this.accentColor,
     required this.onTap,
     required this.blur,
     required this.bgOpacity,
@@ -113,6 +117,7 @@ class _GlassTile extends StatefulWidget {
   final String title;
   final IconData icon;
   final List<Color> gradientColors;
+  final Color accentColor;
   final VoidCallback onTap;
   final double blur;
   final double bgOpacity;
@@ -138,7 +143,12 @@ class _GlassTileState extends State<_GlassTile> {
           ]
         : widget.gradientColors;
 
-    final iconColor = widget.useMono ? widget.monoColor : Colors.white;
+    final accentHsl = HSLColor.fromColor(widget.accentColor);
+    final iconColor = widget.useMono
+        ? widget.monoColor
+        : accentHsl
+            .withLightness((accentHsl.lightness * 0.6).clamp(0.0, 1.0))
+            .toColor();
 
     final iconBadge = Container(
       height: widget.iconSize,

--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -20,14 +20,11 @@ class DesignBackground extends StatelessWidget {
 
         return DecoratedBox(
           decoration: BoxDecoration(
-            gradient: cfg.bgGradient
-                ? LinearGradient(
-                    begin: Alignment.centerLeft,
-                    end: Alignment.centerRight,
-                    colors: baseColors,
-                  )
-                : null,
-            color: cfg.bgGradient ? null : baseColors.first,
+            gradient: LinearGradient(
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+              colors: baseColors,
+            ),
           ),
           child: Stack(
             children: [


### PR DESCRIPTION
## Summary
- default to serene blue palette and restrict design settings to blue tones
- darken accent color for icons and apply blue gradients across pages
- allow larger icons and unify subject tiles with themed colors

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b0540633808323aecd80bcc5d470fa