### PR TITLE
Handle question history exhaustion before starting quizzes

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -77,18 +77,42 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
       _questionCount,
       dedupeByQuestion: true,
     );
-    if (selected.isEmpty) {
+    if (selected.length < _questionCount) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: const Text('Toutes les questions ont été vues.'),
+          content: Text('Historique épuisé — ${selected.length}/'
+              '$_questionCount questions disponibles.'),
           action: SnackBarAction(
             label: 'Réinitialiser',
             onPressed: () => QuestionHistoryStore.clear(),
           ),
         ),
       );
-      return;
+      if (selected.isEmpty) {
+        return;
+      }
+      final proceed = await showDialog<bool>(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('Commencer ?'),
+          content:
+              Text('Commencer avec ${selected.length} questions ?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(_, false),
+              child: const Text('Annuler'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(_, true),
+              child: const Text('Continuer'),
+            ),
+          ],
+        ),
+      );
+      if (proceed != true) {
+        return;
+      }
     }
     await QuestionHistoryStore.addAll(selected.map((q) => q.id));
     final totalSeconds = _perQuestionSeconds * selected.length;

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -212,24 +212,48 @@ class _PlayScreenState extends State<PlayScreen> {
         break;
       case 6:
         try {
+          const int desiredCount = 60;
           final all = await QuestionLoader.loadENA();
           final selected = await pickAndShuffle(
             all,
-            60,
+            desiredCount,
             dedupeByQuestion: true,
           );
-          if (selected.isEmpty) {
+          if (selected.length < desiredCount) {
             if (!mounted) return;
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: const Text('Toutes les questions ont été vues.'),
+                content: Text('Historique épuisé — ${selected.length}/'
+                    '$desiredCount questions disponibles.'),
                 action: SnackBarAction(
                   label: 'Réinitialiser',
                   onPressed: () => QuestionHistoryStore.clear(),
                 ),
               ),
             );
-            return;
+            if (selected.isEmpty) {
+              return;
+            }
+            final proceed = await showDialog<bool>(
+              context: context,
+              builder: (_) => AlertDialog(
+                title: const Text('Commencer ?'),
+                content: Text('Commencer avec ${selected.length} questions ?'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(_, false),
+                    child: const Text('Annuler'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(_, true),
+                    child: const Text('Continuer'),
+                  ),
+                ],
+              ),
+            );
+            if (proceed != true) {
+              return;
+            }
           }
           await QuestionHistoryStore.addAll(selected.map((q) => q.id));
           if (!mounted) return;

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -34,22 +34,46 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
         _questionCount,
         dedupeByQuestion: true,
       );
-      if (selected.isEmpty) {
+      if (selected.length < _questionCount) {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: const Text('Toutes les questions ont été vues.'),
+            content: Text('Historique épuisé — ${selected.length}/'
+                '$_questionCount questions disponibles.'),
             action: SnackBarAction(
               label: 'Réinitialiser',
               onPressed: () => QuestionHistoryStore.clear(),
             ),
           ),
         );
-        return;
+        if (selected.isEmpty) {
+          return;
+        }
+        final proceed = await showDialog<bool>(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('Commencer ?'),
+            content:
+                Text('Commencer avec ${selected.length} questions ?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(_, false),
+                child: const Text('Annuler'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(_, true),
+                child: const Text('Continuer'),
+              ),
+            ],
+          ),
+        );
+        if (proceed != true) {
+          return;
+        }
       }
       await QuestionHistoryStore.addAll(selected.map((q) => q.id));
 
-      final totalSeconds = _perQuestionSeconds * _questionCount;
+      final totalSeconds = _perQuestionSeconds * selected.length;
       final scoring = const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 1);
 
       final startTime = DateTime.now();


### PR DESCRIPTION
## Summary
- guard quiz launch when question history doesn't provide requested number
- show snackbar with reset option and ask user to confirm starting with fewer questions
- adjust duration to actual question count

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c62210c7f4832f807951c4439068d3