### PR TITLE
Gate Firebase auth reCAPTCHA override to debug builds

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 
 /// Exception thrown for authentication failures with a user-friendly message.
 class AuthException implements Exception {
@@ -14,13 +15,14 @@ class AuthException implements Exception {
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
-  /// Disables Firebase's reCAPTCHA requirement for phone authentication,
-  /// ensuring the login flow does not prompt the user with a challenge.
-  /// This is useful for environments where reCAPTCHA is not desired.
+  /// Disables Firebase's reCAPTCHA requirement for phone authentication only
+  /// during debug builds so developers aren't blocked during local testing.
   AuthService() {
-    unawaited(
-      _auth.setSettings(appVerificationDisabledForTesting: true),
-    );
+    if (kDebugMode) {
+      unawaited(
+        _auth.setSettings(appVerificationDisabledForTesting: true),
+      );
+    }
   }
 
   Stream<User?> get authStateChanges => _auth.authStateChanges();


### PR DESCRIPTION
## Summary
- Prevent reCAPTCHA verification from being disabled in release builds by applying the Firebase `setSettings` override only when `kDebugMode` is true

## Testing
- `flutter test` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git -b stable --depth 1` *(fails: CONNECT tunnel failed, response 403)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b76a8120832f93999c8b5a973f9b