### PR TITLE
feat: disable recaptcha on auth

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 
 /// Exception thrown for authentication failures with a user-friendly message.
@@ -11,6 +13,15 @@ class AuthException implements Exception {
 
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  /// Disables Firebase's reCAPTCHA requirement for phone authentication,
+  /// ensuring the login flow does not prompt the user with a challenge.
+  /// This is useful for environments where reCAPTCHA is not desired.
+  AuthService() {
+    unawaited(
+      _auth.setSettings(appVerificationDisabledForTesting: true),
+    );
+  }
 
   Stream<User?> get authStateChanges => _auth.authStateChanges();
 


### PR DESCRIPTION
## Summary
- disable Firebase reCAPTCHA requirement during authentication

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3a00f79bc832fbba108cca050b782