### PR TITLE
chore: use civexam_pro package name

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Civexam App</string>
+	<string>civexam_pro</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>civexam_app</string>
+	<string>civexam_pro</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "civexam_app")
+set(BINARY_NAME "civexam_pro")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.civexam_app")
+set(APPLICATION_ID "com.example.civexam_pro")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "civexam_app");
+    gtk_header_bar_set_title(header_bar, "civexam_pro");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "civexam_app");
+    gtk_window_set_title(window, "civexam_pro");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* civexam_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "civexam_app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* civexam_pro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "civexam_pro.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -131,7 +131,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* civexam_app.app */,
+				33CC10ED2044A3C60003C045 /* civexam_pro.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -217,7 +217,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* civexam_app.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* civexam_pro.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -388,7 +388,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.civexamApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/civexam_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/civexam_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/civexam_pro.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/civexam_pro";
 			};
 			name = Debug;
 		};
@@ -402,7 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.civexamApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/civexam_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/civexam_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/civexam_pro.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/civexam_pro";
 			};
 			name = Release;
 		};
@@ -416,7 +416,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.civexamApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/civexam_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/civexam_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/civexam_pro.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/civexam_pro";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "civexam_app.app"
+               BuildableName = "civexam_pro.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "civexam_app.app"
+            BuildableName = "civexam_pro.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "civexam_app.app"
+            BuildableName = "civexam_pro.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "civexam_app.app"
+            BuildableName = "civexam_pro.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = civexam_app
+PRODUCT_NAME = civexam_pro
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.civexamApp
+PRODUCT_BUNDLE_IDENTIFIER = com.example.civexamPro
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.

--- a/test/app_widget_test.dart
+++ b/test/app_widget_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:civexam_app/firebase_options.dart';
-import 'package:civexam_app/main.dart';
+import 'package:civexam_pro/firebase_options.dart';
+import 'package:civexam_pro/main.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:civexam_app/firebase_options.dart';
-import 'package:civexam_app/services/auth_service.dart';
+import 'package:civexam_pro/firebase_options.dart';
+import 'package:civexam_pro/services/auth_service.dart';
 
 void main() {
   setUpAll(() async {

--- a/test/design_config_from_json_test.dart
+++ b/test/design_config_from_json_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:civexam_app/models/design_config.dart';
+import 'package:civexam_pro/models/design_config.dart';
 
 void main() {
   test('fromJson ignores non-bool values', () {

--- a/test/design_prefs_test.dart
+++ b/test/design_prefs_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:civexam_app/services/design_prefs.dart';
-import 'package:civexam_app/models/design_config.dart';
+import 'package:civexam_pro/services/design_prefs.dart';
+import 'package:civexam_pro/models/design_config.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/exam_mode_question_count_test.dart
+++ b/test/exam_mode_question_count_test.dart
@@ -6,10 +6,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:civexam_app/services/question_loader.dart';
-import 'package:civexam_app/services/question_randomizer.dart';
-import 'package:civexam_app/services/question_history_store.dart';
-import 'package:civexam_app/services/exam_blueprint.dart';
+import 'package:civexam_pro/services/question_loader.dart';
+import 'package:civexam_pro/services/question_randomizer.dart';
+import 'package:civexam_pro/services/question_history_store.dart';
+import 'package:civexam_pro/services/exam_blueprint.dart';
 
 void main() {
   final binding = TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -1,6 +1,6 @@
-import 'package:civexam_app/firebase_options.dart';
-import 'package:civexam_app/screens/login_screen.dart';
-import 'package:civexam_app/widgets/primary_button.dart';
+import 'package:civexam_pro/firebase_options.dart';
+import 'package:civexam_pro/screens/login_screen.dart';
+import 'package:civexam_pro/widgets/primary_button.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/official_intro_screen_test.dart
+++ b/test/official_intro_screen_test.dart
@@ -3,8 +3,8 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:civexam_app/screens/official_intro_screen.dart';
-import 'package:civexam_app/screens/multi_exam_flow.dart';
+import 'package:civexam_pro/screens/official_intro_screen.dart';
+import 'package:civexam_pro/screens/multi_exam_flow.dart';
 
 void main() {
   final binding = TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/question_bank_validation_test.dart
+++ b/test/question_bank_validation_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:civexam_app/data/ena_taxonomy.dart';
+import 'package:civexam_pro/data/ena_taxonomy.dart';
 
 void main() {
   test('all questions have valid subject/chapter and no duplicates', () async {

--- a/test/question_filter_test.dart
+++ b/test/question_filter_test.dart
@@ -2,9 +2,9 @@ import 'dart:convert';
 import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:civexam_app/models/question.dart';
-import 'package:civexam_app/services/question_loader.dart';
-import 'package:civexam_app/screens/chapter_list_screen.dart';
+import 'package:civexam_pro/models/question.dart';
+import 'package:civexam_pro/services/question_loader.dart';
+import 'package:civexam_pro/screens/chapter_list_screen.dart';
 import 'package:flutter/material.dart';
 
 void main() {

--- a/test/question_loader_test.dart
+++ b/test/question_loader_test.dart
@@ -3,9 +3,9 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:civexam_app/models/question.dart';
-import 'package:civexam_app/services/question_loader.dart';
-import 'package:civexam_app/services/question_randomizer.dart';
+import 'package:civexam_pro/models/question.dart';
+import 'package:civexam_pro/services/question_loader.dart';
+import 'package:civexam_pro/services/question_randomizer.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {

--- a/test/question_parsing_test.dart
+++ b/test/question_parsing_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:civexam_app/models/question.dart';
+import 'package:civexam_pro/models/question.dart';
 
 void main() {
   test('Question parsing works', () {

--- a/test/question_randomizer_dedupe_test.dart
+++ b/test/question_randomizer_dedupe_test.dart
@@ -1,9 +1,9 @@
 import 'dart:math';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:civexam_app/models/question.dart';
-import 'package:civexam_app/services/question_randomizer.dart';
-import 'package:civexam_app/services/question_history_store.dart';
+import 'package:civexam_pro/models/question.dart';
+import 'package:civexam_pro/services/question_randomizer.dart';
+import 'package:civexam_pro/services/question_history_store.dart';
 
 void main() {
   test('dedupeByQuestion avoids duplicates across sessions', () async {

--- a/test/question_randomizer_minimum_test.dart
+++ b/test/question_randomizer_minimum_test.dart
@@ -1,9 +1,9 @@
 import 'dart:math';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:civexam_app/models/question.dart';
-import 'package:civexam_app/services/question_randomizer.dart';
-import 'package:civexam_app/services/question_history_store.dart';
+import 'package:civexam_pro/models/question.dart';
+import 'package:civexam_pro/services/question_randomizer.dart';
+import 'package:civexam_pro/services/question_history_store.dart';
 
 void main() {
   test('returns at least 10 questions when pool has enough items', () async {

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="civexam_app">
+  <meta name="apple-mobile-web-app-title" content="civexam_pro">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>civexam_app</title>
+  <title>civexam_pro</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "civexam_app",
-    "short_name": "civexam_app",
+    "name": "civexam_pro",
+    "short_name": "civexam_pro",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(civexam_app LANGUAGES CXX)
+project(civexam_pro LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "civexam_app")
+set(BINARY_NAME "civexam_pro")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "civexam_app" "\0"
+            VALUE "FileDescription", "civexam_pro" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "civexam_app" "\0"
+            VALUE "InternalName", "civexam_pro" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "civexam_app.exe" "\0"
-            VALUE "ProductName", "civexam_app" "\0"
+            VALUE "OriginalFilename", "civexam_pro.exe" "\0"
+            VALUE "ProductName", "civexam_pro" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"civexam_app", origin, size)) {
+  if (!window.Create(L"civexam_pro", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary
- replace package:civexam_app with package:civexam_pro in tests
- ensure all platform config files use civexam_pro naming

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6317776fc832fb1b67aed87258a89