### PR TITLE
Add profile navigation and display

### DIFF
--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,17 @@
+class UserProfile {
+  final String name;
+  final String nickname;
+  final String photoUrl;
+
+  const UserProfile({
+    required this.name,
+    required this.nickname,
+    required this.photoUrl,
+  });
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) => UserProfile(
+        name: (json['name'] ?? '') as String,
+        nickname: (json['nickname'] ?? '') as String,
+        photoUrl: (json['photoUrl'] ?? '') as String,
+      );
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/leaderboard_entry.dart';
+import '../models/user_profile.dart';
 import '../services/competition_service.dart';
+import '../services/profile_service.dart';
+import 'profile_edit_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -14,6 +17,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   LeaderboardEntry? _entry;
   int? _rank;
   bool _loading = true;
+  UserProfile? _profile;
 
   @override
   void initState() {
@@ -29,10 +33,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
       });
       return;
     }
+    final profile = await ProfileService().fetchCurrentProfile();
     final entries = await CompetitionService().topEntries(limit: 1000);
     final index = entries.indexWhere((e) => e.userId == uid);
     if (!mounted) return;
     setState(() {
+      _profile = profile;
       _entry = index >= 0 ? entries[index] : null;
       _rank = index >= 0 ? index + 1 : null;
       _loading = false;
@@ -42,7 +48,19 @@ class _DashboardScreenState extends State<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Mon dashboard')),
+      appBar: AppBar(
+        title: const Text('Mon dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.person),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const ProfileEditScreen()),
+              );
+            },
+          )
+        ],
+      ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _entry == null
@@ -52,14 +70,42 @@ class _DashboardScreenState extends State<DashboardScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      if (_profile != null)
+                        Row(
+                          children: [
+                            CircleAvatar(
+                              radius: 30,
+                              backgroundImage: _profile!.photoUrl.isNotEmpty
+                                  ? NetworkImage(_profile!.photoUrl)
+                                  : null,
+                              child: _profile!.photoUrl.isEmpty
+                                  ? const Icon(Icons.person)
+                                  : null,
+                            ),
+                            const SizedBox(width: 16),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  _profile!.name,
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .titleMedium,
+                                ),
+                                if (_profile!.nickname.isNotEmpty)
+                                  Text(_profile!.nickname),
+                              ],
+                            ),
+                          ],
+                        ),
+                      const SizedBox(height: 16),
                       Text('Nom : ${_entry!.name}',
                           style: Theme.of(context).textTheme.titleLarge),
                       const SizedBox(height: 8),
                       Text(
                           'Score : ${_entry!.percent.toStringAsFixed(1)}% (${_entry!.correct}/${_entry!.total})'),
                       const SizedBox(height: 8),
-                      if (_rank != null)
-                        Text('Classement global : $_rank'),
+                      if (_rank != null) Text('Classement global : $_rank'),
                     ],
                   ),
                 ),

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ProfileEditScreen extends StatelessWidget {
+  const ProfileEditScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profil')),
+      body: const Center(child: Text('Édition du profil')), 
+    );
+  }
+}

--- a/lib/services/profile_service.dart
+++ b/lib/services/profile_service.dart
@@ -1,0 +1,25 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/user_profile.dart';
+
+class ProfileService {
+  final _col = FirebaseFirestore.instance.collection('users');
+
+  Future<UserProfile?> fetchCurrentProfile() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return null;
+    try {
+      final doc = await _col.doc(uid).get();
+      if (doc.exists) {
+        return UserProfile.fromJson(doc.data() ?? {});
+      }
+    } catch (_) {}
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return null;
+    return UserProfile(
+      name: user.displayName ?? '',
+      nickname: user.displayName ?? '',
+      photoUrl: user.photoURL ?? '',
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add profile model and service to fetch current user profile
- show profile avatar, name and nickname on dashboard
- add app bar profile button to open profile edit screen

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c5e4f82618832faa340d4ebee3d9ea