### PR TITLE
feat: pastelize charcoal electric palette

### DIFF
--- a/lib/utils/palette_utils.dart
+++ b/lib/utils/palette_utils.dart
@@ -136,7 +136,7 @@ List<Color> pastelColors(String name, {bool darkMode = false}) {
     case 'royalBlueGold':
       return const [Color(0xFFFFFFFF), Color(0xFFF6F8FF)];
     case 'charcoalElectric':
-      return const [Color(0xFF0B1220), Color(0xFF0F172A)];
+      return const [Color(0xFFBFDBFE), Color(0xFFDBEAFE)];
     case 'forestSandTerracotta':
       return const [Color(0xFFFFF8F1), Color(0xFFFFFFFF)];
     case 'cobaltLimeSlate':
@@ -196,7 +196,7 @@ Color textColorForPalette(String name, {bool darkMode = false}) {
     case 'royalBlueGold':
       return const Color(0xFF0F172A);
     case 'charcoalElectric':
-      return const Color(0xFFE5E7EB);
+      return const Color(0xFF0F172A);
     case 'forestSandTerracotta':
       return const Color(0xFF1F2937);
     case 'cobaltLimeSlate':


### PR DESCRIPTION
## Summary
- use pastel blue gradient for charcoalElectric palette
- switch charcoalElectric text to dark tone for readability

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4dcc63004832f9c8b4bdf6c1f736d