### PR TITLE
refactor: externalize keystore passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ flutter create .
 flutter run
 ```
 
+## Signature Android
+Pour les builds de production, les mots de passe du keystore ne sont plus inclus dans le dépôt.
+Déclarez `storePassword` et `keyPassword` dans `~/.gradle/gradle.properties` :
+
+```properties
+storePassword=mon-mot-de-passe-store
+keyPassword=mon-mot-de-passe-cle
+```
+
+ou exportez-les comme variables d’environnement avant la compilation :
+
+```bash
+export STORE_PASSWORD="mon-mot-de-passe-store"
+export KEY_PASSWORD="mon-mot-de-passe-cle"
+```
+
 ## Dossiers
 - lib/app/theme.dart – thème (bleu #37478F)
 - lib/services/question_loader.dart – charge JSON + filtre

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -5,6 +5,11 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val storePasswordLocal: String? = project.findProperty("storePassword") as String?
+    ?: System.getenv("STORE_PASSWORD")
+val keyPasswordLocal: String? = project.findProperty("keyPassword") as String?
+    ?: System.getenv("KEY_PASSWORD")
+
 android {
     namespace = "com.company.civexam_pro"
     compileSdk = flutter.compileSdkVersion
@@ -32,9 +37,9 @@ android {
     signingConfigs {
         create("release") {
             storeFile = file("civexam-release.jks")
-            storePassword = "password"
+            storePassword = storePasswordLocal
             keyAlias = "civexam"
-            keyPassword = "password"
+            keyPassword = keyPasswordLocal
         }
     }
 


### PR DESCRIPTION
## Summary
- load keystore passwords from Gradle properties or env variables
- document how to configure keystore passwords for release builds

## Testing
- `flutter test` *(fails: command not found)*
- `bash android/gradlew -p android assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c44f49fd14832f9c21e16ed7ebc63c