### PR TITLE
chore: register splash logo asset

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ flutter:
   assets:
     - assets/questions/           # <-- inclut tout le dossier questions
     - assets/images/logo_splash_square.png
+    - assets/images/logo_splash.png
     - assets/images/logo_icon_square.png
     - assets/icons/
 


### PR DESCRIPTION
## Summary
- reference logo_splash.png in Flutter assets

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d547348832fa38341ea3b4b6b68