### PR TITLE
Add Ivorian themed color palette and apply globally

### DIFF
--- a/lib/models/design_config.dart
+++ b/lib/models/design_config.dart
@@ -42,7 +42,7 @@ class DesignConfig {
 
   const DesignConfig({
     // Thème fond
-    this.bgPaletteName = 'navyCyanAmber',
+    this.bgPaletteName = 'civFlag',
     this.waveEnabled = true,
     this.bgGradient = true,
     this.darkMode = false,
@@ -115,7 +115,7 @@ class DesignConfig {
     final double tileSize = _toDouble(map['tileIconSize'], svgSize);
 
     return DesignConfig(
-      bgPaletteName: map['bgPaletteName'] ?? 'sereneBlue',
+      bgPaletteName: map['bgPaletteName'] ?? 'civFlag',
       waveEnabled: _toBool(map, 'waveEnabled', true),
       bgGradient: _toBool(map, 'bgGradient', true),
       glassBlur: _toDouble(map['glassBlur'], 18.0),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -23,6 +23,7 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
 
   // Palettes proposées (tons épurés et contrastes soignés)
   static const List<String> _palettes = [
+    'civFlag',
     'navyCyanAmber',
     'indigoPurpleSky',
     'emeraldTealMint',
@@ -34,6 +35,7 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   ];
 
   static const Map<String, String> _paletteLabels = {
+    'civFlag': 'Orange/Blanc/Vert',
     'navyCyanAmber': 'Navy/Cyan/Ambre',
     'indigoPurpleSky': 'Indigo/Violet/Ciel',
     'emeraldTealMint': 'Émeraude/Teal/Menthe',

--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -53,6 +53,8 @@ Color accentColor(String name) {
       return const Color(0xFF2563EB); // Primary
     case 'calmPastels':
       return const Color(0xFF8FA6FF); // Primary
+    case 'civFlag':
+      return const Color(0xFFFF7F00); // Primary
     default:
       return const Color(0xFFF5F5F5);
   }
@@ -141,6 +143,8 @@ List<Color> pastelColors(String name, {bool darkMode = false}) {
       return const [Color(0xFFF8FAFC), Color(0xFFFFFFFF)];
     case 'calmPastels':
       return const [Color(0xFFF7F7FB), Color(0xFFFFFFFF)];
+    case 'civFlag':
+      return const [Color(0xFFFFF2E5), Color(0xFFE5FFF1)];
     default:
       final accent = accentColor(name);
       final hsl = HSLColor.fromColor(accent);
@@ -171,6 +175,8 @@ Color complementaryColor(String name) {
       return const Color(0xFF64748B); // Accent
     case 'calmPastels':
       return const Color(0xFFB7E4C7); // Accent
+    case 'civFlag':
+      return const Color(0xFF009E60); // Accent
     default:
       final accent = accentColor(name);
       final hsl = HSLColor.fromColor(accent);
@@ -197,6 +203,8 @@ Color textColorForPalette(String name, {bool darkMode = false}) {
       return const Color(0xFF0F172A);
     case 'calmPastels':
       return const Color(0xFF1F2937);
+    case 'civFlag':
+      return const Color(0xFF0F172A);
     default:
       final colors = pastelColors(name, darkMode: darkMode);
       int r = 0, g = 0, b = 0;


### PR DESCRIPTION
## Summary
- add `civFlag` palette with orange accent and green complementary tones
- set `civFlag` as default theme and expose in design settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d243180c832fa28cbf0e64856be6