### PR TITLE
feat: sync play icon gradients with theme palette

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -4,7 +4,8 @@ import '../utils/palette_utils.dart';
 
 /// Builds the global [ThemeData] based on the chosen palette and mode.
 ThemeData buildAppTheme(DesignConfig cfg) {
-  final accent = accentColor(cfg.bgPaletteName);
+  final iconColors = playIconColors(cfg.bgPaletteName);
+  final accent = iconColors.first;
   final complement = complementaryColor(cfg.bgPaletteName);
   final brightness = cfg.darkMode ? Brightness.dark : Brightness.light;
   final textColor =
@@ -37,7 +38,7 @@ ThemeData buildAppTheme(DesignConfig cfg) {
   return base.copyWith(
     textTheme: textTheme,
     iconTheme: IconThemeData(
-      color: darkerAccentColor(cfg.bgPaletteName),
+      color: iconColors.last,
     ),
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -38,6 +38,7 @@ class _PlayScreenState extends State<PlayScreen> {
             : 'Bienvenue 👋  •  Choisis un mode';
         final textColor =
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
+        final gradientColors = playIconColors(cfg.bgPaletteName);
 
         return Scaffold(
           extendBody: true,
@@ -101,6 +102,7 @@ class _PlayScreenState extends State<PlayScreen> {
                                 size: cfg.tileIconSize,
                                 useMono: cfg.useMono,
                                 monoColor: cfg.monoColor,
+                                gradientColors: gradientColors,
                               ),
                               const SizedBox(width: 12),
                               Expanded(
@@ -135,7 +137,7 @@ class _PlayScreenState extends State<PlayScreen> {
                         return _GlassTile(
                           title: item.title,
                           icon: item.icon,
-                          gradientColors: item.gradientColors,
+                          gradientColors: gradientColors,
                           blur: cfg.glassBlur,
                           bgOpacity: cfg.glassBgOpacity,
                           borderOpacity: cfg.glassBorderOpacity,
@@ -382,16 +384,18 @@ class _IconBadge extends StatelessWidget {
     this.size = 52,
     required this.useMono,
     required this.monoColor,
+    required this.gradientColors,
   });
   final IconData icon;
   final double size;
   final bool useMono;
   final Color monoColor;
+   final List<Color> gradientColors;
   @override
   Widget build(BuildContext context) {
-    final gradientColors = useMono
+    final colors = useMono
         ? [monoColor.withOpacity(0.15), monoColor.withOpacity(0.35)]
-        : const [Color(0xFFFFB25E), Color(0xFFFF7A00)];
+        : gradientColors;
     final iconColor = useMono ? monoColor : Colors.white;
     return Container(
       height: size,
@@ -401,7 +405,7 @@ class _IconBadge extends StatelessWidget {
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: gradientColors,
+          colors: colors,
         ),
       ),
       child: Icon(icon, size: size * 0.58, color: iconColor),
@@ -412,25 +416,16 @@ class _IconBadge extends StatelessWidget {
 class _MenuItem {
   final String title;
   final IconData icon;
-  final List<Color> gradientColors;
-  const _MenuItem(this.title, this.icon, this.gradientColors);
+  const _MenuItem(this.title, this.icon);
 }
 
 const _items = <_MenuItem>[
-  _MenuItem("S'entraîner", Icons.play_circle_fill_rounded,
-      [Color(0xFFFFB25E), Color(0xFFFF7A00)]),
-  _MenuItem('Concours ENA', Icons.school_rounded,
-      [Color(0xFF42A5F5), Color(0xFF1E88E5)]),
-  _MenuItem('Par matière', Icons.menu_book_rounded,
-      [Color(0xFF66BB6A), Color(0xFF2E7D32)]),
-  _MenuItem('Historique examens', Icons.fact_check_rounded,
-      [Color(0xFFAB47BC), Color(0xFF8E24AA)]),
-  _MenuItem("Historique entraînement", Icons.history_rounded,
-      [Color(0xFFFF7043), Color(0xFFD84315)]),
-  _MenuItem('Comment ça marche ?', Icons.info_rounded,
-      [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
-  _MenuItem('Compétition', Icons.sports_kabaddi,
-      [Color(0xFFFFEE58), Color(0xFFFDD835)]),
-  _MenuItem('Classement', Icons.emoji_events_outlined,
-      [Color(0xFFEC407A), Color(0xFFD81B60)]),
+  _MenuItem("S'entraîner", Icons.play_circle_fill_rounded),
+  _MenuItem('Concours ENA', Icons.school_rounded),
+  _MenuItem('Par matière', Icons.menu_book_rounded),
+  _MenuItem('Historique examens', Icons.fact_check_rounded),
+  _MenuItem("Historique entraînement", Icons.history_rounded),
+  _MenuItem('Comment ça marche ?', Icons.info_rounded),
+  _MenuItem('Compétition', Icons.sports_kabaddi),
+  _MenuItem('Classement', Icons.emoji_events_outlined),
 ];

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -69,6 +69,25 @@ Color darken(Color color, [double amount = 0.1]) {
 Color darkerAccentColor(String name, [double amount = 0.2]) =>
     darken(accentColor(name), amount);
 
+/// Gradient colors used for PlayScreen icons based on the active palette.
+///
+/// Returns a pair of colors where the first color should match the
+/// [accentColor] for the palette so that the UI theme and the play icons share
+/// the same hue. If the [paletteName] is unknown, it falls back to the original
+/// PlayScreen gradient.
+List<Color> playIconColors(String paletteName) {
+  const fallback = [Color(0xFFFFB25E), Color(0xFFFF7A00)];
+  final accent = accentColor(paletteName);
+
+  // If the palette name is not recognized, accentColor returns the offWhite
+  // color. In that case, preserve the legacy gradient from the PlayScreen.
+  if (accent.value == const Color(0xFFF5F5F5).value && paletteName != 'offWhite') {
+    return fallback;
+  }
+
+  return [accent, darkerAccentColor(paletteName)];
+}
+
 /// Returns two pastel variants of the accent color for gradient backgrounds.
 List<Color> pastelColors(String name, {bool darkMode = false}) {
   switch (name) {


### PR DESCRIPTION
## Summary
- add `playIconColors` to map palette names to play screen icon gradients
- drive play screen tiles and header icon from palette-based gradients
- seed app theme from icon gradient so icons and theme share the same hue

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4ed7ac50832f985c9e9cbe08ddd2