### PR TITLE
Normalize question filters across app

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -52,12 +52,13 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
   }
 
   List<Question> _filterBy(List<Question> items, {required String subject, required String chapter}) {
-    String norm(String s) => s.toLowerCase().trim();
-    final s0 = norm(subject);
-    final c0 = norm(chapter);
-    final exact = items.where((q) => norm(q.subject) == s0 && norm(q.chapter) == c0).toList(growable: false);
+    final s0 = QuestionLoader.canon(subject);
+    final c0 = QuestionLoader.canon(chapter);
+    final exact = items
+        .where((q) => QuestionLoader.canon(q.subject) == s0 && QuestionLoader.canon(q.chapter) == c0)
+        .toList(growable: false);
     if (exact.isNotEmpty) return exact;
-    return items.where((q) => norm(q.subject) == s0).toList(growable: false);
+    return items.where((q) => QuestionLoader.canon(q.subject) == s0).toList(growable: false);
   }
 
   Future<void> _start() async {

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -53,25 +53,24 @@ int? secondsPerQuestion(ExamDifficulty d) {
   }
 }
 
-String _norm(String s) => s.toLowerCase().trim();
-
 List<Question> _filterQuestions(List<Question> all, String subject, String chapter) {
-  final s0 = _norm(subject);
-  final c0 = _norm(chapter);
+  final s0 = QuestionLoader.canon(subject);
+  final c0 = QuestionLoader.canon(chapter);
   final subjectAliases = {
-    'droit (ohada)': 'droit constitutionnel',
-    'logique': 'organisation & logique',
+    QuestionLoader.canon('droit (ohada)'): QuestionLoader.canon('droit constitutionnel'),
+    QuestionLoader.canon('logique'): QuestionLoader.canon('organisation & logique'),
   };
   final chapterAliases = {
-    'institutions': 'institutions & principes',
-    'geographie de la ci': 'côte d’ivoire',
-    'geographie de la côte d’ivoire': 'côte d’ivoire',
+    QuestionLoader.canon('institutions'): QuestionLoader.canon('institutions & principes'),
+    QuestionLoader.canon('geographie de la ci'): QuestionLoader.canon("côte d’Ivoire"),
+    QuestionLoader.canon('geographie de la côte d’ivoire'): QuestionLoader.canon("côte d’Ivoire"),
   };
   final s = subjectAliases[s0] ?? s0;
   final c = chapterAliases[c0] ?? c0;
-  final exact = all.where((q) => _norm(q.subject) == s && _norm(q.chapter) == c).toList(growable: false);
+  final exact =
+      all.where((q) => QuestionLoader.canon(q.subject) == s && QuestionLoader.canon(q.chapter) == c).toList(growable: false);
   if (exact.isNotEmpty) return exact;
-  final bySubject = all.where((q) => _norm(q.subject) == s).toList(growable: false);
+  final bySubject = all.where((q) => QuestionLoader.canon(q.subject) == s).toList(growable: false);
   return bySubject;
 }
 

--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -10,13 +10,24 @@
 // -----------------------------------------------------------------------------
 
 import 'dart:convert';
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import '../models/question.dart';
 
-String _norm(String s) => s.toLowerCase().trim();
+String _norm(String s) {
+  final base = removeDiacritics(s)
+      .toLowerCase()
+      .replaceAll(RegExp(r"[’`´‘]"), "'")
+      .trim();
+  const aliases = {
+    'culture generale': 'culture générale',
+  };
+  return aliases[base] ?? base;
+}
 
 class QuestionLoader {
+  static String canon(String s) => _norm(s);
   /// Tente de charger la banque principale puis, en fallback, un échantillon.
   static Future<List<Question>> loadENA() async {
     final paths = <String>[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   device_info_plus: ^10.0.0
   confetti: ^0.7.0
   image_picker: ^1.0.5
+  diacritic: ^0.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- strip diacritics and unify apostrophes in question filtering helpers
- reuse QuestionLoader canonicalization across ChapterList and multi-exam screens
- declare diacritic dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c601cf2074832fb526a943802b89ed