### PR TITLE
feat: allow profile photo upload

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   firebase_core: ^2.15.1
   firebase_auth: ^4.9.0
   cloud_firestore: ^4.9.0
+  firebase_storage: ^11.2.5
   wakelock_plus: ^1.3.2
   flutter_windowmanager:
     path: third_party/flutter_windowmanager


### PR DESCRIPTION
## Summary
- add firebase storage dependency
- show dashboard profile avatar and camera button
- allow picking image and uploading to storage

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c5eee57478832fbd7c58d612721c0b