### PR TITLE
Use Timer for splash navigation

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:firebase_auth/firebase_auth.dart';
@@ -14,10 +15,12 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> {
+  Timer? _timer;
+
   @override
   void initState() {
     super.initState();
-    Future.delayed(const Duration(seconds: 2), () {
+    _timer = Timer(const Duration(seconds: 2), () {
       if (!mounted) return;
       final user = FirebaseAuth.instance.currentUser;
       final next = user == null ? const LoginScreen() : const PlayScreen();
@@ -25,6 +28,12 @@ class _SplashScreenState extends State<SplashScreen> {
         MaterialPageRoute(builder: (_) => next),
       );
     });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
## Summary
- Replace Future.delayed with a Timer stored in a private field for splash screen navigation
- Cancel the timer in dispose and guard navigation with mounted check

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e547f88832fae9739d91d1ba09d