### PR TITLE
Sort leaderboard entries by score and time

### DIFF
--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -21,7 +21,13 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
     final all = await LeaderboardStore.all();
     final comp = await CompetitionService().topEntries();
     if (!mounted) return;
-    setState(() { _entries = [...all, ...comp]; });
+    final merged = [...all, ...comp];
+    merged.sort((a, b) {
+      final p = b.percent.compareTo(a.percent);
+      if (p != 0) return p;
+      return a.durationSec.compareTo(b.durationSec);
+    });
+    setState(() { _entries = merged; });
   }
 
   List<LeaderboardEntry> get _filtered {


### PR DESCRIPTION
## Summary
- Merge leaderboard and competition entries then sort by percent (desc) and duration (asc)

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b089d792008323b4ce3af35017f700