### PR TITLE
Handle timeout in splash auth check

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -32,18 +32,22 @@ class _SplashScreenState extends State<SplashScreen> {
       Navigator.of(context).pushReplacement(
         MaterialPageRoute(builder: (_) => next),
       );
-    } catch (e) {
-      if (!mounted) return;
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (_) => const LoginScreen()),
-      );
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content:
-              Text('Connexion impossible. Veuillez vous reconnecter.'),
-        ),
-      );
+    } on TimeoutException {
+      _goToLogin(
+          'La connexion a expiré. Veuillez vous reconnecter.');
+    } catch (_) {
+      _goToLogin('Connexion impossible. Veuillez vous reconnecter.');
     }
+  }
+
+  void _goToLogin(String message) {
+    if (!mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- handle timeout and errors in splash screen login navigation
- route to login with snackbar message on failure

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c44f4899cc832fb510fdee3345ed6e