### PR TITLE
Show dashboard score when user not ranked

### DIFF
--- a/lib/services/competition_service.dart
+++ b/lib/services/competition_service.dart
@@ -37,6 +37,17 @@ class CompetitionService {
     }
   }
 
+  /// Récupère le résultat d'un utilisateur spécifique.
+  Future<LeaderboardEntry?> entryForUser(String userId) async {
+    try {
+      final doc = await _col.doc(userId).get();
+      if (!doc.exists) return null;
+      return LeaderboardEntry.fromJson(doc.data()!);
+    } catch (_) {
+      return null;
+    }
+  }
+
   /// Retourne un flux des meilleurs résultats (max 100 par défaut).
   Stream<List<LeaderboardEntry>> topEntriesStream({int limit = 100}) {
     return _col


### PR DESCRIPTION
## Summary
- add CompetitionService.entryForUser to fetch single leaderboard entries
- ensure DashboardScreen loads user's own entry even if not ranked and display "Non classé" when missing rank

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5eabd099c832f937b62dc66154de5