### PR TITLE
Ensure competition progress reaches 100% on final question

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -379,7 +379,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
               ),
             ),
             LinearProgressIndicator(
-              value: q.isEmpty ? 0 : _currentIndex / q.length,
+              value: (_currentIndex + 1) / q.length,
               minHeight: 6,
             ),
           ],


### PR DESCRIPTION
## Summary
- Show 100% completion when reaching last question in competition mode

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0868553508323b7f74e4ef1d85b43