### PR TITLE
Store attempt timestamps in UTC

### DIFF
--- a/lib/screens/history_screen.dart
+++ b/lib/screens/history_screen.dart
@@ -74,12 +74,13 @@ class _HistoryScreenState extends State<HistoryScreen> {
                   itemBuilder: (_, i) {
                     final a = attempts[i];
                     final pct = (a.score / a.total * 100).toStringAsFixed(0);
+                    final date = a.timestamp.toLocal();
                     return Card(
                       child: ListTile(
                         title: Text('${a.subject} > ${a.chapter}'),
                         subtitle: Text('Score: ${a.score}/${a.total} • ${pct}% • Durée: ${_formatDuration(a.durationSeconds)}'),
                         trailing: Text(
-                          '${a.timestamp.day.toString().padLeft(2, '0')}/${a.timestamp.month.toString().padLeft(2, '0')}/${a.timestamp.year}'
+                          '${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')}/${date.year}'
                         ),
                       ),
                     );

--- a/lib/services/history_service.dart
+++ b/lib/services/history_service.dart
@@ -25,7 +25,7 @@ class Attempt {
     'score': score,
     'total': total,
     'durationSeconds': durationSeconds,
-    'timestamp': timestamp.toIso8601String(),
+    'timestamp': timestamp.toUtc().toIso8601String(),
   };
 
   factory Attempt.fromMap(Map<String, dynamic> m) => Attempt(
@@ -34,7 +34,7 @@ class Attempt {
     score: (m['score'] as num).toInt(),
     total: (m['total'] as num).toInt(),
     durationSeconds: (m['durationSeconds'] as num).toInt(),
-    timestamp: DateTime.parse(m['timestamp'] as String),
+    timestamp: DateTime.parse(m['timestamp'] as String).toUtc(),
   );
 }
 

--- a/test/history_service_test.dart
+++ b/test/history_service_test.dart
@@ -25,6 +25,7 @@ void main() {
     final attempts = await HistoryService.load();
     expect(attempts.length, 1);
     expect(attempts.first.subject, 'Math');
+    expect(attempts.first.timestamp.isUtc, true);
 
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getStringList('attempts_v1'), [valid]);


### PR DESCRIPTION
## Summary
- ensure attempt timestamps are stored in UTC
- parse saved timestamps as UTC
- display timestamps in local time on history screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e60ea78832f9ce0e4b76268e372