### PR TITLE
Throw PaymentException on failed mobile money responses

### DIFF
--- a/lib/services/mobile_money_service.dart
+++ b/lib/services/mobile_money_service.dart
@@ -61,7 +61,8 @@ class MobileMoneyPaymentService {
         }
         throw const FormatException('Réponse JSON invalide');
       }
-      return false;
+      throw PaymentException(
+          'Échec du paiement (code ${response.statusCode}): ${response.body}');
     } on SocketException catch (e) {
       throw PaymentException('Erreur réseau: ${e.message}');
     } on http.ClientException catch (e) {

--- a/test/mobile_money_service_test.dart
+++ b/test/mobile_money_service_test.dart
@@ -30,7 +30,7 @@ void main() {
     service.dispose();
   });
 
-  test('makePayment returns false on 4xx response', () async {
+  test('makePayment throws PaymentException on 4xx response', () async {
     final service = MobileMoneyPaymentService(
       apiUrl: 'https://example.com',
       apiKey: 'token',
@@ -39,18 +39,25 @@ void main() {
       }),
     );
 
-    final ok = await service.makePayment(
-      phoneNumber: '0123456789',
-      amount: 10.0,
-      currency: 'XOF',
+    await expectLater(
+      service.makePayment(
+        phoneNumber: '0123456789',
+        amount: 10.0,
+        currency: 'XOF',
+      ),
+      throwsA(
+        isA<PaymentException>().having(
+          (e) => e.message,
+          'message',
+          contains('code 400'),
+        ),
+      ),
     );
-
-    expect(ok, isFalse);
 
     service.dispose();
   });
 
-  test('makePayment returns false on 5xx response', () async {
+  test('makePayment throws PaymentException on 5xx response', () async {
     final service = MobileMoneyPaymentService(
       apiUrl: 'https://example.com',
       apiKey: 'token',
@@ -59,13 +66,20 @@ void main() {
       }),
     );
 
-    final ok = await service.makePayment(
-      phoneNumber: '0123456789',
-      amount: 10.0,
-      currency: 'XOF',
+    await expectLater(
+      service.makePayment(
+        phoneNumber: '0123456789',
+        amount: 10.0,
+        currency: 'XOF',
+      ),
+      throwsA(
+        isA<PaymentException>().having(
+          (e) => e.message,
+          'message',
+          contains('code 500'),
+        ),
+      ),
     );
-
-    expect(ok, isFalse);
 
     service.dispose();
   });


### PR DESCRIPTION
## Summary
- throw PaymentException with HTTP status and body when mobile money API returns an error
- update mobile money service tests to expect PaymentException and validate message

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c448233754832fac07aba2be97de7e