### PR TITLE
Redirect multi-exam option through official intro

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -8,7 +8,7 @@ import '../services/design_bus.dart';
 import '../utils/palette_utils.dart';
 
 import 'training_quick_start.dart';
-import 'multi_exam_flow.dart';
+import 'official_intro_screen.dart';
 import 'subject_list_screen.dart';
 import 'training_history_screen.dart';
 import 'exam_history_screen.dart';
@@ -166,7 +166,7 @@ class _PlayScreenState extends State<PlayScreen> {
         Navigator.push(context, MaterialPageRoute(builder: (_) => const TrainingQuickStartScreen()));
         break;
       case 1:
-        Navigator.push(context, MaterialPageRoute(builder: (_) => const MultiExamFlowScreen()));
+        Navigator.push(context, MaterialPageRoute(builder: (_) => const OfficialIntroScreen()));
         break;
       case 2:
         Navigator.push(context, MaterialPageRoute(builder: (_) => const SubjectListScreen()));

--- a/test/official_intro_screen_test.dart
+++ b/test/official_intro_screen_test.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:civexam_app/screens/official_intro_screen.dart';
+import 'package:civexam_app/screens/multi_exam_flow.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  ByteData _stringToByteData(String value) {
+    final list = utf8.encode(value);
+    final buffer = Uint8List.fromList(list).buffer;
+    return ByteData.view(buffer);
+  }
+
+  setUp(() {
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (message) async {
+      final key = utf8.decode(message!.buffer.asUint8List());
+      if (key == 'assets/questions/civexam_questions_ena_core.json') {
+        final sample = '[{"id":"Q1","concours":"ENA","subject":"S","chapter":"C","difficulty":1,"question":"Q?","choices":["A","B"],"answerIndex":0}]';
+        return _stringToByteData(sample);
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    binding.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', null);
+  });
+
+  testWidgets('navigates to MultiExamFlow after countdown', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: OfficialIntroScreen()));
+
+    // Accept rules
+    await tester.tap(find.byType(Checkbox));
+    await tester.pumpAndSettle();
+
+    // Start countdown
+    await tester.tap(find.text('Démarrer la simulation officielle'));
+    await tester.pump();
+
+    // Wait for countdown to finish
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MultiExamFlowScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- route "multi-exam" tile on the play screen to `OfficialIntroScreen`
- add widget test verifying intro countdown launches `MultiExamFlowScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc54360b30832f804d8b864cc2c50c