### PR TITLE
Handle corrupted history entries and test

### DIFF
--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:civexam_app/services/history_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('load skips invalid entries and purges them', () async {
+    final attempt = Attempt(
+      subject: 'Math',
+      chapter: '1',
+      score: 5,
+      total: 10,
+      durationSeconds: 60,
+      timestamp: DateTime.utc(2024, 1, 1),
+    );
+    final valid = jsonEncode(attempt.toMap());
+    const invalid = 'not-json';
+    SharedPreferences.setMockInitialValues({
+      'attempts_v1': [valid, invalid],
+    });
+
+    final attempts = await HistoryService.load();
+    expect(attempts.length, 1);
+    expect(attempts.first.subject, 'Math');
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getStringList('attempts_v1'), [valid]);
+  });
+}


### PR DESCRIPTION
## Summary
- Log and purge corrupted history entries while loading
- Add test covering invalid history entry

## Testing
- `flutter test test/history_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb89b83908832faced885d2bbdc1a4