### PR TITLE
Use stream for competition leaderboard updates

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,5 +1,7 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
 
@@ -14,29 +16,33 @@ class _DashboardScreenState extends State<DashboardScreen> {
   LeaderboardEntry? _entry;
   int? _rank;
   bool _loading = true;
+  StreamSubscription<List<LeaderboardEntry>>? _sub;
 
   @override
   void initState() {
     super.initState();
-    _load();
-  }
-
-  Future<void> _load() async {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) {
-      setState(() {
-        _loading = false;
-      });
+      _loading = false;
       return;
     }
-    final entries = await CompetitionService().topEntries(limit: 1000);
-    final index = entries.indexWhere((e) => e.userId == uid);
-    if (!mounted) return;
-    setState(() {
-      _entry = index >= 0 ? entries[index] : null;
-      _rank = index >= 0 ? index + 1 : null;
-      _loading = false;
+    _sub = CompetitionService()
+        .topEntriesStream(limit: 1000)
+        .listen((entries) {
+      final index = entries.indexWhere((e) => e.userId == uid);
+      if (!mounted) return;
+      setState(() {
+        _entry = index >= 0 ? entries[index] : null;
+        _rank = index >= 0 ? index + 1 : null;
+        _loading = false;
+      });
     });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/services/competition_service.dart
+++ b/lib/services/competition_service.dart
@@ -36,4 +36,15 @@ class CompetitionService {
       return [];
     }
   }
+
+  /// Retourne un flux des meilleurs résultats (max 100 par défaut).
+  Stream<List<LeaderboardEntry>> topEntriesStream({int limit = 100}) {
+    return _col
+        .orderBy('percent', descending: true)
+        .orderBy('durationSec')
+        .limit(limit)
+        .snapshots()
+        .map((snap) =>
+            snap.docs.map((d) => LeaderboardEntry.fromJson(d.data())).toList());
+  }
 }


### PR DESCRIPTION
## Summary
- add streaming leaderboard retrieval in `CompetitionService`
- update dashboard to listen for leaderboard updates and cancel subscription on dispose

## Testing
- `dart format lib/services/competition_service.dart lib/screens/dashboard_screen.dart` *(command not found: dart)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ea246c14832f8e58295c95551f6f