### PR TITLE
Set competition mode to 60 questions and display rubric

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -36,7 +36,7 @@ class CompetitionScreen extends StatefulWidget {
   CompetitionScreen({
     super.key,
     required this.questions,
-    this.drawCount = 20,
+    this.drawCount = 60,
     this.timePerQuestion = 5,
     this.currentIndex = 0,
     this.correctCount = 0,
@@ -152,13 +152,19 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                       ),
                     ),
                     const SizedBox(height: 16),
-                    // Question number within the current session.
-                    Text(
-                      'Question ${widget.currentIndex + 1}/${widget.drawCount}',
-                      style: theme.questionIndexTextStyle,
-                    ),
-                    const SizedBox(height: 8),
-                    // Actual question text.
+                      // Question number within the current session.
+                      Text(
+                        'Question ${widget.currentIndex + 1}/${widget.drawCount}',
+                        style: theme.questionIndexTextStyle,
+                      ),
+                      const SizedBox(height: 4),
+                      // Rubric/subject of the current question.
+                      Text(
+                        'Rubrique : ${_currentQuestion.subject}',
+                        style: theme.questionIndexTextStyle,
+                      ),
+                      const SizedBox(height: 8),
+                      // Actual question text.
                     Text(
                       _cleanQuestion(_currentQuestion.question),
                       style: theme.questionTextStyle,

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -213,7 +213,7 @@ class _PlayScreenState extends State<PlayScreen> {
       case 6:
         try {
           final all = await QuestionLoader.loadENA();
-          final selected = await pickAndShuffle(all, 20);
+          final selected = await pickAndShuffle(all, 60);
           await QuestionHistoryStore.addAll(selected.map((q) => q.id));
           if (!mounted) return;
           Navigator.push(


### PR DESCRIPTION
## Summary
- Increase competition mode draw to 60 questions
- Show the question's rubric (subject) on the competition screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60af48860832fa1617682d4c45ce6