### PR TITLE
Handle empty question selections before starting quizzes

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -77,6 +77,19 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
       _questionCount,
       dedupeByQuestion: true,
     );
+    if (selected.isEmpty) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Toutes les questions ont été vues.'),
+          action: SnackBarAction(
+            label: 'Réinitialiser',
+            onPressed: () => QuestionHistoryStore.clear(),
+          ),
+        ),
+      );
+      return;
+    }
     await QuestionHistoryStore.addAll(selected.map((q) => q.id));
     final totalSeconds = _perQuestionSeconds * selected.length;
 

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -182,6 +182,19 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
         sec.targetCount,
         dedupeByQuestion: true,
       );
+      if (qs.isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Toutes les questions ont été vues.'),
+            action: SnackBarAction(
+              label: 'Réinitialiser',
+              onPressed: () => QuestionHistoryStore.clear(),
+            ),
+          ),
+        );
+        return;
+      }
       await QuestionHistoryStore.addAll(qs.map((q) => q.id));
 
       // Choisir la durée en fonction de la difficulté

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -218,6 +218,19 @@ class _PlayScreenState extends State<PlayScreen> {
             60,
             dedupeByQuestion: true,
           );
+          if (selected.isEmpty) {
+            if (!mounted) return;
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: const Text('Toutes les questions ont été vues.'),
+                action: SnackBarAction(
+                  label: 'Réinitialiser',
+                  onPressed: () => QuestionHistoryStore.clear(),
+                ),
+              ),
+            );
+            return;
+          }
           await QuestionHistoryStore.addAll(selected.map((q) => q.id));
           if (!mounted) return;
           Navigator.push(

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -34,6 +34,19 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
         _questionCount,
         dedupeByQuestion: true,
       );
+      if (selected.isEmpty) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Toutes les questions ont été vues.'),
+            action: SnackBarAction(
+              label: 'Réinitialiser',
+              onPressed: () => QuestionHistoryStore.clear(),
+            ),
+          ),
+        );
+        return;
+      }
       await QuestionHistoryStore.addAll(selected.map((q) => q.id));
 
       final totalSeconds = _perQuestionSeconds * _questionCount;


### PR DESCRIPTION
## Summary
- Prevent starting quizzes when pickAndShuffle returns no questions
- Inform the user that all questions have been seen and offer to reset history

## Testing
- ⚠️ `dart format lib/screens/chapter_list_screen.dart lib/screens/play_screen.dart lib/screens/training_quick_start.dart lib/screens/multi_exam_flow.dart` *(dart not installed)*
- ⚠️ `flutter test` *(flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6181c70cc832fa8661597b1679427