### PR TITLE
Handle non-list question choices safely

### DIFF
--- a/lib/models/question.dart
+++ b/lib/models/question.dart
@@ -22,7 +22,10 @@ class Question {
   });
 
   factory Question.fromMap(Map<String, dynamic> map) {
-    final choices = (map['choices'] as List).map((e) => e.toString()).toList(growable: false);
+    final rawChoices = map['choices'];
+    final choices = rawChoices is List
+        ? rawChoices.map((e) => e.toString()).toList(growable: false)
+        : const <String>[];
     return Question(
       id: map['id']?.toString() ?? '',
       concours: map['concours']?.toString() ?? '',


### PR DESCRIPTION
## Summary
- Sanitize `Question.fromMap` choices by validating list type and defaulting to an empty list when absent.

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e5dc46c832f8b8b0a97e0648b9d