### PR TITLE
Add Mobile Money payment service

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ flutter run
 ## Dossiers
 - lib/app/theme.dart – thème (bleu #37478F)
 - lib/services/question_loader.dart – charge JSON + filtre
+- lib/services/mobile_money_service.dart – service de paiement Mobile Money
 - lib/screens/* – Home, Matière, Chapitre, Quiz
 - assets/questions/ena_sample.json – questions de test
 - test/question_parsing_test.dart – test unitaire basique

--- a/lib/services/mobile_money_service.dart
+++ b/lib/services/mobile_money_service.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Service de paiement Mobile Money.
+///
+/// Cette classe fournit une méthode simple pour initier un paiement via
+/// une API REST de Mobile Money. L'URL de l'API et la clé d'authentification
+/// sont injectées afin que le service puisse être facilement configuré et
+/// testé.
+class MobileMoneyPaymentService {
+  final String apiUrl;
+  final String apiKey;
+  final http.Client _client;
+
+  MobileMoneyPaymentService({
+    required this.apiUrl,
+    required this.apiKey,
+    http.Client? client,
+  }) : _client = client ?? http.Client();
+
+  /// Lance un paiement Mobile Money.
+  ///
+  /// Retourne `true` si l'API répond avec un statut `success`.
+  Future<bool> makePayment({
+    required String phoneNumber,
+    required double amount,
+    required String currency,
+  }) async {
+    final response = await _client.post(
+      Uri.parse('$apiUrl/payments'),
+      headers: {
+        'Authorization': 'Bearer $apiKey',
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({
+        'phoneNumber': phoneNumber,
+        'amount': amount,
+        'currency': currency,
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      return data['status'] == 'success';
+    }
+    return false;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -184,7 +184,7 @@ packages:
     source: hosted
     version: "0.15.6"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     path: third_party/flutter_windowmanager
   device_info_plus: ^10.0.0
   confetti: ^0.7.0
+  http: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/mobile_money_service_test.dart
+++ b/test/mobile_money_service_test.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:civexam_app/services/mobile_money_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  test('makePayment returns true on success', () async {
+    final service = MobileMoneyPaymentService(
+      apiUrl: 'https://example.com',
+      apiKey: 'token',
+      client: MockClient((request) async {
+        expect(request.url.toString(), 'https://example.com/payments');
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['phoneNumber'], '0123456789');
+        expect(body['amount'], 10.0);
+        return http.Response(jsonEncode({'status': 'success'}), 200);
+      }),
+    );
+
+    final ok = await service.makePayment(
+      phoneNumber: '0123456789',
+      amount: 10.0,
+      currency: 'XOF',
+    );
+
+    expect(ok, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add HTTP dependency for remote payment API
- implement MobileMoneyPaymentService and unit test
- document new service in README

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ce94a5108323bb4ae6e6a6794837