### PR TITLE
Handle numeric fields in LeaderboardEntry more safely

### DIFF
--- a/lib/models/leaderboard_entry.dart
+++ b/lib/models/leaderboard_entry.dart
@@ -37,12 +37,12 @@ class LeaderboardEntry {
     mode: (m['mode'] ?? 'training') as String,
     subject: (m['subject'] ?? '') as String,
     chapter: (m['chapter'] ?? '') as String,
-    total: (m['total'] ?? 0) as int,
-    correct: (m['correct'] ?? 0) as int,
-    wrong: (m['wrong'] ?? 0) as int,
-    blank: (m['blank'] ?? 0) as int,
-    durationSec: (m['durationSec'] ?? 0) as int,
-    percent: ((m['percent'] ?? 0.0) as num).toDouble(),
+    total: (m['total'] as num?)?.toInt() ?? 0,
+    correct: (m['correct'] as num?)?.toInt() ?? 0,
+    wrong: (m['wrong'] as num?)?.toInt() ?? 0,
+    blank: (m['blank'] as num?)?.toInt() ?? 0,
+    durationSec: (m['durationSec'] as num?)?.toInt() ?? 0,
+    percent: (m['percent'] as num?)?.toDouble() ?? 0.0,
     dateIso: (m['dateIso'] ?? '') as String,
   );
 }


### PR DESCRIPTION
## Summary
- Parse leaderboard counts with `num` casts and `toInt()` fallbacks
- Ensure `percent` field uses `toDouble()` and defaults to 0.0

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08af3ed308323886613c6c7332539