### PR TITLE
refactor: centralize subject/chapter filtering

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -36,7 +36,11 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
   Future<void> _load() async {
     try {
       final all = await QuestionLoader.loadENA();
-      final pool = _filterBy(all, subject: widget.subjectName, chapter: widget.chapterName);
+      final pool = QuestionLoader.bySubjectChapter(
+        all,
+        subject: widget.subjectName,
+        chapter: widget.chapterName,
+      );
       if (!mounted) return;
       setState(() {
         _pool = pool;
@@ -49,15 +53,6 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
         SnackBar(content: Text(e.toString())),
       );
     }
-  }
-
-  List<Question> _filterBy(List<Question> items, {required String subject, required String chapter}) {
-    String norm(String s) => s.toLowerCase().trim();
-    final s0 = norm(subject);
-    final c0 = norm(chapter);
-    final exact = items.where((q) => norm(q.subject) == s0 && norm(q.chapter) == c0).toList(growable: false);
-    if (exact.isNotEmpty) return exact;
-    return items.where((q) => norm(q.subject) == s0).toList(growable: false);
   }
 
   Future<void> _start() async {

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -69,10 +69,7 @@ List<Question> _filterQuestions(List<Question> all, String subject, String chapt
   };
   final s = subjectAliases[s0] ?? s0;
   final c = chapterAliases[c0] ?? c0;
-  final exact = all.where((q) => _norm(q.subject) == s && _norm(q.chapter) == c).toList(growable: false);
-  if (exact.isNotEmpty) return exact;
-  final bySubject = all.where((q) => _norm(q.subject) == s).toList(growable: false);
-  return bySubject;
+  return QuestionLoader.bySubjectChapter(all, subject: s, chapter: c);
 }
 
 class ExamSection {

--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -135,15 +135,19 @@ class QuestionLoader {
   // Helpers de filtrage
   // ----------------------
 
-  /// Filtre par matière/chapter (valeurs pleines). Renvoie une nouvelle liste.
-  static List<Question> whereSubjectChapter(
+  /// Filtre par matière et module. Si aucun module ne correspond, renvoie
+  /// toutes les questions de la matière.
+  static List<Question> bySubjectChapter(
     List<Question> all, {
     required String subject,
     required String chapter,
   }) {
     final s = _norm(subject);
     final c = _norm(chapter);
-    return all.where((q) => _norm(q.subject) == s && _norm(q.chapter) == c).toList(growable: false);
+    final exact =
+        all.where((q) => _norm(q.subject) == s && _norm(q.chapter) == c).toList(growable: false);
+    if (exact.isNotEmpty) return exact;
+    return all.where((q) => _norm(q.subject) == s).toList(growable: false);
   }
 
   /// Filtre par texte « value » à l'intérieur de l'intitulé + matière + chapitre.


### PR DESCRIPTION
## Summary
- remove unused `whereSubjectChapter` from question loader
- centralize subject+chapter filtering via new `bySubjectChapter`
- reuse helper in multi-exam flow and chapter list screens

## Testing
- `dart format lib/services/question_loader.dart lib/screens/chapter_list_screen.dart lib/screens/multi_exam_flow.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c601d40748832f9df62676f39e7ae3