### PR TITLE
refactor: await auth state before navigating

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -15,25 +15,19 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> {
-  Timer? _timer;
-
   @override
   void initState() {
     super.initState();
-    _timer = Timer(const Duration(seconds: 2), () {
-      if (!mounted) return;
-      final user = FirebaseAuth.instance.currentUser;
-      final next = user == null ? const LoginScreen() : const PlayScreen();
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => next),
-      );
-    });
+    _navigate();
   }
 
-  @override
-  void dispose() {
-    _timer?.cancel();
-    super.dispose();
+  Future<void> _navigate() async {
+    final User? user = await FirebaseAuth.instance.authStateChanges().first;
+    if (!mounted) return;
+    final next = user == null ? const LoginScreen() : const PlayScreen();
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => next),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- remove timer from splash screen
- wait for auth state before navigating to login or play screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bc657101bc832f848279de5f517be2