### PR TITLE
Handle competition leaderboard errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ l'utilisateur. Une connexion anonyme n'est effectuée que si la préférence
 
 Si cette préférence vaut `false`, l'application ne se connecte pas
 automatiquement et l'écran de connexion est affiché.
+
+## Gestion des erreurs réseau
+
+Le service `CompetitionService.topEntries()` relance désormais les
+exceptions afin que l'interface puisse détecter un problème de
+connexion. Par exemple, `DashboardScreen` affiche un `SnackBar` et un
+message d'erreur spécifique lorsque le chargement du classement
+échoue.

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -6,7 +6,10 @@ import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
 
 class DashboardScreen extends StatefulWidget {
-  const DashboardScreen({super.key});
+  final CompetitionService service;
+
+  const DashboardScreen({super.key, CompetitionService? service})
+      : service = service ?? CompetitionService();
 
   @override
   State<DashboardScreen> createState() => _DashboardScreenState();
@@ -16,6 +19,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
   LeaderboardEntry? _entry;
   int? _rank;
   bool _loading = true;
+  bool _error = false;
   StreamSubscription<List<LeaderboardEntry>>? _sub;
 
   @override
@@ -26,7 +30,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       _loading = false;
       return;
     }
-    _sub = CompetitionService()
+    _sub = widget.service
         .topEntriesStream(limit: 1000)
         .listen((entries) {
       final index = entries.indexWhere((e) => e.userId == uid);
@@ -35,7 +39,16 @@ class _DashboardScreenState extends State<DashboardScreen> {
         _entry = index >= 0 ? entries[index] : null;
         _rank = index >= 0 ? index + 1 : null;
         _loading = false;
+        _error = false;
       });
+    }, onError: (error) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = true;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Impossible de récupérer le classement')));
     });
   }
 
@@ -51,9 +64,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
       appBar: AppBar(title: const Text('Mon dashboard')),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : _entry == null
-              ? const Center(child: Text('Aucune donnée de compétition'))
-              : Padding(
+          : _error
+              ? const Center(
+                  child: Text('Erreur de chargement du classement'))
+              : _entry == null
+                  ? const Center(child: Text('Aucune donnée de compétition'))
+                  : Padding(
                   padding: const EdgeInsets.all(16),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/services/competition_service.dart
+++ b/lib/services/competition_service.dart
@@ -8,7 +8,11 @@ import '../models/leaderboard_entry.dart';
 /// et permet de récupérer un classement trié par pourcentage décroissant,
 /// puis par durée croissante.
 class CompetitionService {
-  final _col = FirebaseFirestore.instance.collection('competition_scores');
+  final CollectionReference<Map<String, dynamic>> _col;
+
+  CompetitionService({CollectionReference<Map<String, dynamic>>? col})
+      : _col = col ??
+            FirebaseFirestore.instance.collection('competition_scores');
 
   /// Sauvegarde ou met à jour un résultat de compétition pour l'utilisateur.
   Future<void> saveEntry(LeaderboardEntry entry) async {
@@ -22,6 +26,9 @@ class CompetitionService {
   }
 
   /// Récupère les meilleurs résultats (max 100 par défaut).
+  ///
+  /// En cas d'erreur (par exemple réseau), l'exception est relancée afin
+  /// que l'appelant puisse l'intercepter et afficher un message adapté.
   Future<List<LeaderboardEntry>> topEntries({int limit = 100}) async {
     try {
       final snap = await _col
@@ -33,7 +40,7 @@ class CompetitionService {
           .map((d) => LeaderboardEntry.fromJson(d.data()))
           .toList();
     } catch (e) {
-      return [];
+      rethrow;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dev_dependencies:
   flutter_lints: ^3.0.1
   flutter_native_splash: ^2.4.2
   flutter_launcher_icons: ^0.13.1
+  mocktail: ^1.0.0
 
 flutter:
   uses-material-design: true

--- a/test/competition_service_error_test.dart
+++ b/test/competition_service_error_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:civexam_app/services/competition_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class FailingCollectionReference extends Fake
+    implements CollectionReference<Map<String, dynamic>> {
+  @override
+  Query<Map<String, dynamic>> orderBy(String field,
+          {bool descending = false}) =>
+      this;
+
+  @override
+  Query<Map<String, dynamic>> limit(int limit) => this;
+
+  @override
+  Future<QuerySnapshot<Map<String, dynamic>>> get([GetOptions? options]) {
+    throw FirebaseException(
+        plugin: 'firestore', code: 'unavailable', message: 'network');
+  }
+}
+
+void main() {
+  test('topEntries rethrows Firestore errors', () async {
+    final service = CompetitionService(col: FailingCollectionReference());
+    expect(service.topEntries(), throwsA(isA<FirebaseException>()));
+  });
+}

--- a/test/dashboard_screen_error_test.dart
+++ b/test/dashboard_screen_error_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:civexam_app/models/leaderboard_entry.dart';
+import 'package:civexam_app/screens/dashboard_screen.dart';
+import 'package:civexam_app/services/competition_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mocktail/mocktail.dart';
+
+class DummyCollectionReference extends Fake
+    implements CollectionReference<Map<String, dynamic>> {}
+
+class FakeCompetitionService extends CompetitionService {
+  FakeCompetitionService() : super(col: DummyCollectionReference());
+
+  @override
+  Stream<List<LeaderboardEntry>> topEntriesStream({int limit = 100}) {
+    return Stream.error(Exception('network'));
+  }
+}
+
+void main() {
+  testWidgets('shows error message when stream fails', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: DashboardScreen(service: FakeCompetitionService()),
+    ));
+
+    // allow stream to emit the error
+    await tester.pump();
+
+    expect(find.text('Erreur de chargement du classement'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Allow `CompetitionService.topEntries` to rethrow errors instead of swallowing them
- Show a SnackBar and message when leaderboard stream fails on `DashboardScreen`
- Document new error handling and add tests for simulated network failures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5eac06090832fbf3ada9fc9bec494