### PR TITLE
Improve ENA question loading error handling

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -34,13 +34,21 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
   }
 
   Future<void> _load() async {
-    final all = await QuestionLoader.loadENA();
-    final pool = _filterBy(all, subject: widget.subjectName, chapter: widget.chapterName);
-    if (!mounted) return;
-    setState(() {
-      _pool = pool;
-      _loading = false;
-    });
+    try {
+      final all = await QuestionLoader.loadENA();
+      final pool = _filterBy(all, subject: widget.subjectName, chapter: widget.chapterName);
+      if (!mounted) return;
+      setState(() {
+        _pool = pool;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.toString())),
+      );
+    }
   }
 
   List<Question> _filterBy(List<Question> items, {required String subject, required String chapter}) {

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -152,12 +152,20 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
   }
 
   Future<void> _loadAll() async {
-    final data = await QuestionLoader.loadENA();
-    if (!mounted) return;
-    setState(() {
-      all = data;
-      loading = false;
-    });
+    try {
+      final data = await QuestionLoader.loadENA();
+      if (!mounted) return;
+      setState(() {
+        all = data;
+        loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => loading = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.toString())),
+      );
+    }
   }
 
   Future<void> _startFlow() async {

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -210,8 +210,8 @@ class _PlayScreenState extends State<PlayScreen> {
         } catch (e) {
           if (!mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Unable to load question bank.'),
+            SnackBar(
+              content: Text('Unable to load question bank: $e'),
             ),
           );
         }

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -98,7 +98,7 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Échec du lancement de l\'entraînement.')),
+        SnackBar(content: Text('Échec du lancement de l\'entraînement : $e')),
       );
     } finally {
       if (mounted) setState(() => _loading = false);

--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -10,7 +10,6 @@
 // -----------------------------------------------------------------------------
 
 import 'dart:convert';
-import 'package:flutter/foundation.dart' show debugPrint, kDebugMode;
 import 'package:flutter/services.dart' show rootBundle;
 import '../models/question.dart';
 
@@ -24,8 +23,9 @@ class QuestionLoader {
       'assets/questions/ena_sample.json',                 // fallback
     ];
 
-    for (int p = 0; p < paths.length; p++) {
-      final path = paths[p];
+    final errors = <String>[];
+
+    for (final path in paths) {
       try {
         final raw = await rootBundle.loadString(path);
         final decoded = json.decode(raw);
@@ -48,13 +48,19 @@ class QuestionLoader {
           }
         }
       } catch (e) {
-        if (kDebugMode) {
-          debugPrint('Failed to load ENA questions from $path: $e');
-        }
+        final msg = 'Failed to load ENA questions from $path: $e';
+        // Utilise `print` pour logger aussi en production
+        // et conserver le détail du chemin et de l\'exception.
+        // ignore: avoid_print
+        print(msg);
+        errors.add(msg);
         // on passe au fichier suivant
       }
     }
-    throw Exception('Aucune banque de questions ENA n\'a pu être chargée. Veuillez vérifier votre installation.');
+
+    throw Exception(
+      'Aucune banque de questions ENA n\'a pu être chargée. Détails: ${errors.join(' ; ')}',
+    );
   }
 
   /// Convertit `difficulty` (texte/entier) en entier 1..3


### PR DESCRIPTION
## Summary
- Log ENA question loading failures in production and include file path and error details
- Surface detailed question loading errors to users across screens via SnackBars

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6575d9b4832fab99712efcccd1c1