### PR TITLE
Validate login emails and reject invalid addresses

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,7 +1,9 @@
-import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import '../services/auth_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
 import '../models/design_config.dart';
+import '../services/auth_service.dart';
 import '../services/design_bus.dart';
 import '../widgets/primary_button.dart';
 import 'play_screen.dart';
@@ -50,11 +52,20 @@ class _LoginScreenState extends State<LoginScreen> {
                 children: [
                   TextFormField(
                     controller: _emailController,
+                    keyboardType: TextInputType.emailAddress,
+                    autofillHints: const [AutofillHints.email],
                     decoration: const InputDecoration(labelText: 'Email'),
-                    validator: (value) => value == null ||
-                            value.trim().isEmpty
-                        ? 'Email requis'
-                        : null,
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Email requis';
+                      }
+                      final email = value.trim();
+                      final emailRegex = RegExp(r'^[^@]+@[^@]+[.][^@]+$');
+                      if (!emailRegex.hasMatch(email)) {
+                        return 'Email invalide';
+                      }
+                      return null;
+                    },
                   ),
                   if (!_isLogin)
                     TextFormField(

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -1,0 +1,30 @@
+import 'package:civexam_app/firebase_options.dart';
+import 'package:civexam_app/screens/login_screen.dart';
+import 'package:civexam_app/widgets/primary_button.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  });
+
+  testWidgets('rejects invalid emails', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: LoginScreen()));
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Email'),
+      'invalid',
+    );
+    await tester.enterText(
+      find.widgetWithText(TextFormField, 'Mot de passe'),
+      'password123',
+    );
+    await tester.tap(find.byType(PrimaryButton));
+    await tester.pump();
+    expect(find.text('Email invalide'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- validate email format with regex in login screen
- enable email keyboard type and autofill hints
- add widget test to ensure invalid emails are rejected

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository signatures missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb89b353d8832fb48a96006bf06ac8