### PR TITLE
Handle insufficient question pool in multi exam flow

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -177,9 +177,30 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
 
     for (final sec in sections) {
       final pool = _filterQuestions(all, sec.subject, sec.chapter);
+      var takeCount = sec.targetCount;
+      if (pool.length < sec.targetCount) {
+        if (!mounted) return;
+        final reason = await ScaffoldMessenger.of(context)
+            .showSnackBar(
+              SnackBar(
+                content: Text(
+                    'Seulement ${pool.length}/${sec.targetCount} questions disponibles pour ${sec.title}.'),
+                action: SnackBarAction(
+                  label: 'Continuer',
+                  onPressed: () {},
+                ),
+              ),
+            )
+            .closed;
+        if (!mounted) return;
+        if (reason != SnackBarClosedReason.action) {
+          return;
+        }
+        takeCount = pool.length;
+      }
       final qs = await pickAndShuffle(
         pool,
-        sec.targetCount,
+        takeCount,
         dedupeByQuestion: true,
       );
       if (qs.isEmpty) {


### PR DESCRIPTION
## Summary
- Check pool length before starting each section and inform the user when not enough questions are available.
- Allow continuing with the available questions via SnackBar action; otherwise abort.

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c62db6daac832f96796b158bb93797