### PR TITLE
Await showDialog calls across exam screens

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -308,7 +308,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
       return;
     }
 
-    showDialog(
+    await showDialog(
       context: context,
       barrierDismissible: false,
       builder: (_) => AlertDialog(

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -232,7 +232,7 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
     );
     await HistoryStore.add(entry);
 
-    showDialog(
+    await showDialog(
       context: context,
       builder: (_) => AlertDialog(
         title: Text(abandoned ? 'Concours abandonné' : 'Résumé du concours — ${difficultyLabel(_difficulty)}'),

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -176,7 +176,7 @@ class _PlayScreenState extends State<PlayScreen> {
         Navigator.push(context, MaterialPageRoute(builder: (_) => const TrainingHistoryScreen()));
         break;
       case 5:
-        showDialog(
+        await showDialog(
           context: context,
           builder: (_) => const AlertDialog(
             title: Text('Comment ça marche ?'),


### PR DESCRIPTION
## Summary
- Ensure play screen info dialog awaits completion in navigation
- Await summary dialog after multi-exam flow finalization
- Await final results dialog in full exam screen submissions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e5272c8832fb5b6813ea10653a2