### PR TITLE
Remove const from CompetitionScreen constructor

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -39,7 +39,7 @@ class CompetitionScreen extends StatefulWidget {
   /// Visual theme used to style the screen.
   final CompetitionTheme? theme;
 
-  const CompetitionScreen({
+  CompetitionScreen({
     super.key,
     required this.questions,
     required this.indexMap,


### PR DESCRIPTION
## Summary
- allow DateTime.now to initialize startTime by dropping const from CompetitionScreen constructor

## Testing
- `flutter analyze lib/screens/competition_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6c899abc832f8cd499b93a47ec95