### PR TITLE
feat: handle more Firebase Auth errors

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -83,8 +83,19 @@ class AuthService {
         return 'Email déjà utilisé';
       case 'weak-password':
         return 'Mot de passe trop faible';
+      case 'network-request-failed':
+        return 'Problème de connexion réseau';
+      case 'too-many-requests':
+        return 'Trop de tentatives, réessayez plus tard';
+      case 'operation-not-allowed':
+        return 'Opération non autorisée';
+      case 'requires-recent-login':
+        return 'Veuillez vous reconnecter pour continuer';
       default:
         return "Erreur d'authentification";
     }
   }
+
+  @visibleForTesting
+  String messageFromCodeForTest(String code) => _messageFromCode(code);
 }

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:civexam_app/firebase_options.dart';
+import 'package:civexam_app/services/auth_service.dart';
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  });
+
+  final service = AuthService();
+
+  test('returns message for network-request-failed', () {
+    expect(service.messageFromCodeForTest('network-request-failed'),
+        'Problème de connexion réseau');
+  });
+
+  test('returns message for too-many-requests', () {
+    expect(service.messageFromCodeForTest('too-many-requests'),
+        'Trop de tentatives, réessayez plus tard');
+  });
+
+  test('returns message for operation-not-allowed', () {
+    expect(service.messageFromCodeForTest('operation-not-allowed'),
+        'Opération non autorisée');
+  });
+
+  test('returns message for requires-recent-login', () {
+    expect(service.messageFromCodeForTest('requires-recent-login'),
+        'Veuillez vous reconnecter pour continuer');
+  });
+}


### PR DESCRIPTION
## Summary
- expand auth error mapping with network, rate limit and other cases
- add tests for new auth error messages

## Testing
- `flutter test` (fails: command not found)
- `dart test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c44afe64e8832f9a00293862d8c76f