### PR TITLE
feat: warn when ENA bank incomplete

### DIFF
--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -47,7 +47,7 @@ class QuestionLoader {
 
         if (i == 0 && out.length < ExamBlueprint.totalTarget) {
           final msg =
-              'Bank $path has only ${out.length} questions (< ${ExamBlueprint.totalTarget})';
+              'Warning: bank $path has only ${out.length} questions (expected ${ExamBlueprint.totalTarget}); trying fallback.';
           // ignore: avoid_print
           print(msg);
           errors.add(msg);


### PR DESCRIPTION
## Summary
- warn when main ENA bank contains fewer questions than expected and attempt sample fallback

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68c62db4f5dc832fa3965e5f44f36dd9