### PR TITLE
Handle missing firebase options in CloudSync initialization

### DIFF
--- a/lib/services/cloud_sync.dart
+++ b/lib/services/cloud_sync.dart
@@ -27,10 +27,20 @@ class CloudSync {
     if (_ready || _initTried) return _ready;
     try {
       if (Firebase.apps.isEmpty) {
-        await firebase_options.loadLibrary();
-        await Firebase.initializeApp(
-          options: firebase_options.DefaultFirebaseOptions.currentPlatform,
-        );
+        FirebaseOptions? options;
+        try {
+          await firebase_options.loadLibrary();
+          options = firebase_options.DefaultFirebaseOptions.currentPlatform;
+        } catch (e) {
+          if (kDebugMode) {
+            debugPrint('[CloudSync] firebase_options.dart not found: $e');
+          }
+        }
+        if (options != null) {
+          await Firebase.initializeApp(options: options);
+        } else {
+          await Firebase.initializeApp();
+        }
       }
       await _ensureSignedIn();
       _ready = true;


### PR DESCRIPTION
## Summary
- load `firebase_options` dynamically and fall back to default initialization when unavailable

## Testing
- `dart format lib/services/cloud_sync.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e5c54b8832f90e43cdc2ba426f7