### PR TITLE
Move Android MainActivity to civexam_pro package

### DIFF
--- a/android/app/src/main/kotlin/com/company/civexam_pro/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/company/civexam_pro/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.company.civexam
+package com.company.civexam_pro
 
 import io.flutter.embedding.android.FlutterActivity
 


### PR DESCRIPTION
## Summary
- Move MainActivity into new `com.company.civexam_pro` package
- Align package declaration with existing Android manifest and build configs

## Testing
- `./gradlew assembleDebug` *(fails: Included build '/workspace/CIVEXAM/android/C:/src/flutter/packages/flutter_tools/gradle' does not exist)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a6d1cf60832f943aa0c4fd269dff