### PR TITLE
Handle chapters without matching questions

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -42,6 +42,11 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
         _pool = pool;
         _loading = false;
       });
+      if (pool.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Aucune question pour ce module')),
+        );
+      }
     } catch (e) {
       if (!mounted) return;
       setState(() => _loading = false);
@@ -54,16 +59,16 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
   List<Question> _filterBy(List<Question> items, {required String subject, required String chapter}) {
     final s0 = QuestionLoader.canon(subject);
     final c0 = QuestionLoader.canon(chapter);
-    final exact = items
+    return items
         .where((q) => QuestionLoader.canon(q.subject) == s0 && QuestionLoader.canon(q.chapter) == c0)
         .toList(growable: false);
-    if (exact.isNotEmpty) return exact;
-    return items.where((q) => QuestionLoader.canon(q.subject) == s0).toList(growable: false);
   }
 
   Future<void> _start() async {
     if (_pool.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Aucune question disponible pour ce module.')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Aucune question pour ce module')),
+      );
       return;
     }
     final selected = pickAndShuffle(_pool, _questionCount);

--- a/test/question_filter_test.dart
+++ b/test/question_filter_test.dart
@@ -161,5 +161,36 @@ void main() {
 
     expect(find.text('Questions dispo pour ce module : 2'), findsOneWidget);
   });
+
+  testWidgets('ChapterListScreen shows message when no questions match module', (tester) async {
+    final questionsJson = jsonEncode([
+      {
+        'id': 'Q1',
+        'concours': 'ENA',
+        'subject': 'Droit Constitutionnel',
+        'chapter': 'Institutions',
+        'difficulty': 1,
+        'question': 'Q1?',
+        'choices': ['A', 'B'],
+        'answerIndex': 0,
+      }
+    ]);
+
+    mockAssets({
+      'assets/questions/civexam_questions_ena_core.json': questionsJson,
+    });
+
+    await tester.pumpWidget(const MaterialApp(
+      home: ChapterListScreen(
+        subjectName: 'Droit Constitutionnel',
+        chapterName: 'Institutions & principes',
+      ),
+    ));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Questions dispo pour ce module : 0'), findsOneWidget);
+    expect(find.text('Aucune question pour ce module'), findsOneWidget);
+  });
 }
 


### PR DESCRIPTION
## Summary
- Do not fall back to subject questions when no chapter match exists
- Notify user when a module has no questions
- Test chapter filtering with no matching questions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c604811770832f974cc38282b7d537