### PR TITLE
Limit competition to 20 questions and record results

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -186,7 +186,7 @@ class _PlayScreenState extends State<PlayScreen> {
         break;
       case 6:
         final all = await QuestionLoader.loadENA();
-        final selected = pickAndShuffle(all, 50);
+        final selected = pickAndShuffle(all, 20);
         final indexMap = <String, int>{
           for (int i = 0; i < all.length; i++) all[i].id: i + 1
         };
@@ -200,6 +200,7 @@ class _PlayScreenState extends State<PlayScreen> {
               poolSize: all.length,
               drawCount: selected.length,
               timePerQuestion: 5,
+              startTime: DateTime.now(),
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- Restrict competition sessions to 20 questions and timestamp start of each run
- Track wrong and blank answers, compute duration, and persist results to leaderboard

## Testing
- `dart format lib/screens/competition_screen.dart lib/screens/play_screen.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c9aaf9f883239de279a492695c42