### PR TITLE
Rename Flutter app to civexam_pro

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.company.civexam"
+    namespace = "com.company.civexam_pro"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = "27.0.12077973"
 
@@ -20,7 +20,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.company.civexam"
+        applicationId = "com.company.civexam_pro"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.company.civexam_pro">
     <application
-        android:label="civexam_app"
+        android:label="civexam_pro"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon"
         android:enableOnBackInvokedCallback="true">

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: civexam_app
+name: civexam_pro
 description: CivExam ENA - Flutter app with white splash, square logo, and full questions folder
 publish_to: "none"
 version: 1.3.0+7


### PR DESCRIPTION
## Summary
- rename app and Android identifiers from `civexam_app` to `civexam_pro`
- update Android package and application ID to `com.company.civexam_pro`

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c435d42144832fa7b15d6f22a16ed0