### PR TITLE
Add assertion for subject item count

### DIFF
--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -12,6 +12,10 @@ class SubjectListScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    assert(
+      subjectsENA.length == _subjectItems.length,
+      'subjectsENA and _subjectItems should have the same length',
+    );
     return ValueListenableBuilder<DesignConfig>(
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {


### PR DESCRIPTION
## Summary
- ensure SubjectListScreen catches mismatched subject and icon lists via an assertion

## Testing
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73494072c832f8f82483e9f13c75e