### PR TITLE
Clarify default question count for training quick start

### DIFF
--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -19,11 +19,11 @@ class TrainingQuickStartScreen extends StatefulWidget {
 
 class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
   int _perQuestionSeconds = 10; // 5..10s/question via UI
-  int _questionCount = 10;
+  int _questionCount = 10; // default number of questions
   bool _loading = false;
 
   final List<int> _secondOptions = const [5, 6, 7, 8, 9, 10];
-  final List<int> _countOptions = const [5, 10, 15, 20];
+  final List<int> _countOptions = const [5, 10, 15, 20]; // allowed question counts
 
   Future<void> _start() async {
     setState(() => _loading = true);


### PR DESCRIPTION
## Summary
- Document that training quick start uses a default of 10 questions
- Note allowed question count options (5, 10, 15, 20) for quick start

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c61a9f5ee8832f982511e0556c3572