### PR TITLE
Update exam blueprint to 20 questions per section

### DIFF
--- a/README_QuestionCount_Shuffle.md
+++ b/README_QuestionCount_Shuffle.md
@@ -2,8 +2,8 @@
 
 ## Ce que fait ce patch
 - **Fix "bonnes réponses toujours en 1ère position"** : chaque question mélange ses **choix** et met à jour `answerIndex`.
-- **Nombre de questions identique au format ENA (60 total)** : configuration centrale (`ExamBlueprint`) avec **15 par épreuve** (4 épreuves = 60).
-  - Ajustable facilement (ex. 20 par épreuve => 80 total).
+- **Nombre de questions identique au format ENA (80 total)** : configuration centrale (`ExamBlueprint`) avec **20 par épreuve** (4 épreuves = 80).
+  - Ajustable facilement (ex. 25 par épreuve => 100 total).
 - Mélange **aléatoire** de l'ordre des questions **et** des choix à chaque session.
 
 ## Fichiers

--- a/lib/services/exam_blueprint.dart
+++ b/lib/services/exam_blueprint.dart
@@ -1,17 +1,17 @@
 /// Exam blueprint for ENA-like preselection
 /// Frequently observed public info indicates 4 QCM tests, 60 minutes each
 /// (Culture Générale, Aptitude Verbale, Organisation & Logique, Aptitude Numérique).
-/// Nombre de questions : certains formats mentionnent **60 questions au total**.
-/// On répartit par défaut 15 questions *par épreuve* (4 x 15 = 60).
+/// Nombre de questions : certains formats mentionnent **80 questions au total**.
+/// On répartit par défaut 20 questions *par épreuve* (4 x 20 = 80).
 /// Ajuste facilement ci-dessous si besoin.
 class ExamBlueprint {
-  // 15 questions par épreuve (4 épreuves)
-  static const int perSection = 15;
+  // 20 questions par épreuve (4 épreuves)
+  static const int perSection = 20;
 
-  // total visé (4 x 15 = 60)
+  // total visé (4 x 20 = 80)
   static const int totalTarget = perSection * 4;
 
-  // Si tu veux un autre format (ex: 20 par section => 80 total), modifie ici.
+  // Si tu veux un autre format, modifie ici.
   static const int cultureGenerale = perSection;
   static const int aptitudeVerbale = perSection;
   static const int organisationLogique = perSection;


### PR DESCRIPTION
## Summary
- set official exam section size to 20 questions and total target to 80
- document updated question counts in README_QuestionCount_Shuffle

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61ff9134c832f8ac2412e85c54735