### PR TITLE
Store profession and nickname in user profile

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,9 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
     match /users/{userId}/{document=**} {
       // Anonymous users are treated like any other authenticated user.
       allow read, write: if request.auth != null && request.auth.uid == userId;

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,19 @@
+class UserProfile {
+  final String nickname;
+  final String profession;
+
+  const UserProfile({
+    this.nickname = '',
+    this.profession = '',
+  });
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) => UserProfile(
+        nickname: (json['nickname'] ?? '') as String,
+        profession: (json['profession'] ?? '') as String,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'nickname': nickname,
+        'profession': profession,
+      };
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../models/leaderboard_entry.dart';
+import '../models/user_profile.dart';
 import '../services/competition_service.dart';
+import '../services/user_profile_service.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -14,6 +16,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   LeaderboardEntry? _entry;
   int? _rank;
   bool _loading = true;
+  UserProfile? _profile;
 
   @override
   void initState() {
@@ -29,12 +32,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
       });
       return;
     }
+    final profile = await UserProfileService().fetch(uid);
     final entries = await CompetitionService().topEntries(limit: 1000);
     final index = entries.indexWhere((e) => e.userId == uid);
     if (!mounted) return;
     setState(() {
       _entry = index >= 0 ? entries[index] : null;
       _rank = index >= 0 ? index + 1 : null;
+      _profile = profile;
       _loading = false;
     });
   }
@@ -54,6 +59,10 @@ class _DashboardScreenState extends State<DashboardScreen> {
                     children: [
                       Text('Nom : ${_entry!.name}',
                           style: Theme.of(context).textTheme.titleLarge),
+                      if (_profile?.profession.isNotEmpty ?? false) ...[
+                        const SizedBox(height: 4),
+                        Text(_profile!.profession),
+                      ],
                       const SizedBox(height: 8),
                       Text(
                           'Score : ${_entry!.percent.toStringAsFixed(1)}% (${_entry!.correct}/${_entry!.total})'),

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -1,0 +1,111 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../models/user_profile.dart';
+import '../services/user_profile_service.dart';
+
+class ProfileEditScreen extends StatefulWidget {
+  const ProfileEditScreen({super.key});
+
+  @override
+  State<ProfileEditScreen> createState() => _ProfileEditScreenState();
+}
+
+class _ProfileEditScreenState extends State<ProfileEditScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nicknameController = TextEditingController();
+  final _professionController = TextEditingController();
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid != null) {
+      final profile = await UserProfileService().fetch(uid);
+      if (profile != null) {
+        _nicknameController.text = profile.nickname;
+        _professionController.text = profile.profession;
+      }
+    }
+    if (mounted) {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _nicknameController.dispose();
+    _professionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (!_formKey.currentState!.validate()) return;
+    final profile = UserProfile(
+      nickname: _nicknameController.text.trim(),
+      profession: _professionController.text.trim(),
+    );
+    await UserProfileService().save(profile);
+    if (mounted) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mon profil')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      controller: _nicknameController,
+                      decoration: const InputDecoration(labelText: 'Surnom'),
+                      validator: (v) {
+                        final value = v?.trim() ?? '';
+                        if (value.length < 3) {
+                          return 'Au moins 3 caractères';
+                        }
+                        if (!RegExp(r'^[A-Za-z0-9_]+$').hasMatch(value)) {
+                          return 'Caractères non autorisés';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _professionController,
+                      decoration: const InputDecoration(labelText: 'Profession'),
+                      validator: (v) {
+                        final value = v?.trim() ?? '';
+                        if (value.length < 3) {
+                          return 'Au moins 3 caractères';
+                        }
+                        if (!RegExp(r'^[A-Za-zÀ-ÿ\s-]+$').hasMatch(value)) {
+                          return 'Caractères non autorisés';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: _save,
+                      child: const Text('Enregistrer'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+}

--- a/lib/services/user_profile_service.dart
+++ b/lib/services/user_profile_service.dart
@@ -1,0 +1,22 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/user_profile.dart';
+
+class UserProfileService {
+  final _col = FirebaseFirestore.instance.collection('users');
+
+  Future<UserProfile?> fetch(String uid) async {
+    final doc = await _col.doc(uid).get();
+    if (!doc.exists) return null;
+    final data = doc.data();
+    if (data == null) return null;
+    return UserProfile.fromJson(data);
+  }
+
+  Future<void> save(UserProfile profile, {String? uid}) async {
+    final userId = uid ?? FirebaseAuth.instance.currentUser?.uid;
+    if (userId == null) return;
+    await _col.doc(userId).set(profile.toJson(), SetOptions(merge: true));
+  }
+}


### PR DESCRIPTION
## Summary
- extend Firestore rules for direct user document access
- show user profession on dashboard
- add user profile model, service, and editing screen with validation

## Testing
- `dart format lib/models/user_profile.dart lib/services/user_profile_service.dart lib/screens/profile_edit_screen.dart lib/screens/dashboard_screen.dart firestore.rules` *(fails: command not found)*
- `flutter format lib/models/user_profile.dart lib/services/user_profile_service.dart lib/screens/profile_edit_screen.dart lib/screens/dashboard_screen.dart firestore.rules` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e4fc3858832fbffdd826d7ffb03d