### PR TITLE
Add mounted checks before using ScaffoldMessenger

### DIFF
--- a/lib/widgets/leaderboard_save_dialog.dart
+++ b/lib/widgets/leaderboard_save_dialog.dart
@@ -66,7 +66,7 @@ Future<void> showSaveScoreDialog({
       );
       controller.dispose();
     } else {
-      // ignore: use_build_context_synchronously
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Score enregistré 🎉')));
     }
@@ -120,7 +120,7 @@ Future<void> showSaveScoreDialog({
       dateIso: DateTime.now().toIso8601String(),
     );
     await LeaderboardStore.add(entry);
-    // ignore: use_build_context_synchronously
+    if (!context.mounted) return;
     ScaffoldMessenger.of(context)
         .showSnackBar(const SnackBar(content: Text('Score enregistré 🎉')));
   }


### PR DESCRIPTION
## Summary
- ensure context is mounted before showing score saving snackbars

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68b089d900508323a06f88da7ceb8610