### PR TITLE
feat: add profile photo upload

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,5 +1,9 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:image_picker/image_picker.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
 
@@ -14,6 +18,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   LeaderboardEntry? _entry;
   int? _rank;
   bool _loading = true;
+  String? _photoUrl;
 
   @override
   void initState() {
@@ -31,12 +36,32 @@ class _DashboardScreenState extends State<DashboardScreen> {
     }
     final entries = await CompetitionService().topEntries(limit: 1000);
     final index = entries.indexWhere((e) => e.userId == uid);
+    final userDoc = await FirebaseFirestore.instance.collection('users').doc(uid).get();
     if (!mounted) return;
     setState(() {
       _entry = index >= 0 ? entries[index] : null;
       _rank = index >= 0 ? index + 1 : null;
+      _photoUrl = userDoc.data()?['photoUrl'] as String?;
       _loading = false;
     });
+  }
+
+  Future<void> _pickAndUpload() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+    if (picked == null) return;
+    final file = File(picked.path);
+    final ref = FirebaseStorage.instance.ref().child('user_photos/$uid.jpg');
+    await ref.putFile(file);
+    final url = await ref.getDownloadURL();
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .set({'photoUrl': url}, SetOptions(merge: true));
+    if (!mounted) return;
+    setState(() => _photoUrl = url);
   }
 
   @override
@@ -52,6 +77,20 @@ class _DashboardScreenState extends State<DashboardScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      Center(
+                        child: GestureDetector(
+                          onTap: _pickAndUpload,
+                          child: CircleAvatar(
+                            radius: 40,
+                            backgroundImage:
+                                _photoUrl != null ? NetworkImage(_photoUrl!) : null,
+                            child: _photoUrl == null
+                                ? const Icon(Icons.person, size: 40)
+                                : null,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16),
                       Text('Nom : ${_entry!.name}',
                           style: Theme.of(context).textTheme.titleLarge),
                       const SizedBox(height: 8),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
     path: third_party/flutter_windowmanager
   device_info_plus: ^10.0.0
   confetti: ^0.7.0
+  image_picker: ^1.0.7
+  firebase_storage: ^11.2.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add image_picker and firebase_storage dependencies
- allow dashboard users to pick and upload a profile photo
- show uploaded photo in dashboard avatar

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e4faf2e0832fbcb0b7cc4a34f766