### PR TITLE
Handle auth errors with custom AuthException

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -144,7 +143,7 @@ class _LoginScreenState extends State<LoginScreen> {
         context,
         MaterialPageRoute(builder: (_) => const PlayScreen()),
       );
-    } on FirebaseAuthException catch (e) {
+    } on AuthException catch (e) {
       if (mounted) setState(() => _error = e.message);
     } catch (e) {
       if (mounted) {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,24 +1,61 @@
 import 'package:firebase_auth/firebase_auth.dart';
 
+/// Exception thrown for authentication failures with a user-friendly message.
+class AuthException implements Exception {
+  final String message;
+  AuthException(this.message);
+
+  @override
+  String toString() => 'AuthException: $message';
+}
+
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
   Stream<User?> get authStateChanges => _auth.authStateChanges();
 
-  Future<UserCredential> signInWithEmail(String email, String password) {
-    return _auth.signInWithEmailAndPassword(email: email, password: password);
+  Future<UserCredential> signInWithEmail(String email, String password) async {
+    try {
+      return await _auth.signInWithEmailAndPassword(
+          email: email, password: password);
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(_messageFromCode(e.code));
+    }
   }
 
   Future<UserCredential> registerWithEmail(
       String email, String password, String name) async {
-    final userCredential =
-        await _auth.createUserWithEmailAndPassword(email: email, password: password);
-    await userCredential.user?.updateDisplayName(name);
-    await userCredential.user?.reload();
-    return userCredential;
+    try {
+      final userCredential = await _auth.createUserWithEmailAndPassword(
+          email: email, password: password);
+      await userCredential.user?.updateDisplayName(name);
+      await userCredential.user?.reload();
+      return userCredential;
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(_messageFromCode(e.code));
+    }
   }
 
   Future<void> signOut() {
     return _auth.signOut();
+  }
+
+  String _messageFromCode(String code) {
+    switch (code) {
+      case 'invalid-email':
+        return 'Email invalide';
+      case 'user-disabled':
+        return 'Utilisateur désactivé';
+      case 'user-not-found':
+        return 'Utilisateur introuvable';
+      case 'wrong-password':
+        return 'Mot de passe incorrect';
+      case 'email-already-in-use':
+        return 'Email déjà utilisé';
+      case 'weak-password':
+        return 'Mot de passe trop faible';
+      default:
+        return "Erreur d'authentification";
+    }
   }
 }


### PR DESCRIPTION
## Summary
- wrap sign-in and registration with try/catch and raise AuthException with friendly messages
- handle AuthException in login screen and remove direct FirebaseAuth usage

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e64ba24832faa2fa4ed4eec74d5