### PR TITLE
Handle invalid entries in leaderboard store

### DIFF
--- a/lib/services/leaderboard_store.dart
+++ b/lib/services/leaderboard_store.dart
@@ -23,10 +23,15 @@ class LeaderboardStore {
     final prefs = await SharedPreferences.getInstance();
     final list = prefs.getStringList(_kKey) ?? <String>[];
     list.add(json.encode(e.toJson()));
-    final entries = list
-        .map((s) =>
-            LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>))
-        .toList();
+    final entries = <LeaderboardEntry>[];
+    for (final s in list) {
+      try {
+        entries.add(
+            LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>));
+      } catch (_) {
+        // ignore invalid stored entries
+      }
+    }
     final sorted = _sortEntries(entries);
     final encoded = sorted.map((e) => json.encode(e.toJson())).toList();
     await prefs.setStringList(_kKey, encoded);
@@ -35,10 +40,15 @@ class LeaderboardStore {
   static Future<List<LeaderboardEntry>> all() async {
     final prefs = await SharedPreferences.getInstance();
     final list = prefs.getStringList(_kKey) ?? <String>[];
-    final entries = list
-        .map((s) =>
-            LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>))
-        .toList();
+    final entries = <LeaderboardEntry>[];
+    for (final s in list) {
+      try {
+        entries.add(
+            LeaderboardEntry.fromJson(json.decode(s) as Map<String, dynamic>));
+      } catch (_) {
+        // ignore invalid stored entries
+      }
+    }
     return _sortEntries(entries);
   }
 


### PR DESCRIPTION
## Summary
- Skip malformed leaderboard entries when adding or retrieving records

## Testing
- ❌ `flutter test` (missing `flutter` command)
- ❌ `dart format lib/services/leaderboard_store.dart` (missing `dart` command)


------
https://chatgpt.com/codex/tasks/task_e_68b0869bebf88323b93ed25bf4d2981d