### PR TITLE
Deduplicate questions before shuffle

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -44,7 +44,12 @@ Future<List<Question>> pickAndShuffle(List<Question> pool, int take, {Random? rn
 
   // Remove questions already seen according to the history store.
   final history = await QuestionHistoryStore.load();
-  final filtered = pool.where((q) => !history.contains(q.id)).toList();
+
+  // Deduplicate by question id while filtering out history entries.
+  final seen = <String>{};
+  final filtered = pool
+      .where((q) => !history.contains(q.id) && seen.add(q.id))
+      .toList();
 
   final copy = List<Question>.from(filtered)..shuffle(r);
   final n = take <= copy.length ? take : copy.length;


### PR DESCRIPTION
## Summary
- Deduplicate incoming question pools in `pickAndShuffle` to avoid repeated `Question.id`s before shuffling.

## Testing
- ⚠️ `dart analyze` *(missing `dart` command; attempted install but repositories inaccessible)*

------
https://chatgpt.com/codex/tasks/task_e_68c612f09800832f9010c1ab4d7ec51c