### PR TITLE
Disable autocorrect for password field

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -83,6 +83,9 @@ class _LoginScreenState extends State<LoginScreen> {
                     controller: _passwordController,
                     decoration:
                         const InputDecoration(labelText: 'Mot de passe'),
+                    keyboardType: TextInputType.visiblePassword,
+                    autocorrect: false,
+                    enableSuggestions: false,
                     obscureText: true,
                     validator: (value) => value == null ||
                             value.trim().isEmpty


### PR DESCRIPTION
## Summary
- Turn off autocorrect and suggestions in login password field and specify visible password keyboard

## Testing
- `dart format lib/screens/login_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8d104294832fa5ed7fb00459b7a4