### PR TITLE
Add splash & home screens with reusable primary button

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'app/theme.dart';
 import 'firebase_options.dart';
-import 'screens/play_screen.dart';
-import 'screens/login_screen.dart';
 import 'services/design_prefs.dart';
 import 'services/design_bus.dart';
 import 'widgets/design_background.dart';
 import 'models/design_config.dart';
+import 'screens/splash_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -32,18 +30,7 @@ class CivExamApp extends StatelessWidget {
           theme: buildAppTheme(cfg),
           builder: (context, child) =>
               DesignBackground(child: child ?? const SizedBox()),
-          home: StreamBuilder<User?>(
-            stream: FirebaseAuth.instance.authStateChanges(),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              if (snapshot.hasData) {
-                return const PlayScreen();
-              }
-              return const LoginScreen();
-            },
-          ),
+          home: const SplashScreen(),
         );
       },
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/primary_button.dart';
+
+/// Basic home screen derived from design mocks.
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: Center(
+        child: PrimaryButton(
+          onPressed: () {},
+          child: const Text('Start Quiz'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../services/auth_service.dart';
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../widgets/primary_button.dart';
 import 'play_screen.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -81,14 +82,13 @@ class _LoginScreenState extends State<LoginScreen> {
                   if (_error != null)
                     Text(_error!, style: errorStyle),
                   const SizedBox(height: 12),
-                  ElevatedButton(
+                  PrimaryButton(
                     onPressed: _isLoading ? null : _submit,
                     child: _isLoading
                         ? const SizedBox(
                             width: 24,
                             height: 24,
-                            child:
-                                CircularProgressIndicator(strokeWidth: 2),
+                            child: CircularProgressIndicator(strokeWidth: 2),
                           )
                         : Text(_isLogin ? 'Connexion' : 'Inscription'),
                   ),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'login_screen.dart';
+import 'play_screen.dart';
+
+/// Initial splash screen showing the app logo before navigating to login.
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 2), () {
+      if (!mounted) return;
+      final user = FirebaseAuth.instance.currentUser;
+      final next = user == null ? const LoginScreen() : const PlayScreen();
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => next),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Image(
+          image: AssetImage('assets/images/logo_splash.png'),
+          width: 200,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/primary_button.dart
+++ b/lib/widgets/primary_button.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// A reusable primary button that uses the app's [ElevatedButtonTheme].
+///
+/// This widget avoids button style duplication across screens.
+class PrimaryButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final Widget child;
+
+  const PrimaryButton({super.key, required this.onPressed, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create PrimaryButton widget for consistent elevated button styling
- implement SplashScreen that routes to login or play after delay
- add basic HomeScreen and wire app start to SplashScreen
- use PrimaryButton in LoginScreen

## Testing
- `dart format lib/main.dart lib/screens/login_screen.dart lib/screens/splash_screen.dart lib/screens/home_screen.dart lib/widgets/primary_button.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0836db7f08323bf01ec2aa496da54