### PR TITLE
Unify blue palette with darker icons

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -36,7 +36,8 @@ ThemeData buildAppTheme(DesignConfig cfg) {
 
   return base.copyWith(
     textTheme: textTheme,
-    iconTheme: IconThemeData(color: textColor, size: cfg.tileIconSize),
+    iconTheme:
+        IconThemeData(color: iconColorForPalette(cfg.bgPaletteName), size: cfg.tileIconSize),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
       foregroundColor: textColor,

--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -30,7 +30,7 @@ class DesignConfig {
 
   const DesignConfig({
     // Thème fond
-    this.bgPaletteName = 'offWhite',
+    this.bgPaletteName = 'sereneBlue',
     this.waveEnabled = true,
     this.bgGradient = true,
     this.darkMode = false,
@@ -103,7 +103,7 @@ class DesignConfig {
     final double tileSize = (map['tileIconSize'] ?? svgSize).toDouble();
 
     return DesignConfig(
-      bgPaletteName: map['bgPaletteName'] ?? 'offWhite',
+      bgPaletteName: map['bgPaletteName'] ?? 'sereneBlue',
       waveEnabled: (map['waveEnabled'] ?? true) as bool,
       bgGradient: (map['bgGradient'] ?? true) as bool,
       glassBlur: (map['glassBlur'] ?? 18.0).toDouble(),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -21,41 +21,19 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
 
   // Palettes proposées (tons épurés et contrastes soignés)
   static const List<String> _palettes = [
-    'offWhite',
-    'lightGrey',
     'pastelBlue',
-    'powderPink',
-    'lightGreen',
-    'softYellow',
     'midnightBlue',
-    'anthracite',
     'blueIndigo',
-    'violetRose',
-    'mintTurquoise',
-    'deepBlack',
     'sereneBlue',
-    'forestGreen',
     'deepIndigo',
-    'royalViolet',
   ];
 
   static const Map<String, String> _paletteLabels = {
-    'offWhite': 'Blanc cassé',
-    'lightGrey': 'Gris clair',
     'pastelBlue': 'Bleu pastel',
-    'powderPink': 'Rose poudré',
-    'lightGreen': 'Vert doux',
-    'softYellow': 'Jaune pâle',
     'midnightBlue': 'Bleu nuit',
-    'anthracite': 'Anthracite',
     'blueIndigo': 'Indigo',
-    'violetRose': 'Violet',
-    'mintTurquoise': 'Turquoise',
-    'deepBlack': 'Noir profond',
     'sereneBlue': 'Bleu sérieux',
-    'forestGreen': 'Vert forêt',
     'deepIndigo': 'Indigo profond',
-    'royalViolet': 'Violet royal',
   };
 
   @override
@@ -148,9 +126,8 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
             onChanged: (v) => _apply(
               _cfg.copyWith(
                 useMono: v,
-                monoColor: v
-                    ? complementaryColor(_cfg.bgPaletteName)
-                    : _cfg.monoColor,
+                monoColor:
+                    v ? iconColorForPalette(_cfg.bgPaletteName) : _cfg.monoColor,
               ),
             ),
           ),
@@ -231,7 +208,7 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
         final updated = _cfg.useMono
             ? _cfg.copyWith(
                 bgPaletteName: name,
-                monoColor: complementaryColor(name),
+                monoColor: iconColorForPalette(name),
               )
             : _cfg.copyWith(bgPaletteName: name);
         _apply(updated);

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -99,6 +99,7 @@ class _PlayScreenState extends State<PlayScreen> {
                                 size: cfg.tileIconSize,
                                 useMono: cfg.useMono,
                                 monoColor: cfg.monoColor,
+                                paletteName: cfg.bgPaletteName,
                               ),
                               const SizedBox(width: 12),
                               Expanded(
@@ -133,7 +134,7 @@ class _PlayScreenState extends State<PlayScreen> {
                         return _GlassTile(
                           title: item.title,
                           icon: item.icon,
-                          gradientColors: item.gradientColors,
+                          paletteName: cfg.bgPaletteName,
                           blur: cfg.glassBlur,
                           bgOpacity: cfg.glassBgOpacity,
                           borderOpacity: cfg.glassBorderOpacity,
@@ -197,7 +198,7 @@ class _GlassTile extends StatefulWidget {
   const _GlassTile({
     required this.title,
     required this.icon,
-    required this.gradientColors,
+    required this.paletteName,
     required this.onTap,
     required this.blur,
     required this.bgOpacity,
@@ -210,7 +211,7 @@ class _GlassTile extends StatefulWidget {
   });
   final String title;
   final IconData icon;
-  final List<Color> gradientColors;
+  final String paletteName;
   final VoidCallback onTap;
   final double blur;
   final double bgOpacity;
@@ -234,9 +235,10 @@ class _GlassTileState extends State<_GlassTile> {
             widget.monoColor.withOpacity(0.15),
             widget.monoColor.withOpacity(0.35)
           ]
-        : widget.gradientColors;
+        : iconGradientForPalette(widget.paletteName);
 
-    final iconColor = widget.useMono ? widget.monoColor : Colors.white;
+    final iconColor =
+        widget.useMono ? widget.monoColor : iconColorForPalette(widget.paletteName);
 
     final iconBadge = Container(
       height: widget.iconSize,
@@ -350,17 +352,20 @@ class _IconBadge extends StatelessWidget {
     this.size = 52,
     required this.useMono,
     required this.monoColor,
+    required this.paletteName,
   });
   final IconData icon;
   final double size;
   final bool useMono;
   final Color monoColor;
+  final String paletteName;
   @override
   Widget build(BuildContext context) {
     final gradientColors = useMono
         ? [monoColor.withOpacity(0.15), monoColor.withOpacity(0.35)]
-        : const [Color(0xFFFFB25E), Color(0xFFFF7A00)];
-    final iconColor = useMono ? monoColor : Colors.white;
+        : iconGradientForPalette(paletteName);
+    final iconColor =
+        useMono ? monoColor : iconColorForPalette(paletteName);
     return Container(
       height: size,
       width: size,
@@ -380,25 +385,16 @@ class _IconBadge extends StatelessWidget {
 class _MenuItem {
   final String title;
   final IconData icon;
-  final List<Color> gradientColors;
-  const _MenuItem(this.title, this.icon, this.gradientColors);
+  const _MenuItem(this.title, this.icon);
 }
 
 const _items = <_MenuItem>[
-  _MenuItem("S'entraîner", Icons.play_circle_fill_rounded,
-      [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
-  _MenuItem('Concours ENA', Icons.school_rounded,
-      [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
-  _MenuItem('Par matière', Icons.menu_book_rounded,
-      [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
-  _MenuItem('Historique examens', Icons.fact_check_rounded,
-      [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
-  _MenuItem("Historique entraînement", Icons.history_rounded,
-      [Color(0xFFFF7043), Color(0xFFD84315)]),
-  _MenuItem('Comment ça marche ?', Icons.info_rounded,
-      [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
-  _MenuItem('Compétition', Icons.sports_kabaddi,
-      [Color(0xFFFFEE58), Color(0xFFFDD835)]),
-  _MenuItem('Classement', Icons.emoji_events_outlined,
-      [Color(0xFFEC407A), Color(0xFFD81B60)]),
+  _MenuItem("S'entraîner", Icons.play_circle_fill_rounded),
+  _MenuItem('Concours ENA', Icons.school_rounded),
+  _MenuItem('Par matière', Icons.menu_book_rounded),
+  _MenuItem('Historique examens', Icons.fact_check_rounded),
+  _MenuItem("Historique entraînement", Icons.history_rounded),
+  _MenuItem('Comment ça marche ?', Icons.info_rounded),
+  _MenuItem('Compétition', Icons.sports_kabaddi),
+  _MenuItem('Classement', Icons.emoji_events_outlined),
 ];

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -47,7 +47,7 @@ class SubjectListScreen extends StatelessWidget {
                   return _GlassTile(
                     title: subject.name,
                     icon: item.icon,
-                    gradientColors: item.gradientColors,
+                    paletteName: cfg.bgPaletteName,
                     blur: cfg.glassBlur,
                     bgOpacity: cfg.glassBgOpacity,
                     borderOpacity: cfg.glassBorderOpacity,
@@ -82,24 +82,23 @@ class SubjectListScreen extends StatelessWidget {
 
 class _SubjectItem {
   final IconData icon;
-  final List<Color> gradientColors;
-  const _SubjectItem(this.icon, this.gradientColors);
+  const _SubjectItem(this.icon);
 }
 
 const _subjectItems = <_SubjectItem>[
-  _SubjectItem(Icons.public, [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
-  _SubjectItem(Icons.gavel, [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
-  _SubjectItem(Icons.bar_chart, [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
-  _SubjectItem(Icons.functions, [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
-  _SubjectItem(Icons.menu_book, [Color(0xFFFF7043), Color(0xFFD84315)]),
-  _SubjectItem(Icons.extension, [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
+  _SubjectItem(Icons.public),
+  _SubjectItem(Icons.gavel),
+  _SubjectItem(Icons.bar_chart),
+  _SubjectItem(Icons.functions),
+  _SubjectItem(Icons.menu_book),
+  _SubjectItem(Icons.extension),
 ];
 
 class _GlassTile extends StatefulWidget {
   const _GlassTile({
     required this.title,
     required this.icon,
-    required this.gradientColors,
+    required this.paletteName,
     required this.onTap,
     required this.blur,
     required this.bgOpacity,
@@ -112,7 +111,7 @@ class _GlassTile extends StatefulWidget {
   });
   final String title;
   final IconData icon;
-  final List<Color> gradientColors;
+  final String paletteName;
   final VoidCallback onTap;
   final double blur;
   final double bgOpacity;
@@ -136,9 +135,10 @@ class _GlassTileState extends State<_GlassTile> {
             widget.monoColor.withOpacity(0.15),
             widget.monoColor.withOpacity(0.35)
           ]
-        : widget.gradientColors;
+        : iconGradientForPalette(widget.paletteName);
 
-    final iconColor = widget.useMono ? widget.monoColor : Colors.white;
+    final iconColor =
+        widget.useMono ? widget.monoColor : iconColorForPalette(widget.paletteName);
 
     final iconBadge = Container(
       height: widget.iconSize,

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -97,6 +97,24 @@ Color complementaryColor(String name) {
   return hsl.withHue((hsl.hue + 180.0) % 360).toColor();
 }
 
+/// Returns a darker shade of the palette color for icons so that they remain
+/// visible while staying in the same blue-toned family.
+Color iconColorForPalette(String name) {
+  final accent = accentColor(name);
+  final hsl = HSLColor.fromColor(accent);
+  // Reduce lightness to create a darker variant.
+  final dark = hsl.withLightness((hsl.lightness * 0.7).clamp(0.0, 1.0));
+  return dark.toColor();
+}
+
+/// Gradient used for icon badges based on the palette. The gradient goes from a
+/// darker shade to the base accent color for a subtle blue effect.
+List<Color> iconGradientForPalette(String name) {
+  final accent = accentColor(name);
+  final dark = iconColorForPalette(name);
+  return [dark, accent];
+}
+
 /// Returns [Colors.white] or [Colors.black] depending on the background brightness.
 Color textColorForPalette(String name, {bool darkMode = false}) {
   final colors = pastelColors(name, darkMode: darkMode);


### PR DESCRIPTION
## Summary
- limit theme palettes to blue tones and default to sereneBlue
- add helpers for palette-based icon colors and gradients
- update tiles and icons to use uniform blue gradients and scalable icon sizing

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0540633808323aecd80bcc5d470fa