### PR TITLE
Generate ENA sections dynamically from taxonomy

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -7,6 +7,7 @@ import '../models/exam_history_entry.dart';
 import '../services/question_randomizer.dart';
 import '../services/question_history_store.dart';
 import '../services/exam_blueprint.dart';
+import '../data/ena_taxonomy.dart';
 import 'exam_full_screen.dart';
 import 'exam_history_screen.dart';
 
@@ -114,39 +115,26 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
   @override
   void initState() {
     super.initState();
+
+    final counts = {
+      'Culture Générale': ExamBlueprint.cultureGenerale,
+      'Droit Constitutionnel': ExamBlueprint.droitConstitutionnel,
+      'Problèmes Économiques & Sociaux': ExamBlueprint.problemesEconomiquesSociaux,
+      'Aptitude Numérique': ExamBlueprint.aptitudeNumerique,
+      'Aptitude Verbale': ExamBlueprint.aptitudeVerbale,
+      'Organisation & Logique': ExamBlueprint.organisationLogique,
+    };
+
     sections = [
-      ExamSection(
-        title: 'Culture Générale',
-        subject: 'Culture Générale',
-        chapter: 'Côte d’Ivoire',
-        duration: const Duration(minutes: 60),
-        scoring: const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 2),
-        targetCount: ExamBlueprint.cultureGenerale,
-      ),
-      ExamSection(
-        title: 'Aptitude Verbale',
-        subject: 'Aptitude Verbale',
-        chapter: 'Vocabulaire & règles',
-        duration: const Duration(minutes: 60),
-        scoring: const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 2),
-        targetCount: ExamBlueprint.aptitudeVerbale,
-      ),
-      ExamSection(
-        title: 'Organisation & Logique',
-        subject: 'Organisation & Logique',
-        chapter: 'Classements & déductions',
-        duration: const Duration(minutes: 60),
-        scoring: const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 2),
-        targetCount: ExamBlueprint.organisationLogique,
-      ),
-      ExamSection(
-        title: 'Aptitude Numérique',
-        subject: 'Aptitude Numérique',
-        chapter: 'Bases & proportionnalité',
-        duration: const Duration(minutes: 60),
-        scoring: const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 2),
-        targetCount: ExamBlueprint.aptitudeNumerique,
-      ),
+      for (final subj in subjectsENA)
+        ExamSection(
+          title: subj.name,
+          subject: subj.name,
+          chapter: subj.chapters.first.name,
+          duration: const Duration(minutes: 60),
+          scoring: const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 2),
+          targetCount: counts[subj.name] ?? ExamBlueprint.perSection,
+        ),
     ];
     _loadAll();
   }
@@ -350,12 +338,16 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
     switch (title) {
       case 'Culture Générale':
         return Icons.public;
+      case 'Droit Constitutionnel':
+        return Icons.account_balance;
+      case 'Problèmes Économiques & Sociaux':
+        return Icons.bar_chart;
+      case 'Aptitude Numérique':
+        return Icons.calculate;
       case 'Aptitude Verbale':
         return Icons.menu_book_outlined;
       case 'Organisation & Logique':
         return Icons.extension;
-      case 'Aptitude Numérique':
-        return Icons.calculate;
       default:
         return Icons.help_outline;
     }

--- a/lib/services/exam_blueprint.dart
+++ b/lib/services/exam_blueprint.dart
@@ -1,19 +1,21 @@
-/// Exam blueprint for ENA-like preselection
-/// Frequently observed public info indicates 4 QCM tests, 60 minutes each
-/// (Culture Générale, Aptitude Verbale, Organisation & Logique, Aptitude Numérique).
-/// Nombre de questions : le concours officiel comporte **100 questions au total**.
-/// On répartit donc 25 questions *par épreuve* (4 × 25 = 100).
+/// Exam blueprint for ENA-like preselection.
+/// Observed formats indicate 6 QCM tests, 60 minutes each:
+/// Culture Générale, Droit Constitutionnel, Problèmes Économiques & Sociaux,
+/// Aptitude Numérique, Aptitude Verbale et Organisation & Logique.
+/// Avec 25 questions par épreuve cela donne un total de 150 questions.
 /// Ajuste facilement ci-dessous si besoin.
 class ExamBlueprint {
-  // 25 questions par épreuve (4 épreuves)
+  // 25 questions par épreuve (6 épreuves)
   static const int perSection = 25;
 
-  // total visé (4 x 25 = 100)
-  static const int totalTarget = perSection * 4;
+  // total visé (6 x 25 = 150)
+  static const int totalTarget = perSection * 6;
 
   // Si tu veux un autre format, modifie ici.
   static const int cultureGenerale = perSection;
+  static const int droitConstitutionnel = perSection;
+  static const int problemesEconomiquesSociaux = perSection;
+  static const int aptitudeNumerique = perSection;
   static const int aptitudeVerbale = perSection;
   static const int organisationLogique = perSection;
-  static const int aptitudeNumerique = perSection;
 }

--- a/test/exam_mode_question_count_test.dart
+++ b/test/exam_mode_question_count_test.dart
@@ -40,9 +40,11 @@ void main() {
     // Build a synthetic bank with more than enough questions for each subject.
     final subjects = [
       'Culture Générale',
+      'Droit Constitutionnel',
+      'Problèmes Économiques & Sociaux',
+      'Aptitude Numérique',
       'Aptitude Verbale',
       'Organisation & Logique',
-      'Aptitude Numérique',
     ];
 
     final data = <Map<String, dynamic>>[];


### PR DESCRIPTION
## Summary
- build ENA exam sections dynamically from `subjectsENA`
- add Droit Constitutionnel and Problèmes Économiques & Sociaux sections with icons
- extend exam blueprint and tests for six ENA modules

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c730546344832f8e635dd08b978508