### PR TITLE
Add persistent question history to avoid repeats

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/question_loader.dart';
 import '../services/question_randomizer.dart';
+import '../services/question_history_store.dart';
 import '../models/question.dart';
 import '../services/scoring.dart';
 import '../models/training_history_entry.dart';
@@ -71,7 +72,8 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
       );
       return;
     }
-    final selected = pickAndShuffle(_pool, _questionCount);
+    final selected = await pickAndShuffle(_pool, _questionCount);
+    await QuestionHistoryStore.addAll(selected.map((q) => q.id));
     final totalSeconds = _perQuestionSeconds * selected.length;
 
     final scoring = const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 1);

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -5,6 +5,7 @@ import '../services/question_loader.dart';
 import '../services/history_store.dart';
 import '../models/exam_history_entry.dart';
 import '../services/question_randomizer.dart';
+import '../services/question_history_store.dart';
 import '../services/exam_blueprint.dart';
 import 'exam_full_screen.dart';
 import 'exam_history_screen.dart';
@@ -172,9 +173,12 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
     abandoned = false;
     final perQ = secondsPerQuestion(_difficulty);
 
+    await QuestionHistoryStore.clear();
+
     for (final sec in sections) {
       final pool = _filterQuestions(all, sec.subject, sec.chapter);
-      final qs = pickAndShuffle(pool, sec.targetCount);
+      final qs = await pickAndShuffle(pool, sec.targetCount);
+      await QuestionHistoryStore.addAll(qs.map((q) => q.id));
 
       // Choisir la durée en fonction de la difficulté
       final Duration effDuration;

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -21,6 +21,7 @@ import 'competition_screen.dart';
 import 'login_screen.dart';
 import '../services/question_loader.dart';
 import '../services/question_randomizer.dart';
+import '../services/question_history_store.dart';
 
 class PlayScreen extends StatefulWidget {
   const PlayScreen({super.key});
@@ -212,7 +213,8 @@ class _PlayScreenState extends State<PlayScreen> {
       case 6:
         try {
           final all = await QuestionLoader.loadENA();
-          final selected = pickAndShuffle(all, 20);
+          final selected = await pickAndShuffle(all, 20);
+          await QuestionHistoryStore.addAll(selected.map((q) => q.id));
           if (!mounted) return;
           Navigator.push(
             context,

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -3,6 +3,7 @@ import '../services/question_loader.dart';
 import '../models/question.dart';
 import '../services/scoring.dart';
 import '../services/question_randomizer.dart';
+import '../services/question_history_store.dart';
 import '../models/training_history_entry.dart';
 import '../services/training_history_store.dart';
 import 'exam_full_screen.dart';
@@ -28,7 +29,8 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
     setState(() => _loading = true);
     try {
       final List<Question> all = await QuestionLoader.loadENA();
-      final List<Question> selected = pickAndShuffle(all, _questionCount);
+      final List<Question> selected = await pickAndShuffle(all, _questionCount);
+      await QuestionHistoryStore.addAll(selected.map((q) => q.id));
 
       final totalSeconds = _perQuestionSeconds * _questionCount;
       final scoring = const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 1);

--- a/lib/services/question_history_store.dart
+++ b/lib/services/question_history_store.dart
@@ -1,0 +1,37 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists IDs of questions already used so we can avoid repetitions
+/// across quiz sessions.
+class QuestionHistoryStore {
+  static const String _key = 'questionHistoryV1';
+
+  /// Loads the set of question IDs already used.
+  static Future<Set<String>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = prefs.getStringList(_key);
+    if (list == null || list.isEmpty) return <String>{};
+    return list.toSet();
+  }
+
+  /// Adds a single question ID to the history store.
+  static Future<void> add(String id) async {
+    final ids = await load();
+    ids.add(id);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, ids.toList());
+  }
+
+  /// Adds multiple question IDs to the history store.
+  static Future<void> addAll(Iterable<String> ids) async {
+    final current = await load();
+    current.addAll(ids);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_key, current.toList());
+  }
+
+  /// Clears the stored question IDs.
+  static Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}

--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -4,6 +4,7 @@
 // -----------------------------------------------------------------------------
 import 'dart:math';
 import '../models/question.dart';
+import 'question_history_store.dart';
 
 final _rng = Random();
 
@@ -37,10 +38,15 @@ Question shuffleChoices(Question q, {Random? rng}) {
 
 /// Sélectionne jusqu'à `take` questions **au hasard**, puis mélange l'ordre
 /// des questions et des choix.
-List<Question> pickAndShuffle(List<Question> pool, int take, {Random? rng}) {
+Future<List<Question>> pickAndShuffle(List<Question> pool, int take, {Random? rng}) async {
   final r = rng ?? _rng;
   if (pool.isEmpty) return const <Question>[];
-  final copy = List<Question>.from(pool)..shuffle(r);
+
+  // Remove questions already seen according to the history store.
+  final history = await QuestionHistoryStore.load();
+  final filtered = pool.where((q) => !history.contains(q.id)).toList();
+
+  final copy = List<Question>.from(filtered)..shuffle(r);
   final n = take <= copy.length ? take : copy.length;
   final selected = copy.take(n).map((q) => shuffleChoices(q, rng: r)).toList();
   return selected;

--- a/test/question_loader_test.dart
+++ b/test/question_loader_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:civexam_app/models/question.dart';
 import 'package:civexam_app/services/question_loader.dart';
 import 'package:civexam_app/services/question_randomizer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   final binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -63,7 +64,8 @@ void main() {
     await expectLater(QuestionLoader.loadENA(), throwsException);
   });
 
-  test('pickAndShuffle is deterministic with injected Random', () {
+  test('pickAndShuffle is deterministic with injected Random', () async {
+    SharedPreferences.setMockInitialValues({});
     final pool = [
       const Question(
         id: 'Q1',
@@ -100,8 +102,8 @@ void main() {
     final r1 = Random(1);
     final r2 = Random(1);
 
-    final res1 = pickAndShuffle(pool, 3, rng: r1);
-    final res2 = pickAndShuffle(pool, 3, rng: r2);
+    final res1 = await pickAndShuffle(pool, 3, rng: r1);
+    final res2 = await pickAndShuffle(pool, 3, rng: r2);
 
     expect(res1.map((q) => q.id).toList(), res2.map((q) => q.id).toList());
     expect(res1.first.choices, res2.first.choices);


### PR DESCRIPTION
## Summary
- Store asked question IDs in new QuestionHistoryStore
- Filter out previously asked questions when randomizing
- Clear or update history in quiz entry points to prevent repeats

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c606f0c1fc832f81ce4f17fa6ae4a5