### PR TITLE
feat: clean question prefix in exam screen

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -140,6 +140,13 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     return '$m:$ss';
   }
 
+  /// Removes any "Question XX:" prefix from the question text.
+  String _cleanQuestion(String q) {
+    return q.replaceFirst(
+        RegExp(r'^Question\s*\d+[:\.\)]?\s*', caseSensitive: false),
+        '');
+  }
+
   void _onAnswer(int index, int choice) {
     setState(() => answers[index] = choice);
     if (widget.competitionMode) {
@@ -171,7 +178,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                 ),
                 const SizedBox(width: 8),
                 Expanded(
-                    child: Text(item.question,
+                    child: Text(_cleanQuestion(item.question),
                         style: const TextStyle(fontWeight: FontWeight.w600))),
               ],
             ),


### PR DESCRIPTION
## Summary
- add `_cleanQuestion` helper to strip `Question XX` prefix in `ExamFullScreen`
- use `_cleanQuestion` when rendering question text

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ae3cc3e4832fb8c57d3b82a7d430