### PR TITLE
refactor: simplify auth service

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -15,22 +15,6 @@ class AuthException implements Exception {
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 
-  /// Disables Firebase's reCAPTCHA requirement for phone authentication only
-  /// during debug builds so developers aren't blocked during local testing.
-  AuthService() {
-    if (kDebugMode) {
-      unawaited(
-        FirebaseAuth.instance
-            .setSettings(appVerificationDisabledForTesting: true)
-            .catchError((error, _) {
-          debugPrint('Failed to configure FirebaseAuth: $error');
-          throw AuthException(
-              'Failed to disable app verification for testing: $error');
-        }),
-      );
-    }
-  }
-
   Future<UserCredential> signInWithEmail(String email, String password) async {
     try {
       return await _auth.signInWithEmailAndPassword(


### PR DESCRIPTION
## Summary
- remove debug-only FirebaseAuth settings from AuthService
- keep only basic email auth methods: signInWithEmail, registerWithEmail and signOut

## Testing
- `flutter test test/auth_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c49d7903e0832f85df3b9fd1042f0f