### PR TITLE
Dispose HTTP client in MobileMoneyPaymentService

### DIFF
--- a/lib/services/mobile_money_service.dart
+++ b/lib/services/mobile_money_service.dart
@@ -72,4 +72,9 @@ class MobileMoneyPaymentService {
       throw PaymentException('Délai d\'attente dépassé');
     }
   }
+
+  /// Ferme le client HTTP sous-jacent.
+  void dispose() {
+    _client.close();
+  }
 }

--- a/test/mobile_money_service_test.dart
+++ b/test/mobile_money_service_test.dart
@@ -26,6 +26,8 @@ void main() {
     );
 
     expect(ok, isTrue);
+
+    service.dispose();
   });
 
   test('makePayment returns false on 4xx response', () async {
@@ -44,6 +46,8 @@ void main() {
     );
 
     expect(ok, isFalse);
+
+    service.dispose();
   });
 
   test('makePayment returns false on 5xx response', () async {
@@ -62,6 +66,8 @@ void main() {
     );
 
     expect(ok, isFalse);
+
+    service.dispose();
   });
 
   test('makePayment throws PaymentException on timeout', () async {
@@ -74,14 +80,16 @@ void main() {
       }),
     );
 
-    expect(
-      () => service.makePayment(
+    await expectLater(
+      service.makePayment(
         phoneNumber: '0123456789',
         amount: 10.0,
         currency: 'XOF',
       ),
       throwsA(isA<PaymentException>()),
     );
+
+    service.dispose();
   });
 
   test('makePayment throws PaymentException on invalid JSON', () async {
@@ -93,13 +101,15 @@ void main() {
       }),
     );
 
-    expect(
-      () => service.makePayment(
+    await expectLater(
+      service.makePayment(
         phoneNumber: '0123456789',
         amount: 10.0,
         currency: 'XOF',
       ),
       throwsA(isA<PaymentException>()),
     );
+
+    service.dispose();
   });
 }


### PR DESCRIPTION
## Summary
- add dispose method to `MobileMoneyPaymentService`
- ensure mobile money tests dispose service when finished

## Testing
- `flutter test test/mobile_money_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb8e63d4c4832f8c20d8287e8c6905