### PR TITLE
Require authentication for cloud sync

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- require existing authenticated session instead of anonymous sign-in
- block uploads and prompt sign-in when no user session
- add Firestore rules requiring valid user uid

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44dadc1c4832fbb8c2c8946c02e80