### PR TITLE
Add profile action icons to DashboardScreen

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -137,7 +137,19 @@ class _DashboardScreenState extends State<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Mon dashboard')),
+      appBar: AppBar(
+        title: const Text('Mon dashboard'),
+        actions: [
+          IconButton(
+              onPressed: _pickPhoto,
+              icon: const Icon(Icons.camera_alt),
+              tooltip: 'Changer la photo'),
+          IconButton(
+              onPressed: _editName,
+              icon: const Icon(Icons.edit),
+              tooltip: 'Modifier le nom'),
+        ],
+      ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _entry == null
@@ -159,17 +171,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
                                 ? null
                                 : const Icon(Icons.person),
                           ),
-                          IconButton(
-                              onPressed: _pickPhoto,
-                              icon: const Icon(Icons.camera_alt)),
                           Expanded(
                               child: Text(
                                   'Pseudo : ${_profile?.nickname ?? ''}',
                                   style:
                                       Theme.of(context).textTheme.titleLarge)),
-                          IconButton(
-                              onPressed: _editName,
-                              icon: const Icon(Icons.edit)),
                         ],
                       ),
                       const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- Add camera and edit icons to DashboardScreen AppBar for changing photo and editing nickname
- Remove inline action icons from profile row

## Testing
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68c5f02b0a30832fb58186a6e98484db