### PR TITLE
Handle internal auth configuration errors

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -20,7 +20,7 @@ class AuthService {
       return await _auth.signInWithEmailAndPassword(
           email: email, password: password);
     } on FirebaseAuthException catch (e) {
-      throw AuthException(_messageFromCode(e.code));
+      throw AuthException(_messageFromCode(e.code, e.message));
     }
   }
 
@@ -39,7 +39,7 @@ class AuthService {
       }
       return userCredential;
     } on FirebaseAuthException catch (e) {
-      throw AuthException(_messageFromCode(e.code));
+      throw AuthException(_messageFromCode(e.code, e.message));
     }
   }
 
@@ -54,7 +54,7 @@ class AuthService {
     }
   }
 
-  String _messageFromCode(String code) {
+  String _messageFromCode(String code, [String? message]) {
     switch (code) {
       case 'invalid-email':
         return 'Email invalide';
@@ -76,11 +76,17 @@ class AuthService {
         return 'Opération non autorisée';
       case 'requires-recent-login':
         return 'Veuillez vous reconnecter pour continuer';
+      case 'internal-error':
+        if (message != null && message.contains('CONFIGURATION_NOT_FOUND')) {
+          return 'Configuration d’authentification invalide – reCAPTCHA manquant.';
+        }
+        return "Erreur interne d'authentification";
       default:
         return "Erreur d'authentification";
     }
   }
 
   @visibleForTesting
-  String messageFromCodeForTest(String code) => _messageFromCode(code);
+  String messageFromCodeForTest(String code, [String? message]) =>
+      _messageFromCode(code, message);
 }

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -30,4 +30,11 @@ void main() {
     expect(service.messageFromCodeForTest('requires-recent-login'),
         'Veuillez vous reconnecter pour continuer');
   });
+
+  test('returns message for internal-error with CONFIGURATION_NOT_FOUND', () {
+    expect(
+        service.messageFromCodeForTest(
+            'internal-error', 'Some CONFIGURATION_NOT_FOUND error'),
+        'Configuration d’authentification invalide – reCAPTCHA manquant.');
+  });
 }


### PR DESCRIPTION
## Summary
- handle `internal-error` auth failures with guidance when configuration is missing
- pass Firebase messages to `_messageFromCode` and expose optional message parameter for testing
- add unit test for the new branch

## Testing
- `flutter test test/auth_service_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c4a8ee7fe4832fa0af9fe3dc3335b2