### PR TITLE
Disable Firebase recaptcha in debug and streamline auth service

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-
 import '../models/design_config.dart';
 import '../services/auth_service.dart';
 import '../services/design_bus.dart';

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -20,12 +20,11 @@ class AuthService {
   AuthService() {
     if (kDebugMode) {
       unawaited(
-        _auth.setSettings(appVerificationDisabledForTesting: true),
+        FirebaseAuth.instance
+            .setSettings(appVerificationDisabledForTesting: true),
       );
     }
   }
-
-  Stream<User?> get authStateChanges => _auth.authStateChanges();
 
   Future<UserCredential> signInWithEmail(String email, String password) async {
     try {
@@ -47,10 +46,6 @@ class AuthService {
     } on FirebaseAuthException catch (e) {
       throw AuthException(_messageFromCode(e.code));
     }
-  }
-
-  Future<void> signOut() {
-    return _auth.signOut();
   }
 
   String _messageFromCode(String code) {


### PR DESCRIPTION
## Summary
- simplify `AuthService` to support only email sign-in and registration
- disable Firebase phone reCAPTCHA in debug builds
- remove unused import in login screen and rely on `AuthService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c422c199c0832f841526b71a36fd4f