### PR TITLE
Allow RNG injection for deterministic question shuffling

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -9,9 +9,10 @@ final _rng = Random();
 
 /// Retourne une **copie** de la question avec les choix mélangés
 /// et un `answerIndex` recalculé.
-Question shuffleChoices(Question q) {
+Question shuffleChoices(Question q, {Random? rng}) {
+  final r = rng ?? _rng;
   // permutation aléatoire des indices
-  final order = List.generate(q.choices.length, (i) => i)..shuffle(_rng);
+  final order = List.generate(q.choices.length, (i) => i)..shuffle(r);
 
   final newChoices = <String>[];
   int newAnswer = 0;
@@ -36,11 +37,11 @@ Question shuffleChoices(Question q) {
 
 /// Sélectionne jusqu'à `take` questions **au hasard**, puis mélange l'ordre
 /// des questions et des choix.
-List<Question> pickAndShuffle(List<Question> pool, int take) {
+List<Question> pickAndShuffle(List<Question> pool, int take, {Random? rng}) {
+  final r = rng ?? _rng;
   if (pool.isEmpty) return const <Question>[];
-  final copy = List<Question>.from(pool)..shuffle(_rng);
+  final copy = List<Question>.from(pool)..shuffle(r);
   final n = take <= copy.length ? take : copy.length;
-  final selected = copy.take(n).map(shuffleChoices).toList();
-  selected.shuffle(_rng);
+  final selected = copy.take(n).map((q) => shuffleChoices(q, rng: r)).toList();
   return selected;
 }

--- a/test/question_loader_test.dart
+++ b/test/question_loader_test.dart
@@ -1,8 +1,11 @@
 import 'dart:convert';
+import 'dart:math';
 import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:civexam_app/models/question.dart';
 import 'package:civexam_app/services/question_loader.dart';
+import 'package:civexam_app/services/question_randomizer.dart';
 
 void main() {
   final binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -58,5 +61,49 @@ void main() {
     mockAssets({});
 
     await expectLater(QuestionLoader.loadENA(), throwsException);
+  });
+
+  test('pickAndShuffle is deterministic with injected Random', () {
+    final pool = [
+      const Question(
+        id: 'Q1',
+        concours: 'ENA',
+        subject: 'S',
+        chapter: 'C',
+        difficulty: 1,
+        question: '1?',
+        choices: ['A', 'B'],
+        answerIndex: 0,
+      ),
+      const Question(
+        id: 'Q2',
+        concours: 'ENA',
+        subject: 'S',
+        chapter: 'C',
+        difficulty: 1,
+        question: '2?',
+        choices: ['C', 'D'],
+        answerIndex: 1,
+      ),
+      const Question(
+        id: 'Q3',
+        concours: 'ENA',
+        subject: 'S',
+        chapter: 'C',
+        difficulty: 1,
+        question: '3?',
+        choices: ['E', 'F'],
+        answerIndex: 0,
+      ),
+    ];
+
+    final r1 = Random(1);
+    final r2 = Random(1);
+
+    final res1 = pickAndShuffle(pool, 3, rng: r1);
+    final res2 = pickAndShuffle(pool, 3, rng: r2);
+
+    expect(res1.map((q) => q.id).toList(), res2.map((q) => q.id).toList());
+    expect(res1.first.choices, res2.first.choices);
   });
 }


### PR DESCRIPTION
## Summary
- inject optional `Random` into question randomizer and drop redundant shuffle
- add deterministic shuffling test

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e660148832f8b2aa53522f1ffec