### PR TITLE
Use double quotes in ENA question loader exception

### DIFF
--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -68,7 +68,7 @@ class QuestionLoader {
     }
 
     throw Exception(
-      'Aucune banque de questions ENA n'a pu être chargée. Détails: ${errors.join(' ; ')}',
+      "Aucune banque de questions ENA n'a pu être chargée. Détails: ${errors.join(' ; ')}",
     );
   }
 


### PR DESCRIPTION
## Summary
- fix exception message quoting in `loadENA`

## Testing
- `flutter build apk` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c62f4b5f08832f9a8c222d763bb981