### PR TITLE
Handle Firestore errors in competition service

### DIFF
--- a/lib/services/competition_service.dart
+++ b/lib/services/competition_service.dart
@@ -14,16 +14,26 @@ class CompetitionService {
   Future<void> saveEntry(LeaderboardEntry entry) async {
     final data = entry.toJson();
     data['updatedAt'] = FieldValue.serverTimestamp();
-    await _col.doc(entry.userId).set(data);
+    try {
+      await _col.doc(entry.userId).set(data);
+    } catch (e) {
+      throw Exception("Échec de l'enregistrement du score: $e");
+    }
   }
 
   /// Récupère les meilleurs résultats (max 100 par défaut).
   Future<List<LeaderboardEntry>> topEntries({int limit = 100}) async {
-    final snap = await _col
-        .orderBy('percent', descending: true)
-        .orderBy('durationSec')
-        .limit(limit)
-        .get();
-    return snap.docs.map((d) => LeaderboardEntry.fromJson(d.data())).toList();
+    try {
+      final snap = await _col
+          .orderBy('percent', descending: true)
+          .orderBy('durationSec')
+          .limit(limit)
+          .get();
+      return snap.docs
+          .map((d) => LeaderboardEntry.fromJson(d.data()))
+          .toList();
+    } catch (e) {
+      return [];
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Guard competition score writes with try/catch and surface save errors
- Safely fetch leaderboard entries, returning an empty list on failure

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44b039e04832f89b55e59ef2bdaab