### PR TITLE
Guard emulator check from web platform

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
-import 'dart:io';
+import 'dart:io' show Platform;
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
@@ -229,6 +230,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
   }
 
   Future<void> _checkEmulator() async {
+    if (kIsWeb) return;
     final info = DeviceInfoPlugin();
     bool emulator = false;
     if (Platform.isAndroid) {


### PR DESCRIPTION
## Summary
- Use conditional `Platform` import and expose `kIsWeb`
- Skip emulator detection when running on the web

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08693321c83238eca1fb2830bed46