### PR TITLE
Add sign-out handling via AuthService

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../services/auth_service.dart';
 import '../utils/palette_utils.dart';
 import '../widgets/glass_tile.dart';
 
@@ -26,6 +27,7 @@ class PlayScreen extends StatefulWidget {
 }
 
 class _PlayScreenState extends State<PlayScreen> {
+  final _auth = AuthService();
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<DesignConfig>(
@@ -55,12 +57,22 @@ class _PlayScreenState extends State<PlayScreen> {
                 icon: const Icon(Icons.logout),
                 tooltip: 'Déconnexion',
                 onPressed: () async {
-                  await FirebaseAuth.instance.signOut();
-                  if (!mounted) return;
-                  Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(builder: (_) => const LoginScreen()),
-                  );
+                  try {
+                    await _auth.signOut();
+                    if (!mounted) return;
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(builder: (_) => const LoginScreen()),
+                    );
+                  } catch (e) {
+                    if (!mounted) return;
+                    final message = e is AuthException
+                        ? e.message
+                        : 'Déconnexion échouée';
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(message)),
+                    );
+                  }
                 },
               ),
               IconButton(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -53,6 +53,17 @@ class AuthService {
     }
   }
 
+  Future<void> signOut() async {
+    try {
+      await _auth.signOut();
+    } catch (e) {
+      if (kDebugMode) {
+        print('Sign out failed: $e');
+      }
+      throw AuthException("Échec de la déconnexion");
+    }
+  }
+
   String _messageFromCode(String code) {
     switch (code) {
       case 'invalid-email':


### PR DESCRIPTION
## Summary
- add signOut method to AuthService with error handling
- invoke AuthService.signOut from PlayScreen and show snackbar on failure

## Testing
- `dart format lib/services/auth_service.dart lib/screens/play_screen.dart` *(fails: command not found)*
- `flutter format lib/services/auth_service.dart lib/screens/play_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4481dac3c832faa37234b65b58ee0