### PR TITLE
Add user profile model and Firestore service

### DIFF
--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,25 @@
+// lib/models/user_profile.dart
+class UserProfile {
+  final String firstName, lastName, nickname, profession, photoUrl;
+  const UserProfile({
+    required this.firstName,
+    required this.lastName,
+    required this.nickname,
+    required this.profession,
+    required this.photoUrl,
+  });
+  Map<String, dynamic> toJson() => {
+        'firstName': firstName,
+        'lastName': lastName,
+        'nickname': nickname,
+        'profession': profession,
+        'photoUrl': photoUrl,
+      };
+  factory UserProfile.fromJson(Map<String, dynamic> m) => UserProfile(
+        firstName: (m['firstName'] ?? '') as String,
+        lastName: (m['lastName'] ?? '') as String,
+        nickname: (m['nickname'] ?? '') as String,
+        profession: (m['profession'] ?? '') as String,
+        photoUrl: (m['photoUrl'] ?? '') as String,
+      );
+}

--- a/lib/services/user_profile_service.dart
+++ b/lib/services/user_profile_service.dart
@@ -1,0 +1,34 @@
+// lib/services/user_profile_service.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/user_profile.dart';
+
+/// Service Firestore pour le profil utilisateur.
+class UserProfileService {
+  final _col = FirebaseFirestore.instance.collection('users');
+
+  /// Charge le profil de l'utilisateur [uid].
+  Future<UserProfile?> loadProfile(String uid) async {
+    try {
+      final doc = await _col.doc(uid).get();
+      final data = doc.data();
+      if (data == null) return null;
+      return UserProfile.fromJson(data);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Sauvegarde le profil de l'utilisateur actuellement connecté.
+  Future<void> saveProfile(UserProfile profile) async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      throw Exception('Aucun utilisateur authentifié');
+    }
+    try {
+      await _col.doc(uid).set(profile.toJson(), SetOptions(merge: true));
+    } catch (e) {
+      throw Exception("Échec de l'enregistrement du profil: $e");
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `UserProfile` model with JSON serialization
- implement `UserProfileService` for loading and saving profiles in Firestore

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e4f6d774832fa8f3bf58bfa1d832