### PR TITLE
Handle errors in training quick start

### DIFF
--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -95,6 +95,11 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
           const SnackBar(content: Text('Tentative enregistrée — Abandonné.')),
         );
       }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Échec du lancement de l\'entraînement.')),
+      );
     } finally {
       if (mounted) setState(() => _loading = false);
     }


### PR DESCRIPTION
## Summary
- wrap training quick start in try-catch-finally
- show error SnackBar on failure and always reset loading flag

## Testing
- `dart format lib/screens/training_quick_start.dart` *(fails: command not found)*
- `flutter format lib/screens/training_quick_start.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08af6d01483238d8392bf19b6effa