### PR TITLE
Restrict theme palette to blues and support larger icons

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -36,7 +36,10 @@ ThemeData buildAppTheme(DesignConfig cfg) {
 
   return base.copyWith(
     textTheme: textTheme,
-    iconTheme: IconThemeData(color: textColor, size: cfg.tileIconSize),
+    iconTheme: IconThemeData(
+      color: darkerAccentColor(cfg.bgPaletteName),
+      size: cfg.tileIconSize,
+    ),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
       foregroundColor: textColor,

--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -30,7 +30,7 @@ class DesignConfig {
 
   const DesignConfig({
     // Thème fond
-    this.bgPaletteName = 'offWhite',
+    this.bgPaletteName = 'sereneBlue',
     this.waveEnabled = true,
     this.bgGradient = true,
     this.darkMode = false,
@@ -103,7 +103,7 @@ class DesignConfig {
     final double tileSize = (map['tileIconSize'] ?? svgSize).toDouble();
 
     return DesignConfig(
-      bgPaletteName: map['bgPaletteName'] ?? 'offWhite',
+      bgPaletteName: map['bgPaletteName'] ?? 'sereneBlue',
       waveEnabled: (map['waveEnabled'] ?? true) as bool,
       bgGradient: (map['bgGradient'] ?? true) as bool,
       glassBlur: (map['glassBlur'] ?? 18.0).toDouble(),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -21,41 +21,19 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
 
   // Palettes proposées (tons épurés et contrastes soignés)
   static const List<String> _palettes = [
-    'offWhite',
-    'lightGrey',
     'pastelBlue',
-    'powderPink',
-    'lightGreen',
-    'softYellow',
-    'midnightBlue',
-    'anthracite',
-    'blueIndigo',
-    'violetRose',
-    'mintTurquoise',
-    'deepBlack',
     'sereneBlue',
-    'forestGreen',
+    'blueIndigo',
+    'midnightBlue',
     'deepIndigo',
-    'royalViolet',
   ];
 
   static const Map<String, String> _paletteLabels = {
-    'offWhite': 'Blanc cassé',
-    'lightGrey': 'Gris clair',
     'pastelBlue': 'Bleu pastel',
-    'powderPink': 'Rose poudré',
-    'lightGreen': 'Vert doux',
-    'softYellow': 'Jaune pâle',
-    'midnightBlue': 'Bleu nuit',
-    'anthracite': 'Anthracite',
-    'blueIndigo': 'Indigo',
-    'violetRose': 'Violet',
-    'mintTurquoise': 'Turquoise',
-    'deepBlack': 'Noir profond',
     'sereneBlue': 'Bleu sérieux',
-    'forestGreen': 'Vert forêt',
+    'blueIndigo': 'Indigo',
+    'midnightBlue': 'Bleu nuit',
     'deepIndigo': 'Indigo profond',
-    'royalViolet': 'Violet royal',
   };
 
   @override
@@ -195,8 +173,8 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
                 label: 'Taille icône (px)',
                 value: _cfg.tileIconSize,
                 min: 36,
-                max: 76,
-                divisions: 40,
+                max: 100,
+                divisions: 64,
                 onChanged: (v) =>
                     _apply(_cfg.copyWith(tileIconSize: v)),
               ),

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -42,6 +42,17 @@ Color accentColor(String name) {
   }
 }
 
+/// Darkens a [Color] by decreasing its lightness in HSL space.
+Color darken(Color color, [double amount = 0.1]) {
+  final hsl = HSLColor.fromColor(color);
+  final lightness = (hsl.lightness - amount).clamp(0.0, 1.0);
+  return hsl.withLightness(lightness).toColor();
+}
+
+/// Returns a darker variant of the palette's accent color.
+Color darkerAccentColor(String name, [double amount = 0.2]) =>
+    darken(accentColor(name), amount);
+
 /// Returns two pastel variants of the accent color for gradient backgrounds.
 List<Color> pastelColors(String name, {bool darkMode = false}) {
   switch (name) {


### PR DESCRIPTION
## Summary
- default to a blue color palette and restrict palette choices to blue tones
- darken icon colors based on the selected blue palette
- allow larger tile icons via expanded slider range

## Testing
- `dart format lib/app/theme.dart lib/utils/palette_utils.dart lib/screens/design_settings_screen.dart lib/models/design_config.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b062604d988323a893d9c94d3dab22