### PR TITLE
Avoid repeated questions with content dedupe

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -72,7 +72,11 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
       );
       return;
     }
-    final selected = await pickAndShuffle(_pool, _questionCount);
+    final selected = await pickAndShuffle(
+      _pool,
+      _questionCount,
+      dedupeByQuestion: true,
+    );
     await QuestionHistoryStore.addAll(selected.map((q) => q.id));
     final totalSeconds = _perQuestionSeconds * selected.length;
 

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -177,7 +177,11 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
 
     for (final sec in sections) {
       final pool = _filterQuestions(all, sec.subject, sec.chapter);
-      final qs = await pickAndShuffle(pool, sec.targetCount);
+      final qs = await pickAndShuffle(
+        pool,
+        sec.targetCount,
+        dedupeByQuestion: true,
+      );
       await QuestionHistoryStore.addAll(qs.map((q) => q.id));
 
       // Choisir la durée en fonction de la difficulté

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -213,7 +213,11 @@ class _PlayScreenState extends State<PlayScreen> {
       case 6:
         try {
           final all = await QuestionLoader.loadENA();
-          final selected = await pickAndShuffle(all, 60);
+          final selected = await pickAndShuffle(
+            all,
+            60,
+            dedupeByQuestion: true,
+          );
           await QuestionHistoryStore.addAll(selected.map((q) => q.id));
           if (!mounted) return;
           Navigator.push(

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -29,7 +29,11 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
     setState(() => _loading = true);
     try {
       final List<Question> all = await QuestionLoader.loadENA();
-      final List<Question> selected = await pickAndShuffle(all, _questionCount);
+      final List<Question> selected = await pickAndShuffle(
+        all,
+        _questionCount,
+        dedupeByQuestion: true,
+      );
       await QuestionHistoryStore.addAll(selected.map((q) => q.id));
 
       final totalSeconds = _perQuestionSeconds * _questionCount;

--- a/test/question_randomizer_dedupe_test.dart
+++ b/test/question_randomizer_dedupe_test.dart
@@ -1,0 +1,59 @@
+import 'dart:math';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:civexam_app/models/question.dart';
+import 'package:civexam_app/services/question_randomizer.dart';
+import 'package:civexam_app/services/question_history_store.dart';
+
+void main() {
+  test('dedupeByQuestion avoids duplicates across sessions', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    const q1 = Question(
+      id: 'Q1',
+      concours: 'ENA',
+      subject: 'S',
+      chapter: 'C',
+      difficulty: 1,
+      question: 'Dup?',
+      choices: ['A', 'B'],
+      answerIndex: 0,
+    );
+    const q2 = Question(
+      id: 'Q2',
+      concours: 'ENA',
+      subject: 'S',
+      chapter: 'C',
+      difficulty: 1,
+      question: 'Dup?',
+      choices: ['A', 'B'],
+      answerIndex: 0,
+    );
+    const q3 = Question(
+      id: 'Q3',
+      concours: 'ENA',
+      subject: 'S',
+      chapter: 'C',
+      difficulty: 1,
+      question: 'Unique?',
+      choices: ['A', 'B'],
+      answerIndex: 0,
+    );
+
+    final pool = [q1, q2, q3];
+
+    final first = await pickAndShuffle(pool, 1,
+        rng: Random(1), dedupeByQuestion: true);
+    await QuestionHistoryStore.addAll(first.map((q) => q.id));
+
+    final second = await pickAndShuffle(pool, 1,
+        rng: Random(2), dedupeByQuestion: true);
+    await QuestionHistoryStore.addAll(second.map((q) => q.id));
+
+    expect(first.first.question, isNot(second.first.question));
+
+    final third =
+        await pickAndShuffle(pool, 1, rng: Random(3), dedupeByQuestion: true);
+    expect(third, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Optionally dedupe selected questions by their text, ignoring those already seen
- Ensure training flows request content-level dedupe when drawing questions
- Add test covering cross-session dedupe behaviour

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61500b928832fa5dfc8d71057d617