### PR TITLE
Use questions length for competition progress

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -9,9 +9,6 @@ class CompetitionScreen extends StatefulWidget {
   /// List of questions drawn for the competition.
   final List<Question> questions;
 
-  /// Number of questions in this session.
-  final int drawCount;
-
   /// Time allowed for each question (seconds).
   final int timePerQuestion;
 
@@ -36,7 +33,6 @@ class CompetitionScreen extends StatefulWidget {
   CompetitionScreen({
     super.key,
     required this.questions,
-    this.drawCount = 60,
     this.timePerQuestion = 5,
     this.currentIndex = 0,
     this.correctCount = 0,
@@ -154,7 +150,7 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                     const SizedBox(height: 16),
                       // Question number within the current session.
                       Text(
-                        'Question ${widget.currentIndex + 1}/${widget.drawCount}',
+                        'Question ${widget.currentIndex + 1}/${widget.questions.length}',
                         style: theme.questionIndexTextStyle,
                       ),
                       const SizedBox(height: 4),
@@ -172,7 +168,7 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                     const SizedBox(height: 12),
                     // Progress bar for overall quiz progression.
                     LinearProgressIndicator(
-                      value: (widget.currentIndex + 1) / widget.drawCount,
+                      value: (widget.currentIndex + 1) / widget.questions.length,
                       color: theme.progressBarColor,
                       backgroundColor:
                           theme.progressBarColor.withOpacity(0.3),
@@ -256,14 +252,13 @@ class _CompetitionScreenState extends State<CompetitionScreen>
     final int totalWrong = widget.wrongCount + (isWrong ? 1 : 0);
     final int totalBlank = widget.blankCount + (isBlank ? 1 : 0);
 
-    if (widget.currentIndex + 1 < widget.drawCount) {
+    if (widget.currentIndex + 1 < widget.questions.length) {
       // Continue to the next question by replacing the current screen.
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(
           builder: (_) => CompetitionScreen(
             questions: widget.questions,
-            drawCount: widget.drawCount,
             timePerQuestion: widget.timePerQuestion,
             currentIndex: widget.currentIndex + 1,
             correctCount: totalCorrect,
@@ -282,7 +277,7 @@ class _CompetitionScreenState extends State<CompetitionScreen>
         context,
         MaterialPageRoute(
           builder: (_) => CompetitionResultScreen(
-            total: widget.drawCount,
+            total: widget.questions.length,
             correct: totalCorrect,
             wrong: totalWrong,
             blank: totalBlank,

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -233,7 +233,6 @@ class _PlayScreenState extends State<PlayScreen> {
             MaterialPageRoute(
               builder: (_) => CompetitionScreen(
                 questions: selected,
-                drawCount: selected.length,
                 timePerQuestion: 5,
                 startTime: DateTime.now(),
               ),

--- a/test/competition_navigation_test.dart
+++ b/test/competition_navigation_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:civexam_pro/models/question.dart';
+import 'package:civexam_pro/screens/competition_screen.dart';
+
+void main() {
+  testWidgets('CompetitionScreen navigates through all questions',
+      (tester) async {
+    final questions = List.generate(
+      3,
+      (i) => Question(
+        id: 'q$i',
+        concours: 'ENA',
+        subject: 'Sujet',
+        chapter: 'Chap',
+        difficulty: 1,
+        question: 'Question $i',
+        choices: const ['A', 'B'],
+        answerIndex: 0,
+      ),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: CompetitionScreen(
+        questions: questions,
+        timePerQuestion: 5,
+        startTime: DateTime.now(),
+      ),
+    ));
+
+    for (var i = 0; i < questions.length; i++) {
+      expect(
+        find.text('Question ${i + 1}/${questions.length}'),
+        findsOneWidget,
+      );
+
+      if (i < questions.length - 1) {
+        await tester.tap(find.text('A'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+    }
+  });
+}
+


### PR DESCRIPTION
## Summary
- remove `drawCount` from `CompetitionScreen` and compute totals from `questions.length`
- update PlayScreen to match new `CompetitionScreen` signature
- add widget test to verify navigation across all competition questions

## Testing
- `flutter test` *(fails: bash: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c629b0ace0832fb17e3799ea21a48c