### PR TITLE
Limit history attempts

### DIFF
--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -39,6 +39,7 @@ class Attempt {
 
 class HistoryService {
   static const _key = 'attempts_v1';
+  static const int _maxAttempts = 100;
 
   static Future<void> addAttempt({
     required String subject,
@@ -59,6 +60,7 @@ class HistoryService {
       timestamp: timestamp,
     );
     list.add(jsonEncode(a.toMap()));
+    if (list.length > _maxAttempts) list.removeAt(0);
     await prefs.setStringList(_key, list);
   }
 


### PR DESCRIPTION
## Summary
- add max attempts constant to history service
- remove oldest history entry when exceeding limit

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08696f1948323aaad53bfa5883e35