### PR TITLE
Ensure fallback questions asset included in all pubspec variants

### DIFF
--- a/pubspec_cloud_sync.yaml
+++ b/pubspec_cloud_sync.yaml
@@ -2,3 +2,7 @@ dependencies:
   firebase_core: ^3.4.0
   firebase_auth: ^5.2.0
   cloud_firestore: ^5.4.0
+
+flutter:
+  assets:
+    - assets/questions/ena_sample.json

--- a/pubspec_combo.yaml
+++ b/pubspec_combo.yaml
@@ -31,9 +31,9 @@ flutter_icons:
   adaptive_icon_foreground: "assets/images/logo_icon_square.png"
   min_sdk_android: 21
 
-# N'oubliez pas d'énumérer les assets :
-# flutter:
-#   uses-material-design: true
-#   assets:
-#     - assets/images/logo_splash_square.png
-#     - assets/images/logo_icon_square.png
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/images/logo_splash_square.png
+    - assets/images/logo_icon_square.png
+    - assets/questions/ena_sample.json

--- a/pubspec_splash_patch.yaml
+++ b/pubspec_splash_patch.yaml
@@ -12,3 +12,7 @@ flutter_native_splash:
   android: true
   ios: false
   web: false
+
+flutter:
+  assets:
+    - assets/questions/ena_sample.json

--- a/pubspec_splash_patch_v2.yaml
+++ b/pubspec_splash_patch_v2.yaml
@@ -12,3 +12,7 @@ flutter_native_splash:
   android: true
   ios: false
   web: false
+
+flutter:
+  assets:
+    - assets/questions/ena_sample.json

--- a/pubspec_splash_square.yaml
+++ b/pubspec_splash_square.yaml
@@ -10,7 +10,7 @@ flutter_native_splash:
   ios: false
   web: false
 
-# Assurez-vous aussi d'avoir les assets ci-dessous dans la section flutter:
-# flutter:
-#   assets:
-#     - assets/images/logo_splash_square.png
+flutter:
+  assets:
+    - assets/images/logo_splash_square.png
+    - assets/questions/ena_sample.json

--- a/pubspec_splash_square_alt.yaml
+++ b/pubspec_splash_square_alt.yaml
@@ -10,3 +10,8 @@ flutter_native_splash:
   android: true
   ios: false
   web: false
+
+flutter:
+  assets:
+    - assets/images/logo_splash_square.png
+    - assets/questions/ena_sample.json


### PR DESCRIPTION
## Summary
- include `assets/questions/ena_sample.json` in all alternate pubspec files to avoid missing asset errors

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c633912474832f89a19048b7c83537