### PR TITLE
refactor: extract reusable glass tile widget

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -1,11 +1,11 @@
 // lib/screens/play_screen.dart — Live design via DesignBus + centrage tuiles + taille icône
-import 'dart:ui' show ImageFilter;
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
 import '../utils/palette_utils.dart';
+import '../widgets/glass_tile.dart';
 
 import 'training_quick_start.dart';
 import 'official_intro_screen.dart';
@@ -89,7 +89,7 @@ class _PlayScreenState extends State<PlayScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                      _GlassCard(
+                      GlassCard(
                         blur: cfg.glassBlur,
                         backgroundOpacity: cfg.glassBgOpacity,
                         borderOpacity: cfg.glassBorderOpacity,
@@ -134,7 +134,7 @@ class _PlayScreenState extends State<PlayScreen> {
                       itemCount: _items.length,
                       itemBuilder: (context, i) {
                         final item = _items[i];
-                        return _GlassTile(
+                        return GlassTile(
                           title: item.title,
                           icon: item.icon,
                           gradientColors: gradientColors,
@@ -223,158 +223,6 @@ class _PlayScreenState extends State<PlayScreen> {
         assert(false, 'Unexpected index: $index');
         break;
     }
-  }
-}
-
-// ---- Widgets “glass” ----
-class _GlassTile extends StatefulWidget {
-  const _GlassTile({
-    required this.title,
-    required this.icon,
-    required this.gradientColors,
-    required this.onTap,
-    required this.blur,
-    required this.bgOpacity,
-    required this.borderOpacity,
-    required this.iconSize,
-    required this.centerContent,
-    required this.useMono,
-    required this.monoColor,
-    required this.textColor,
-  });
-  final String title;
-  final IconData icon;
-  final List<Color> gradientColors;
-  final VoidCallback onTap;
-  final double blur;
-  final double bgOpacity;
-  final double borderOpacity;
-  final double iconSize;
-  final bool centerContent;
-  final bool useMono;
-  final Color monoColor;
-  final Color textColor;
-
-  @override
-  State<_GlassTile> createState() => _GlassTileState();
-}
-
-class _GlassTileState extends State<_GlassTile> {
-  bool _pressed = false;
-  @override
-  Widget build(BuildContext context) {
-    final gradientColors = widget.useMono
-        ? [
-            widget.monoColor.withOpacity(0.15),
-            widget.monoColor.withOpacity(0.35)
-          ]
-        : widget.gradientColors;
-
-    final iconColor = widget.useMono ? widget.monoColor : Colors.white;
-
-    final iconBadge = Container(
-      height: widget.iconSize,
-      width: widget.iconSize,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: gradientColors,
-        ),
-        border: Border.all(color: Colors.white.withOpacity(0.25)),
-      ),
-      child: Icon(widget.icon, size: widget.iconSize * 0.58, color: iconColor),
-    );
-
-    final title = Text(
-      widget.title,
-      textAlign: widget.centerContent ? TextAlign.center : TextAlign.left,
-      style: TextStyle(
-        fontSize: 20,
-        height: 1.15,
-        fontWeight: FontWeight.w800,
-        color: widget.textColor,
-      ),
-      maxLines: 2,
-      overflow: TextOverflow.ellipsis,
-    );
-
-    return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapCancel: () => setState(() => _pressed = false),
-      onTapUp: (_) => setState(() => _pressed = false),
-      onTap: widget.onTap,
-      child: AnimatedScale(
-        duration: const Duration(milliseconds: 110),
-        curve: Curves.easeOut,
-        scale: _pressed ? 0.98 : 1.0,
-        child: _GlassCard(
-          blur: widget.blur,
-          backgroundOpacity: widget.bgOpacity,
-          borderOpacity: widget.borderOpacity,
-          child: Padding(
-            padding: const EdgeInsets.all(18),
-            child: widget.centerContent
-                ? Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      iconBadge,
-                      const SizedBox(height: 12),
-                      title,
-                    ],
-                  )
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Align(alignment: Alignment.topLeft, child: iconBadge),
-                      const Spacer(),
-                      title,
-                    ],
-                  ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _GlassCard extends StatelessWidget {
-  const _GlassCard({
-    required this.child,
-    this.blur = 16,
-    this.backgroundOpacity = 0.16,
-    this.borderOpacity = 0.22,
-  });
-  final Widget child;
-  final double blur;
-  final double backgroundOpacity;
-  final double borderOpacity;
-
-  @override
-  Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(22),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
-        child: Container(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-              colors: [
-                Colors.white.withOpacity(backgroundOpacity + 0.05),
-                Colors.white.withOpacity(backgroundOpacity),
-              ],
-            ),
-            border: Border.all(color: Colors.white.withOpacity(borderOpacity), width: 1.2),
-            borderRadius: BorderRadius.circular(22),
-          ),
-          child: child,
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -1,9 +1,9 @@
-import 'dart:ui' show ImageFilter;
 import 'package:flutter/material.dart';
 import '../data/ena_taxonomy.dart';
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
 import '../utils/palette_utils.dart';
+import '../widgets/glass_tile.dart';
 import 'chapter_list_screen.dart';
 
 /// Liste des matières ENA
@@ -41,7 +41,7 @@ class SubjectListScreen extends StatelessWidget {
                 itemBuilder: (context, index) {
                   final subject = subjectsENA[index];
                   final item = _subjectItems[index];
-                  return _GlassTile(
+                  return GlassTile(
                     title: subject.name,
                     icon: item.icon,
                     gradientColors: item.gradientColors,
@@ -91,155 +91,3 @@ const _subjectItems = <_SubjectItem>[
   _SubjectItem(Icons.menu_book, [Color(0xFFFF7043), Color(0xFFD84315)]),
   _SubjectItem(Icons.extension, [Color(0xFF26C6DA), Color(0xFF00ACC1)]),
 ];
-
-class _GlassTile extends StatefulWidget {
-  const _GlassTile({
-    required this.title,
-    required this.icon,
-    required this.gradientColors,
-    required this.onTap,
-    required this.blur,
-    required this.bgOpacity,
-    required this.borderOpacity,
-    required this.iconSize,
-    required this.centerContent,
-    required this.useMono,
-    required this.monoColor,
-    required this.textColor,
-  });
-  final String title;
-  final IconData icon;
-  final List<Color> gradientColors;
-  final VoidCallback onTap;
-  final double blur;
-  final double bgOpacity;
-  final double borderOpacity;
-  final double iconSize;
-  final bool centerContent;
-  final bool useMono;
-  final Color monoColor;
-  final Color textColor;
-
-  @override
-  State<_GlassTile> createState() => _GlassTileState();
-}
-
-class _GlassTileState extends State<_GlassTile> {
-  bool _pressed = false;
-  @override
-  Widget build(BuildContext context) {
-    final gradientColors = widget.useMono
-        ? [
-            widget.monoColor.withOpacity(0.15),
-            widget.monoColor.withOpacity(0.35)
-          ]
-        : widget.gradientColors;
-
-    final iconColor = widget.useMono ? widget.monoColor : Colors.white;
-
-    final iconBadge = Container(
-      height: widget.iconSize,
-      width: widget.iconSize,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: gradientColors,
-        ),
-        border: Border.all(color: Colors.white.withOpacity(0.25)),
-      ),
-      child: Icon(widget.icon, size: widget.iconSize * 0.58, color: iconColor),
-    );
-
-    final title = Text(
-      widget.title,
-      textAlign: widget.centerContent ? TextAlign.center : TextAlign.left,
-      style: TextStyle(
-        fontSize: 20,
-        height: 1.15,
-        fontWeight: FontWeight.w800,
-        color: widget.textColor,
-      ),
-      maxLines: 2,
-      overflow: TextOverflow.ellipsis,
-    );
-
-    return GestureDetector(
-      onTapDown: (_) => setState(() => _pressed = true),
-      onTapCancel: () => setState(() => _pressed = false),
-      onTapUp: (_) => setState(() => _pressed = false),
-      onTap: widget.onTap,
-      child: AnimatedScale(
-        duration: const Duration(milliseconds: 110),
-        curve: Curves.easeOut,
-        scale: _pressed ? 0.98 : 1.0,
-        child: _GlassCard(
-          blur: widget.blur,
-          backgroundOpacity: widget.bgOpacity,
-          borderOpacity: widget.borderOpacity,
-          child: Padding(
-            padding: const EdgeInsets.all(18),
-            child: widget.centerContent
-                ? Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      iconBadge,
-                      const SizedBox(height: 12),
-                      title,
-                    ],
-                  )
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Align(alignment: Alignment.topLeft, child: iconBadge),
-                      const Spacer(),
-                      title,
-                    ],
-                  ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _GlassCard extends StatelessWidget {
-  const _GlassCard({
-    required this.child,
-    this.blur = 16,
-    this.backgroundOpacity = 0.16,
-    this.borderOpacity = 0.22,
-  });
-  final Widget child;
-  final double blur;
-  final double backgroundOpacity;
-  final double borderOpacity;
-
-  @override
-  Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(22),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
-        child: Container(
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-              colors: [
-                Colors.white.withOpacity(backgroundOpacity + 0.05),
-                Colors.white.withOpacity(backgroundOpacity),
-              ],
-            ),
-            border: Border.all(
-                color: Colors.white.withOpacity(borderOpacity), width: 1.2),
-            borderRadius: BorderRadius.circular(22),
-          ),
-          child: child,
-        ),
-      ),
-    );
-  }
-}

--- a/lib/widgets/glass_tile.dart
+++ b/lib/widgets/glass_tile.dart
@@ -1,0 +1,162 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+
+class GlassTile extends StatefulWidget {
+  const GlassTile({
+    super.key,
+    required this.title,
+    required this.icon,
+    required this.gradientColors,
+    required this.onTap,
+    required this.blur,
+    required this.bgOpacity,
+    required this.borderOpacity,
+    required this.iconSize,
+    required this.centerContent,
+    required this.useMono,
+    required this.monoColor,
+    required this.textColor,
+  });
+
+  final String title;
+  final IconData icon;
+  final List<Color> gradientColors;
+  final VoidCallback onTap;
+  final double blur;
+  final double bgOpacity;
+  final double borderOpacity;
+  final double iconSize;
+  final bool centerContent;
+  final bool useMono;
+  final Color monoColor;
+  final Color textColor;
+
+  @override
+  State<GlassTile> createState() => _GlassTileState();
+}
+
+class _GlassTileState extends State<GlassTile> {
+  bool _pressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final gradientColors = widget.useMono
+        ? [
+            widget.monoColor.withOpacity(0.15),
+            widget.monoColor.withOpacity(0.35),
+          ]
+        : widget.gradientColors;
+
+    final iconColor = widget.useMono ? widget.monoColor : Colors.white;
+
+    final iconBadge = Container(
+      height: widget.iconSize,
+      width: widget.iconSize,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: gradientColors,
+        ),
+        border: Border.all(color: Colors.white.withOpacity(0.25)),
+      ),
+      child: Icon(widget.icon, size: widget.iconSize * 0.58, color: iconColor),
+    );
+
+    final title = Text(
+      widget.title,
+      textAlign: widget.centerContent ? TextAlign.center : TextAlign.left,
+      style: TextStyle(
+        fontSize: 20,
+        height: 1.15,
+        fontWeight: FontWeight.w800,
+        color: widget.textColor,
+      ),
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapCancel: () => setState(() => _pressed = false),
+      onTapUp: (_) => setState(() => _pressed = false),
+      onTap: widget.onTap,
+      child: AnimatedScale(
+        duration: const Duration(milliseconds: 110),
+        curve: Curves.easeOut,
+        scale: _pressed ? 0.98 : 1.0,
+        child: GlassCard(
+          blur: widget.blur,
+          backgroundOpacity: widget.bgOpacity,
+          borderOpacity: widget.borderOpacity,
+          child: Padding(
+            padding: const EdgeInsets.all(18),
+            child: widget.centerContent
+                ? Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      iconBadge,
+                      const SizedBox(height: 12),
+                      title,
+                    ],
+                  )
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Align(alignment: Alignment.topLeft, child: iconBadge),
+                      const Spacer(),
+                      title,
+                    ],
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class GlassCard extends StatelessWidget {
+  const GlassCard({
+    super.key,
+    required this.child,
+    this.blur = 16,
+    this.backgroundOpacity = 0.16,
+    this.borderOpacity = 0.22,
+  });
+
+  final Widget child;
+  final double blur;
+  final double backgroundOpacity;
+  final double borderOpacity;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(22),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Colors.white.withOpacity(backgroundOpacity + 0.05),
+                Colors.white.withOpacity(backgroundOpacity),
+              ],
+            ),
+            border: Border.all(
+              color: Colors.white.withOpacity(borderOpacity),
+              width: 1.2,
+            ),
+            borderRadius: BorderRadius.circular(22),
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `GlassTile` and `GlassCard` widgets for shared glassmorphic tiles
- reuse new widgets in play and subject list screens

## Testing
- `dart format lib/widgets/glass_tile.dart lib/screens/play_screen.dart lib/screens/subject_list_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6573d0b4832f9bad00cd2c6574fb