### PR TITLE
feat: add circular quiz timer and dynamic question indexing

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -17,6 +17,7 @@ import 'design_settings_screen.dart';
 import 'competition_screen.dart';
 import 'login_screen.dart';
 import '../services/question_loader.dart';
+import '../services/question_randomizer.dart';
 
 class PlayScreen extends StatefulWidget {
   const PlayScreen({super.key});
@@ -184,12 +185,22 @@ class _PlayScreenState extends State<PlayScreen> {
         );
         break;
       case 6:
-        final qs = await QuestionLoader.loadENA();
+        final all = await QuestionLoader.loadENA();
+        final selected = pickAndShuffle(all, 50);
+        final indexMap = <String, int>{
+          for (int i = 0; i < all.length; i++) all[i].id: i + 1
+        };
         if (!mounted) return;
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => CompetitionScreen(questions: qs),
+            builder: (_) => CompetitionScreen(
+              questions: selected,
+              indexMap: indexMap,
+              poolSize: all.length,
+              drawCount: selected.length,
+              timePerQuestion: 5,
+            ),
           ),
         );
         break;


### PR DESCRIPTION
## Summary
- select 50 random questions from the 500-question pool and pass original indices
- redesign competition screen with animated 5s circular countdown and progress bar
- show dynamic "Question {index}/500" and track progress over 50 questions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b78404a48323af6658b209247027