### PR TITLE
Handle FirebaseAuth errors in auth service

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -144,7 +143,7 @@ class _LoginScreenState extends State<LoginScreen> {
         context,
         MaterialPageRoute(builder: (_) => const PlayScreen()),
       );
-    } on FirebaseAuthException catch (e) {
+    } on AuthException catch (e) {
       if (mounted) setState(() => _error = e.message);
     } catch (e) {
       if (mounted) {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,21 +1,38 @@
 import 'package:firebase_auth/firebase_auth.dart';
 
+class AuthException implements Exception {
+  final String message;
+  AuthException(this.message);
+
+  @override
+  String toString() => 'AuthException: $message';
+}
+
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
   Stream<User?> get authStateChanges => _auth.authStateChanges();
 
-  Future<UserCredential> signInWithEmail(String email, String password) {
-    return _auth.signInWithEmailAndPassword(email: email, password: password);
+  Future<UserCredential> signInWithEmail(String email, String password) async {
+    try {
+      return await _auth.signInWithEmailAndPassword(
+          email: email, password: password);
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.message ?? 'Erreur de connexion');
+    }
   }
 
   Future<UserCredential> registerWithEmail(
       String email, String password, String name) async {
-    final userCredential =
-        await _auth.createUserWithEmailAndPassword(email: email, password: password);
-    await userCredential.user?.updateDisplayName(name);
-    await userCredential.user?.reload();
-    return userCredential;
+    try {
+      final userCredential = await _auth.createUserWithEmailAndPassword(
+          email: email, password: password);
+      await userCredential.user?.updateDisplayName(name);
+      await userCredential.user?.reload();
+      return userCredential;
+    } on FirebaseAuthException catch (e) {
+      throw AuthException(e.message ?? "Erreur d'enregistrement");
+    }
   }
 
   Future<void> signOut() {


### PR DESCRIPTION
## Summary
- add `AuthException` to surface friendly messages
- wrap email sign-in and registration with `FirebaseAuthException` try/catch
- adjust login screen to handle `AuthException`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e5e9170832fb5ed2dbf812b57a0