### PR TITLE
feat: add profile editing screen

### DIFF
--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ProfileEditScreen extends StatefulWidget {
+  const ProfileEditScreen({super.key});
+
+  @override
+  State<ProfileEditScreen> createState() => _ProfileEditScreenState();
+}
+
+class _ProfileEditScreenState extends State<ProfileEditScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _firstNameController = TextEditingController();
+  final _lastNameController = TextEditingController();
+  final _pseudoController = TextEditingController();
+  final _professionController = TextEditingController();
+  String? _avatarPath;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPrefs();
+  }
+
+  Future<void> _loadPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    _firstNameController.text = prefs.getString('first_name') ?? '';
+    _lastNameController.text = prefs.getString('last_name') ?? '';
+    _pseudoController.text = prefs.getString('pseudo') ?? '';
+    _professionController.text = prefs.getString('profession') ?? '';
+    setState(() {
+      _avatarPath = prefs.getString('avatar_path');
+    });
+  }
+
+  @override
+  void dispose() {
+    _firstNameController.dispose();
+    _lastNameController.dispose();
+    _pseudoController.dispose();
+    _professionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _avatarPath = picked.path;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('first_name', _firstNameController.text);
+    await prefs.setString('last_name', _lastNameController.text);
+    await prefs.setString('pseudo', _pseudoController.text);
+    await prefs.setString('profession', _professionController.text);
+    if (_avatarPath != null) {
+      await prefs.setString('avatar_path', _avatarPath!);
+    }
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Profil enregistré')));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Modifier le profil')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              Center(
+                child: InkWell(
+                  onTap: _pickImage,
+                  child: CircleAvatar(
+                    radius: 50,
+                    backgroundImage:
+                        _avatarPath != null ? FileImage(File(_avatarPath!)) : null,
+                    child: _avatarPath == null
+                        ? const Icon(Icons.person, size: 50)
+                        : null,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              TextFormField(
+                controller: _firstNameController,
+                decoration: const InputDecoration(labelText: 'Prénom'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _lastNameController,
+                decoration: const InputDecoration(labelText: 'Nom'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _pseudoController,
+                decoration: const InputDecoration(labelText: 'Pseudonyme'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _professionController,
+                decoration: const InputDecoration(labelText: 'Profession'),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _save,
+                child: const Text('Enregistrer'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     path: third_party/flutter_windowmanager
   device_info_plus: ^10.0.0
   confetti: ^0.7.0
+  image_picker: ^1.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add profile edit screen with avatar picker and form fields
- persist profile info using SharedPreferences
- add image_picker dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `git clone https://github.com/flutter/flutter.git --depth 1 ~/flutter` *(fails: 403)*


------
https://chatgpt.com/codex/tasks/task_e_68c5e4f55784832fa0290752bba0d493