### PR TITLE
Set exam sections to 15 questions each

### DIFF
--- a/lib/services/exam_blueprint.dart
+++ b/lib/services/exam_blueprint.dart
@@ -5,8 +5,11 @@
 /// On répartit par défaut 15 questions *par épreuve* (4 x 15 = 60).
 /// Ajuste facilement ci-dessous si besoin.
 class ExamBlueprint {
-  static const int totalTarget = 60; // total visé
-  static const int perSection = 15;  // 15 par épreuve (4 épreuves)
+  // 15 questions par épreuve (4 épreuves)
+  static const int perSection = 15;
+
+  // total visé (4 x 15 = 60)
+  static const int totalTarget = perSection * 4;
 
   // Si tu veux un autre format (ex: 20 par section => 80 total), modifie ici.
   static const int cultureGenerale = perSection;


### PR DESCRIPTION
## Summary
- Define 15 questions per section and compute total target from this value.
- Use `perSection` for each exam area.

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c61a66b41c832f9a9b2e00f7920580