### PR TITLE
chore: remove outdated TODO in desktop CMake scripts

### DIFF
--- a/linux/flutter/CMakeLists.txt
+++ b/linux/flutter/CMakeLists.txt
@@ -5,10 +5,6 @@ set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 
 # Configuration provided via flutter tool.
 include(${EPHEMERAL_DIR}/generated_config.cmake)
-
-# TODO: Move the rest of this into files in ephemeral. See
-# https://github.com/flutter/flutter/issues/57146.
-
 # Serves the same purpose as list(TRANSFORM ... PREPEND ...),
 # which isn't available in 3.10.
 function(list_prepend LIST_NAME PREFIX)

--- a/windows/flutter/CMakeLists.txt
+++ b/windows/flutter/CMakeLists.txt
@@ -5,9 +5,6 @@ set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
 
 # Configuration provided via flutter tool.
 include(${EPHEMERAL_DIR}/generated_config.cmake)
-
-# TODO: Move the rest of this into files in ephemeral. See
-# https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
 # Set fallback configurations for older versions of the flutter tool.


### PR DESCRIPTION
## Summary
- remove obsolete TODO comment referencing flutter/flutter#57146 from Linux CMake
- remove same TODO from Windows CMake

## Testing
- `flutter build linux` *(fails: command not found)*
- `flutter build windows` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e50d4a0832fb4d45b997b9bc4e9