### PR TITLE
Handle errors when saving design settings

### DIFF
--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -3,6 +3,8 @@
 // Propose un aperçu dynamique, un choix de couleurs épuré et des options
 // avancées masquées dans des sections extensibles.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
@@ -56,10 +58,19 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
     DesignBus.push(c);
   }
 
-  Future<void> _apply(DesignConfig c) async {
+  void _apply(DesignConfig c) {
     setState(() => _cfg = c);
     DesignBus.push(c); // mise à jour en direct
-    await DesignPrefs.save(c); // persistance
+    unawaited(() async {
+      try {
+        await DesignPrefs.save(c); // persistance
+      } catch (e) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Impossible de sauvegarder')),
+        );
+      }
+    }());
   }
 
   @override


### PR DESCRIPTION
## Summary
- Handle persistence errors in design settings screen and show SnackBar on failure

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0869ea3348323a980caed4f256486