### PR TITLE
Load user profile in dashboard

### DIFF
--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,25 @@
+// lib/models/user_profile.dart
+class UserProfile {
+  final String uid;
+  final String name;
+  final String email;
+  final String photoUrl;
+  const UserProfile({
+    required this.uid,
+    required this.name,
+    required this.email,
+    required this.photoUrl,
+  });
+  Map<String, dynamic> toJson() => {
+        'uid': uid,
+        'name': name,
+        'email': email,
+        'photoUrl': photoUrl,
+      };
+  factory UserProfile.fromJson(Map<String, dynamic> json) => UserProfile(
+        uid: (json['uid'] ?? '') as String,
+        name: (json['name'] ?? '') as String,
+        email: (json['email'] ?? '') as String,
+        photoUrl: (json['photoUrl'] ?? '') as String,
+      );
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
+import '../models/user_profile.dart';
+import '../services/user_profile_service.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -13,6 +15,7 @@ class DashboardScreen extends StatefulWidget {
 class _DashboardScreenState extends State<DashboardScreen> {
   LeaderboardEntry? _entry;
   int? _rank;
+  UserProfile? _profile;
   bool _loading = true;
 
   @override
@@ -29,12 +32,18 @@ class _DashboardScreenState extends State<DashboardScreen> {
       });
       return;
     }
-    final entries = await CompetitionService().topEntries(limit: 1000);
+    final results = await Future.wait([
+      CompetitionService().topEntries(limit: 1000),
+      UserProfileService.loadProfile(uid),
+    ]);
+    final entries = results[0] as List<LeaderboardEntry>;
+    final profile = results[1] as UserProfile?;
     final index = entries.indexWhere((e) => e.userId == uid);
     if (!mounted) return;
     setState(() {
       _entry = index >= 0 ? entries[index] : null;
       _rank = index >= 0 ? index + 1 : null;
+      _profile = profile;
       _loading = false;
     });
   }
@@ -45,24 +54,28 @@ class _DashboardScreenState extends State<DashboardScreen> {
       appBar: AppBar(title: const Text('Mon dashboard')),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : _entry == null
-              ? const Center(child: Text('Aucune donnée de compétition'))
-              : Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text('Nom : ${_entry!.name}',
-                          style: Theme.of(context).textTheme.titleLarge),
-                      const SizedBox(height: 8),
-                      Text(
-                          'Score : ${_entry!.percent.toStringAsFixed(1)}% (${_entry!.correct}/${_entry!.total})'),
-                      const SizedBox(height: 8),
-                      if (_rank != null)
-                        Text('Classement global : $_rank'),
-                    ],
-                  ),
-                ),
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (_profile != null)
+                    Text('Nom : ${_profile!.name}',
+                        style: Theme.of(context).textTheme.titleLarge),
+                  if (_entry != null) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                        'Score : ${_entry!.percent.toStringAsFixed(1)}% (${_entry!.correct}/${_entry!.total})'),
+                    const SizedBox(height: 8),
+                    if (_rank != null)
+                      Text('Classement global : $_rank'),
+                  ] else ...[
+                    const SizedBox(height: 8),
+                    const Text('Aucune donnée de compétition'),
+                  ]
+                ],
+              ),
+            ),
     );
   }
 }

--- a/lib/services/user_profile_service.dart
+++ b/lib/services/user_profile_service.dart
@@ -1,0 +1,19 @@
+// lib/services/user_profile_service.dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/user_profile.dart';
+
+class UserProfileService {
+  static final _col = FirebaseFirestore.instance.collection('profiles');
+
+  static Future<UserProfile?> loadProfile(String uid) async {
+    try {
+      final doc = await _col.doc(uid).get();
+      if (!doc.exists) return null;
+      final data = doc.data();
+      if (data == null) return null;
+      return UserProfile.fromJson(data);
+    } catch (_) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fetch user profile in parallel with competition entries on the dashboard
- Store loaded profile in dashboard state and display user name
- Add `UserProfile` model and service for Firestore-backed profiles

## Testing
- `flutter format lib/screens/dashboard_screen.dart lib/models/user_profile.dart lib/services/user_profile_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e4fd6730832fbc679fa0e779d755