### PR TITLE
Remove unused subjectIndex from SubjectListScreen

### DIFF
--- a/README_SubjectList_Fix.txt
+++ b/README_SubjectList_Fix.txt
@@ -1,14 +1,11 @@
-Ce mini-patch corrige l'erreur :
-No named parameter with the name 'subjectIndex' pour SubjectListScreen.
+Ce mini-patch supprime l'ancien paramètre `subjectIndex` du constructeur
+`SubjectListScreen`.
 
 Changement :
-- Ajout d'un paramètre optionnel `subjectIndex` au constructeur
-  (il est ignoré si non utilisé dans l'écran).
+- retrait de `subjectIndex`, désormais inutile.
 
-Application :
-1) Remplacez `lib/screens/subject_list_screen.dart` par ce fichier.
-2) Hot restart.
+Migration :
+- Remplacez les anciens appels `SubjectListScreen(subjectIndex: index)` par
+  `const SubjectListScreen()`.
 
-Compatibilité :
-- Les anciens appels `SubjectListScreen(subjectIndex: index)` compilent à nouveau.
-- Le comportement visuel reste identique (liste des matières + navigation).
+Le comportement visuel reste identique (liste des matières + navigation).

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -7,11 +7,8 @@ import '../utils/palette_utils.dart';
 import 'chapter_list_screen.dart';
 
 /// Liste des matières ENA
-/// Ajout : [subjectIndex] optionnel pour compatibilité avec les anciens appels
-/// (ex: SubjectListScreen(subjectIndex: index)).
 class SubjectListScreen extends StatelessWidget {
-  final int? subjectIndex;
-  const SubjectListScreen({super.key, this.subjectIndex});
+  const SubjectListScreen({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- remove obsolete `subjectIndex` parameter from `SubjectListScreen`
- document removal of `subjectIndex`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc578b74cc832fba104502af394730