### PR TITLE
Configure Android release package ID and signing

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.civexam_app"
+    namespace = "com.company.civexam"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -20,8 +20,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.civexam_app"
+        applicationId = "com.company.civexam"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -30,11 +29,18 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file("civexam-release.jks")
+            storePassword = "password"
+            keyAlias = "civexam"
+            keyPassword = "password"
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 }


### PR DESCRIPTION
## Summary
- set `com.company.civexam` as final application ID and namespace
- add release signing configuration using a keystore and remove debug signing

## Testing
- `gradle assembleRelease` *(fails: Error resolving plugin 'dev.flutter.flutter-plugin-loader', Flutter SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e50d4f0832f98ed2e87d6d9e2de