### PR TITLE
Add theme customizations and comments to competition screen

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -1,16 +1,33 @@
 import 'package:flutter/material.dart';
 
 import '../models/question.dart';
+import '../theme/competition_theme.dart';
 
 /// Competition quiz screen with a circular countdown and progress tracking.
 class CompetitionScreen extends StatefulWidget {
+  /// List of questions drawn for the competition.
   final List<Question> questions;
+
+  /// Maps question IDs to their global index. Used for display.
   final Map<String, int> indexMap;
+
+  /// Total size of the question pool.
   final int poolSize;
+
+  /// Number of questions in this session.
   final int drawCount;
+
+  /// Time allowed for each question (seconds).
   final int timePerQuestion;
+
+  /// Index of the currently displayed question.
   final int currentIndex;
+
+  /// Number of correct answers so far.
   final int correctCount;
+
+  /// Visual theme used to style the screen.
+  final CompetitionTheme theme;
 
   const CompetitionScreen({
     super.key,
@@ -21,6 +38,7 @@ class CompetitionScreen extends StatefulWidget {
     this.timePerQuestion = 5,
     this.currentIndex = 0,
     this.correctCount = 0,
+    this.theme = kDefaultCompetitionTheme,
   });
 
   @override
@@ -29,34 +47,45 @@ class CompetitionScreen extends StatefulWidget {
 
 class _CompetitionScreenState extends State<CompetitionScreen>
     with SingleTickerProviderStateMixin {
+  /// Currently selected answer index. `-1` means no selection yet.
   int _selected = -1;
+
+  /// Animation controller driving the countdown timer.
   late final AnimationController _controller;
 
+  /// Convenient getter for the question being displayed.
   Question get _currentQuestion => widget.questions[widget.currentIndex];
 
+  /// Remaining seconds on the countdown clock.
   int get _remainingSeconds =>
       (_controller.value * widget.timePerQuestion).ceil();
 
   @override
   void initState() {
     super.initState();
+    // Initialize the timer controller with the provided duration.
     _controller = AnimationController(
       vsync: this,
       duration: Duration(seconds: widget.timePerQuestion),
     )
+      // Rebuild the widget tree every tick to update the remaining time.
       ..addListener(() => setState(() {}))
+      // When the animation completes (time runs out), move to the next question.
       ..addStatusListener((s) {
         if (s == AnimationStatus.dismissed) _goNext();
       });
+    // Start the countdown immediately.
     _controller.reverse(from: 1.0);
   }
 
   @override
   void dispose() {
+    // Always dispose animation controllers to free resources.
     _controller.dispose();
     super.dispose();
   }
 
+  /// Removes any "Question XX:" prefix from the question text.
   String _cleanQuestion(String q) {
     return q.replaceFirst(
         RegExp(r'^Question\s*\d+[:\.\)]?\s*', caseSensitive: false),
@@ -67,107 +96,97 @@ class _CompetitionScreenState extends State<CompetitionScreen>
   Widget build(BuildContext context) {
     final questionIndex = widget.indexMap[_currentQuestion.id] ?? 0;
     return Scaffold(
-      backgroundColor: const Color(0xFFF5F5F5),
+      // Global background color comes from the theme.
+      backgroundColor: widget.theme.backgroundColor,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
+              // Top card displaying the timer, question text and progress bar.
               Container(
                 width: double.infinity,
                 padding: const EdgeInsets.all(16),
                 decoration: BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: BorderRadius.circular(16),
-                  boxShadow: const [
-                    BoxShadow(
-                      color: Colors.black12,
-                      blurRadius: 6,
-                      offset: Offset(0, 3),
-                    ),
-                  ],
+                  color: widget.theme.questionCardColor,
+                  borderRadius:
+                      BorderRadius.circular(widget.theme.questionCardRadius),
+                  boxShadow: widget.theme.questionCardShadow,
                 ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    // Countdown circle.
                     Center(
                       child: Container(
                         padding: const EdgeInsets.all(8),
                         decoration: BoxDecoration(
-                          color: Colors.white,
-                          borderRadius: BorderRadius.circular(12),
-                          boxShadow: const [
-                            BoxShadow(
-                              color: Colors.black12,
-                              blurRadius: 4,
-                              offset: Offset(0, 2),
-                            ),
-                          ],
+                          color: widget.theme.timerContainerColor,
+                          borderRadius: BorderRadius.circular(
+                              widget.theme.timerContainerRadius),
+                          boxShadow: widget.theme.timerContainerShadow,
                         ),
                         child: Stack(
                           alignment: Alignment.center,
                           children: [
                             SizedBox(
-                              width: 80,
-                              height: 80,
+                              width: widget.theme.timerSize,
+                              height: widget.theme.timerSize,
                               child: CircularProgressIndicator(
                                 value: _controller.value,
-                                strokeWidth: 6,
+                                strokeWidth: widget.theme.timerStrokeWidth,
+                                color: widget.theme.timerColor,
                               ),
                             ),
                             Text(
                               '$_remainingSeconds',
-                              style: const TextStyle(
-                                fontSize: 24,
-                                fontWeight: FontWeight.bold,
-                              ),
+                              style: widget.theme.timerTextStyle,
                             ),
                           ],
                         ),
                       ),
                     ),
                     const SizedBox(height: 16),
+                    // Question number within the pool.
                     Text(
                       'Question $questionIndex/${widget.poolSize}',
-                      style: const TextStyle(
-                        fontSize: 14,
-                        color: Colors.black54,
-                      ),
+                      style: widget.theme.questionIndexTextStyle,
                     ),
                     const SizedBox(height: 8),
+                    // Actual question text.
                     Text(
                       _cleanQuestion(_currentQuestion.question),
-                      style: const TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.black,
-                      ),
+                      style: widget.theme.questionTextStyle,
                     ),
                     const SizedBox(height: 12),
+                    // Progress bar for overall quiz progression.
                     LinearProgressIndicator(
                       value: (widget.currentIndex + 1) / widget.drawCount,
+                      color: widget.theme.progressBarColor,
+                      backgroundColor:
+                          widget.theme.progressBarColor.withOpacity(0.3),
                     ),
                   ],
                 ),
               ),
               const SizedBox(height: 24),
+              // Chip displaying the selected answer when user taps an option.
               if (_selected >= 0)
                 Container(
                   padding:
                       const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
                   decoration: BoxDecoration(
-                    color: Colors.pinkAccent.shade100,
-                    borderRadius: BorderRadius.circular(20),
+                    color: widget.theme.selectedChipBackgroundColor,
+                    borderRadius:
+                        BorderRadius.circular(widget.theme.selectedChipRadius),
                   ),
                   child: Text(
                     _currentQuestion.choices[_selected],
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w600,
-                    ),
+                    style: widget.theme.selectedChipTextStyle,
                   ),
                 ),
               const SizedBox(height: 24),
+              // Answer options list.
               ...List.generate(_currentQuestion.choices.length, (i) {
                 final bool isSelected = _selected == i;
                 return Padding(
@@ -178,18 +197,13 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                       width: double.infinity,
                       padding: const EdgeInsets.symmetric(vertical: 16),
                       decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(24),
-                        boxShadow: const [
-                          BoxShadow(
-                            color: Colors.black12,
-                            blurRadius: 6,
-                            offset: Offset(0, 3),
-                          ),
-                        ],
+                        color: widget.theme.optionCardColor,
+                        borderRadius: BorderRadius.circular(
+                            widget.theme.optionCardRadius),
+                        boxShadow: widget.theme.optionCardShadow,
                         border: isSelected
                             ? Border.all(
-                                color: Colors.pinkAccent,
+                                color: widget.theme.optionSelectedBorderColor,
                                 width: 2,
                               )
                             : null,
@@ -197,11 +211,7 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                       child: Text(
                         _currentQuestion.choices[i],
                         textAlign: TextAlign.center,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                          color: Colors.black,
-                        ),
+                        style: widget.theme.optionTextStyle,
                       ),
                     ),
                   ),
@@ -216,18 +226,22 @@ class _CompetitionScreenState extends State<CompetitionScreen>
   }
 
   void _onOptionTap(int i) {
+    // Prevent selecting multiple answers.
     if (_selected >= 0) return;
     setState(() => _selected = i);
+    // Pause the timer and move to next question shortly after.
     _controller.stop();
     Future.delayed(const Duration(milliseconds: 300), () => _goNext(i));
   }
 
   void _goNext([int? selected]) {
+    // Determine whether the chosen option (if any) is correct.
     final isCorrect = selected != null &&
         selected == _currentQuestion.answerIndex;
     final int totalCorrect =
         widget.correctCount + (isCorrect ? 1 : 0);
     if (widget.currentIndex + 1 < widget.drawCount) {
+      // Continue to the next question by replacing the current screen.
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
@@ -239,16 +253,19 @@ class _CompetitionScreenState extends State<CompetitionScreen>
             timePerQuestion: widget.timePerQuestion,
             currentIndex: widget.currentIndex + 1,
             correctCount: totalCorrect,
+            theme: widget.theme,
           ),
         ),
       );
     } else {
+      // All questions answered: show result screen.
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
           builder: (_) => CompetitionResultScreen(
             total: widget.drawCount,
             correct: totalCorrect,
+            theme: widget.theme,
           ),
         ),
       );
@@ -257,24 +274,38 @@ class _CompetitionScreenState extends State<CompetitionScreen>
 }
 
 class CompetitionResultScreen extends StatelessWidget {
+  /// Total number of questions answered.
   final int total;
+
+  /// Number of correct answers.
   final int correct;
 
-  const CompetitionResultScreen({super.key, required this.total, required this.correct});
+  /// Theme used to style the result screen.
+  final CompetitionTheme theme;
+
+  const CompetitionResultScreen({
+    super.key,
+    required this.total,
+    required this.correct,
+    this.theme = kDefaultCompetitionTheme,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: theme.backgroundColor,
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text(
+            // Title of the result screen.
+            Text(
               'Résultat',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+              style: theme.questionTextStyle,
             ),
             const SizedBox(height: 16),
-            Text('Score: $correct / $total'),
+            // Display final score.
+            Text('Score: $correct / $total', style: theme.optionTextStyle),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () => Navigator.pop(context),

--- a/lib/theme/competition_theme.dart
+++ b/lib/theme/competition_theme.dart
@@ -1,0 +1,151 @@
+/// Design options for the `CompetitionScreen`.
+///
+/// Centralizes all visual settings so the appearance of the screen can be
+/// tweaked in a single place. Each field controls one aspect of the UI and can
+/// be modified as needed.
+import 'package:flutter/material.dart';
+
+@immutable
+class CompetitionTheme {
+  /// Background color of the whole screen.
+  final Color backgroundColor;
+
+  /// Styling for the card that holds the question and progress information.
+  final Color questionCardColor;
+  final double questionCardRadius;
+  final List<BoxShadow> questionCardShadow;
+
+  /// Styling for the options (answer) cards.
+  final Color optionCardColor;
+  final double optionCardRadius;
+  final List<BoxShadow> optionCardShadow;
+  final Color optionSelectedBorderColor;
+
+  /// Color of the progress bar displayed under the question.
+  final Color progressBarColor;
+
+  /// Dimensions and appearance of the countdown circle.
+  final double timerSize;
+  final double timerStrokeWidth;
+  final Color timerColor;
+  final Color timerContainerColor;
+  final double timerContainerRadius;
+  final List<BoxShadow> timerContainerShadow;
+
+  /// Text styles used throughout the screen.
+  final TextStyle timerTextStyle;
+  final TextStyle questionIndexTextStyle;
+  final TextStyle questionTextStyle;
+  final TextStyle optionTextStyle;
+  final TextStyle selectedChipTextStyle;
+
+  /// Appearance of the chip that shows the selected answer.
+  final Color selectedChipBackgroundColor;
+  final double selectedChipRadius;
+
+  const CompetitionTheme({
+    this.backgroundColor = const Color(0xFFF5F5F5),
+    this.questionCardColor = Colors.white,
+    this.questionCardRadius = 16.0,
+    this.questionCardShadow = const [
+      BoxShadow(color: Colors.black12, blurRadius: 6, offset: Offset(0, 3)),
+    ],
+    this.optionCardColor = Colors.white,
+    this.optionCardRadius = 24.0,
+    this.optionCardShadow = const [
+      BoxShadow(color: Colors.black12, blurRadius: 6, offset: Offset(0, 3)),
+    ],
+    this.optionSelectedBorderColor = Colors.pinkAccent,
+    this.progressBarColor = Colors.pinkAccent,
+    this.timerSize = 80.0,
+    this.timerStrokeWidth = 6.0,
+    this.timerColor = Colors.pinkAccent,
+    this.timerContainerColor = Colors.white,
+    this.timerContainerRadius = 12.0,
+    this.timerContainerShadow = const [
+      BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, 2)),
+    ],
+    this.timerTextStyle = const TextStyle(
+      fontSize: 24,
+      fontWeight: FontWeight.bold,
+    ),
+    this.questionIndexTextStyle = const TextStyle(
+      fontSize: 14,
+      color: Colors.black54,
+    ),
+    this.questionTextStyle = const TextStyle(
+      fontSize: 20,
+      fontWeight: FontWeight.bold,
+      color: Colors.black,
+    ),
+    this.optionTextStyle = const TextStyle(
+      fontSize: 16,
+      fontWeight: FontWeight.w500,
+      color: Colors.black,
+    ),
+    this.selectedChipTextStyle = const TextStyle(
+      color: Colors.white,
+      fontWeight: FontWeight.w600,
+    ),
+    this.selectedChipBackgroundColor = Colors.pinkAccent,
+    this.selectedChipRadius = 20.0,
+  });
+
+  /// Creates a copy of this theme with the given fields replaced by new values.
+  CompetitionTheme copyWith({
+    Color? backgroundColor,
+    Color? questionCardColor,
+    double? questionCardRadius,
+    List<BoxShadow>? questionCardShadow,
+    Color? optionCardColor,
+    double? optionCardRadius,
+    List<BoxShadow>? optionCardShadow,
+    Color? optionSelectedBorderColor,
+    Color? progressBarColor,
+    double? timerSize,
+    double? timerStrokeWidth,
+    Color? timerColor,
+    Color? timerContainerColor,
+    double? timerContainerRadius,
+    List<BoxShadow>? timerContainerShadow,
+    TextStyle? timerTextStyle,
+    TextStyle? questionIndexTextStyle,
+    TextStyle? questionTextStyle,
+    TextStyle? optionTextStyle,
+    TextStyle? selectedChipTextStyle,
+    Color? selectedChipBackgroundColor,
+    double? selectedChipRadius,
+  }) {
+    return CompetitionTheme(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      questionCardColor: questionCardColor ?? this.questionCardColor,
+      questionCardRadius: questionCardRadius ?? this.questionCardRadius,
+      questionCardShadow: questionCardShadow ?? this.questionCardShadow,
+      optionCardColor: optionCardColor ?? this.optionCardColor,
+      optionCardRadius: optionCardRadius ?? this.optionCardRadius,
+      optionCardShadow: optionCardShadow ?? this.optionCardShadow,
+      optionSelectedBorderColor:
+          optionSelectedBorderColor ?? this.optionSelectedBorderColor,
+      progressBarColor: progressBarColor ?? this.progressBarColor,
+      timerSize: timerSize ?? this.timerSize,
+      timerStrokeWidth: timerStrokeWidth ?? this.timerStrokeWidth,
+      timerColor: timerColor ?? this.timerColor,
+      timerContainerColor: timerContainerColor ?? this.timerContainerColor,
+      timerContainerRadius: timerContainerRadius ?? this.timerContainerRadius,
+      timerContainerShadow: timerContainerShadow ?? this.timerContainerShadow,
+      timerTextStyle: timerTextStyle ?? this.timerTextStyle,
+      questionIndexTextStyle:
+          questionIndexTextStyle ?? this.questionIndexTextStyle,
+      questionTextStyle: questionTextStyle ?? this.questionTextStyle,
+      optionTextStyle: optionTextStyle ?? this.optionTextStyle,
+      selectedChipTextStyle:
+          selectedChipTextStyle ?? this.selectedChipTextStyle,
+      selectedChipBackgroundColor:
+          selectedChipBackgroundColor ?? this.selectedChipBackgroundColor,
+      selectedChipRadius: selectedChipRadius ?? this.selectedChipRadius,
+    );
+  }
+}
+
+/// Default visual settings used by the competition screen.
+const CompetitionTheme kDefaultCompetitionTheme = CompetitionTheme();


### PR DESCRIPTION
## Summary
- add `CompetitionTheme` centralizing design options for countdown colors, text styles, cards and more
- comment and refactor `CompetitionScreen` to use the theme and document each part
- theme-aware result screen for consistent styling

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb1a25d48323b0c1a2702ba965bf