### PR TITLE
Handle Firebase auth settings errors

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -21,7 +21,12 @@ class AuthService {
     if (kDebugMode) {
       unawaited(
         FirebaseAuth.instance
-            .setSettings(appVerificationDisabledForTesting: true),
+            .setSettings(appVerificationDisabledForTesting: true)
+            .catchError((error, _) {
+          debugPrint('Failed to configure FirebaseAuth: $error');
+          throw AuthException(
+              'Failed to disable app verification for testing: $error');
+        }),
       );
     }
   }


### PR DESCRIPTION
## Summary
- handle errors when disabling Firebase phone auth verification in debug mode

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c4480d4508832f9f0a64f3723a0b2d