### PR TITLE
Ensure question randomizer meets requested count

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -84,13 +84,14 @@ Future<List<Question>> pickAndShuffle(
     filtered.add(q);
   }
 
-  // If filtering removed too many questions while the pool still contains
-  // enough items, clear history and retry without history/deduplication to
-  // ensure at least `take` questions are returned.
-  if (filtered.length < take && pool.length >= take &&
-      (history.isNotEmpty || dedupeByQuestion)) {
-    await QuestionHistoryStore.clear();
-    return pickAndShuffle(pool, take, rng: r, dedupeByQuestion: false);
+  // After filtering, if fewer than `take` questions remain while the original
+  // pool still has more items, clear the history and retry without
+  // de-duplication to obtain at least `take` questions.
+  if (filtered.length < take && pool.length > filtered.length) {
+    if (history.isNotEmpty || dedupeByQuestion) {
+      await QuestionHistoryStore.clear();
+      return pickAndShuffle(pool, take, rng: r, dedupeByQuestion: false);
+    }
   }
 
   final copy = List<Question>.from(filtered)..shuffle(r);

--- a/test/question_randomizer_minimum_test.dart
+++ b/test/question_randomizer_minimum_test.dart
@@ -1,0 +1,31 @@
+import 'dart:math';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:civexam_app/models/question.dart';
+import 'package:civexam_app/services/question_randomizer.dart';
+import 'package:civexam_app/services/question_history_store.dart';
+
+void main() {
+  test('returns at least 10 questions when pool has enough items', () async {
+    SharedPreferences.setMockInitialValues({});
+
+    final pool = List<Question>.generate(
+      20,
+      (i) => Question(
+        id: 'Q\${i + 1}',
+        concours: 'ENA',
+        subject: 'S',
+        chapter: 'C',
+        difficulty: 1,
+        question: 'Question \${i + 1}?',
+        choices: ['A', 'B'],
+        answerIndex: 0,
+      ),
+    );
+
+    await QuestionHistoryStore.addAll(pool.take(15).map((q) => q.id));
+
+    final selected = await pickAndShuffle(pool, 10, rng: Random(42));
+    expect(selected.length, greaterThanOrEqualTo(10));
+  });
+}


### PR DESCRIPTION
## Summary
- Retry question selection without de-duplication when filtering yields too few questions
- Add unit test to confirm requesting 10 questions yields at least 10 items when available

## Testing
- `flutter test test/question_randomizer_minimum_test.dart` *(fails: command not found)*
- `dart test test/question_randomizer_minimum_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c629aa48f8832fb6d8175afb169161