### PR TITLE
Make competition start time optional

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -50,9 +50,9 @@ class CompetitionScreen extends StatefulWidget {
     this.correctCount = 0,
     this.wrongCount = 0,
     this.blankCount = 0,
-    required this.startTime,
+    DateTime? startTime,
     this.theme = kDefaultCompetitionTheme,
-  });
+  }) : startTime = startTime ?? DateTime.now();
 
   @override
   State<CompetitionScreen> createState() => _CompetitionScreenState();


### PR DESCRIPTION
## Summary
- Allow `CompetitionScreen` to initialize its own start time if none provided

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cbc2f3dc8323aa16bf16a11d90a0