### PR TITLE
Handle partial main bank without fallback

### DIFF
--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -47,11 +47,9 @@ class QuestionLoader {
 
         if (i == 0 && out.length < ExamBlueprint.totalTarget) {
           final msg =
-              'Warning: bank $path has only ${out.length} questions (expected ${ExamBlueprint.totalTarget}); trying fallback.';
+              'Warning: bank $path has only ${out.length} questions (expected ${ExamBlueprint.totalTarget}).';
           // ignore: avoid_print
           print(msg);
-          errors.add(msg);
-          continue; // try next bank
         }
 
         // OK


### PR DESCRIPTION
## Summary
- Allow loading primary question bank even when incomplete, logging a warning instead of falling back to sample bank

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c631719600832fb0b96b2153f57079