### PR TITLE
feat: add new design palettes and adjust icon sizing

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -38,7 +38,6 @@ ThemeData buildAppTheme(DesignConfig cfg) {
     textTheme: textTheme,
     iconTheme: IconThemeData(
       color: darkerAccentColor(cfg.bgPaletteName),
-      size: cfg.tileIconSize,
     ),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,

--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -30,7 +30,7 @@ class DesignConfig {
 
   const DesignConfig({
     // Thème fond
-    this.bgPaletteName = 'sereneBlue',
+    this.bgPaletteName = 'navyCyanAmber',
     this.waveEnabled = true,
     this.bgGradient = true,
     this.darkMode = false,

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -21,19 +21,25 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
 
   // Palettes proposées (tons épurés et contrastes soignés)
   static const List<String> _palettes = [
-    'pastelBlue',
-    'sereneBlue',
-    'blueIndigo',
-    'midnightBlue',
-    'deepIndigo',
+    'navyCyanAmber',
+    'indigoPurpleSky',
+    'emeraldTealMint',
+    'royalBlueGold',
+    'charcoalElectric',
+    'forestSandTerracotta',
+    'cobaltLimeSlate',
+    'calmPastels',
   ];
 
   static const Map<String, String> _paletteLabels = {
-    'pastelBlue': 'Bleu pastel',
-    'sereneBlue': 'Bleu sérieux',
-    'blueIndigo': 'Indigo',
-    'midnightBlue': 'Bleu nuit',
-    'deepIndigo': 'Indigo profond',
+    'navyCyanAmber': 'Navy/Cyan/Ambre',
+    'indigoPurpleSky': 'Indigo/Violet/Ciel',
+    'emeraldTealMint': 'Émeraude/Teal/Menthe',
+    'royalBlueGold': 'Bleu royal/Or doux',
+    'charcoalElectric': 'Charbon/Bleu élect.',
+    'forestSandTerracotta': 'Forêt/Sable/Terre cuite',
+    'cobaltLimeSlate': 'Cobalt/Lime/Ardoise',
+    'calmPastels': 'Pastels calmes',
   };
 
   @override

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -37,6 +37,22 @@ Color accentColor(String name) {
       return const Color(0xFF283593);
     case 'royalViolet':
       return const Color(0xFF6A1B9A);
+    case 'navyCyanAmber':
+      return const Color(0xFF1E3A8A); // Primary
+    case 'indigoPurpleSky':
+      return const Color(0xFF4F46E5); // Primary
+    case 'emeraldTealMint':
+      return const Color(0xFF059669); // Primary
+    case 'royalBlueGold':
+      return const Color(0xFF37478F); // Primary
+    case 'charcoalElectric':
+      return const Color(0xFF3B82F6); // Primary
+    case 'forestSandTerracotta':
+      return const Color(0xFF1B5E20); // Primary
+    case 'cobaltLimeSlate':
+      return const Color(0xFF2563EB); // Primary
+    case 'calmPastels':
+      return const Color(0xFF8FA6FF); // Primary
     default:
       return const Color(0xFFF5F5F5);
   }
@@ -90,6 +106,22 @@ List<Color> pastelColors(String name, {bool darkMode = false}) {
       return const [Color(0xFF283593), Color(0xFF5C6BC0)];
     case 'royalViolet':
       return const [Color(0xFF6A1B9A), Color(0xFFBA68C8)];
+    case 'navyCyanAmber':
+      return const [Color(0xFFF8FAFC), Color(0xFFFFFFFF)];
+    case 'indigoPurpleSky':
+      return const [Color(0xFFF5F3FF), Color(0xFFFFFFFF)];
+    case 'emeraldTealMint':
+      return const [Color(0xFFF0FDF4), Color(0xFFFFFFFF)];
+    case 'royalBlueGold':
+      return const [Color(0xFFFFFFFF), Color(0xFFF6F8FF)];
+    case 'charcoalElectric':
+      return const [Color(0xFF0B1220), Color(0xFF0F172A)];
+    case 'forestSandTerracotta':
+      return const [Color(0xFFFFF8F1), Color(0xFFFFFFFF)];
+    case 'cobaltLimeSlate':
+      return const [Color(0xFFF8FAFC), Color(0xFFFFFFFF)];
+    case 'calmPastels':
+      return const [Color(0xFFF7F7FB), Color(0xFFFFFFFF)];
     default:
       final accent = accentColor(name);
       final hsl = HSLColor.fromColor(accent);
@@ -103,23 +135,61 @@ List<Color> pastelColors(String name, {bool darkMode = false}) {
 
 /// Complementary color used for buttons to stand out from the background.
 Color complementaryColor(String name) {
-  final accent = accentColor(name);
-  final hsl = HSLColor.fromColor(accent);
-  return hsl.withHue((hsl.hue + 180.0) % 360).toColor();
+  switch (name) {
+    case 'navyCyanAmber':
+      return const Color(0xFFF59E0B); // Accent
+    case 'indigoPurpleSky':
+      return const Color(0xFF38BDF8); // Accent
+    case 'emeraldTealMint':
+      return const Color(0xFF2DD4BF); // Accent
+    case 'royalBlueGold':
+      return const Color(0xFF00B3C6); // Accent
+    case 'charcoalElectric':
+      return const Color(0xFFF472B6); // Accent
+    case 'forestSandTerracotta':
+      return const Color(0xFFD4A373); // Accent
+    case 'cobaltLimeSlate':
+      return const Color(0xFF64748B); // Accent
+    case 'calmPastels':
+      return const Color(0xFFB7E4C7); // Accent
+    default:
+      final accent = accentColor(name);
+      final hsl = HSLColor.fromColor(accent);
+      return hsl.withHue((hsl.hue + 180.0) % 360).toColor();
+  }
 }
 
 /// Returns [Colors.white] or [Colors.black] depending on the background brightness.
 Color textColorForPalette(String name, {bool darkMode = false}) {
-  final colors = pastelColors(name, darkMode: darkMode);
-  int r = 0, g = 0, b = 0;
-  for (final c in colors) {
-    r += c.red;
-    g += c.green;
-    b += c.blue;
+  switch (name) {
+    case 'navyCyanAmber':
+      return const Color(0xFF0F172A);
+    case 'indigoPurpleSky':
+      return const Color(0xFF111827);
+    case 'emeraldTealMint':
+      return const Color(0xFF0F172A);
+    case 'royalBlueGold':
+      return const Color(0xFF0F172A);
+    case 'charcoalElectric':
+      return const Color(0xFFE5E7EB);
+    case 'forestSandTerracotta':
+      return const Color(0xFF1F2937);
+    case 'cobaltLimeSlate':
+      return const Color(0xFF0F172A);
+    case 'calmPastels':
+      return const Color(0xFF1F2937);
+    default:
+      final colors = pastelColors(name, darkMode: darkMode);
+      int r = 0, g = 0, b = 0;
+      for (final c in colors) {
+        r += c.red;
+        g += c.green;
+        b += c.blue;
+      }
+      final avg = Color.fromARGB(255, r ~/ colors.length, g ~/ colors.length, b ~/ colors.length);
+      final brightness = ThemeData.estimateBrightnessForColor(avg);
+      return brightness == Brightness.dark ? Colors.white : Colors.black;
   }
-  final avg = Color.fromARGB(255, r ~/ colors.length, g ~/ colors.length, b ~/ colors.length);
-  final brightness = ThemeData.estimateBrightnessForColor(avg);
-  return brightness == Brightness.dark ? Colors.white : Colors.black;
 }
 
 /// Helper to get readable text color on top of any solid [color].


### PR DESCRIPTION
## Summary
- add eight new color palette combinations and update design settings
- default to navy/cyan/amber palette and support specific text colors
- limit large icon sizing to tiles by removing global icon sizing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b065cc5e748323a4880734def5216f