### PR TITLE
feat: expand firebase options for platforms

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,10 +1,74 @@
+// ignore_for_file: lines_longer_than_80_chars, avoid_classes_with_only_static_members
+
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
 
 class DefaultFirebaseOptions {
-  static FirebaseOptions get currentPlatform => const FirebaseOptions(
-        apiKey: 'AIzaSyATko5Si9KUY3y3Auz-Ow-tpTMkktjEt8E',
-        appId: '1:78598100276:android:753a0038044fca59d3c161',
-        messagingSenderId: '78598100276',
-        projectId: 'civexam-bfc8d',
-      );
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      case TargetPlatform.windows:
+        return windows;
+      case TargetPlatform.linux:
+        return linux;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not supported for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: '',
+    appId: '',
+    messagingSenderId: '',
+    projectId: '',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'AIzaSyDWgRCw51mY8n4ZiX257UlEVxG9F_1D9ac',
+    appId: '1:339452590323:android:8157ff3781f38b4b0b9f86',
+    messagingSenderId: '339452590323',
+    projectId: 'civexam-bf521',
+    storageBucket: 'civexam-bf521.firebasestorage.app',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: '',
+    appId: '',
+    messagingSenderId: '',
+    projectId: '',
+    iosBundleId: '',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: '',
+    appId: '',
+    messagingSenderId: '',
+    projectId: '',
+    iosBundleId: '',
+  );
+
+  static const FirebaseOptions windows = FirebaseOptions(
+    apiKey: '',
+    appId: '',
+    messagingSenderId: '',
+    projectId: '',
+  );
+
+  static const FirebaseOptions linux = FirebaseOptions(
+    apiKey: '',
+    appId: '',
+    messagingSenderId: '',
+    projectId: '',
+  );
 }
+


### PR DESCRIPTION
## Summary
- expand `firebase_options.dart` with stubs for all supported platforms, filling Android values from `google-services.json`
- ensure initialization uses `DefaultFirebaseOptions.currentPlatform`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d5a7f50832facb32186a5ed44f7