### PR TITLE
Add default case for PlayScreen navigation

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -208,6 +208,9 @@ class _PlayScreenState extends State<PlayScreen> {
       case 7:
         Navigator.push(context, MaterialPageRoute(builder: (_) => const LeaderboardScreen()));
         break;
+      default:
+        assert(false, 'Unexpected index: $index');
+        break;
     }
   }
 }


### PR DESCRIPTION
## Summary
- handle unknown navigation indices in PlayScreen with an assertion
- ensure leaderboard option (index 7) navigates correctly

## Testing
- `dart format lib/screens/play_screen.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8d075300832f91169bab30957551