### PR TITLE
Load ENA questions on startup and build subjects dynamically

### DIFF
--- a/lib/data/ena_taxonomy.dart
+++ b/lib/data/ena_taxonomy.dart
@@ -1,3 +1,6 @@
+import 'package:diacritic/diacritic.dart';
+import '../models/question.dart';
+
 class Subject {
   final String name;
   final List<Chapter> chapters;
@@ -9,24 +12,40 @@ class Chapter {
   const Chapter(this.name);
 }
 
-// Aligne les intitulés avec le JSON (6 matières)
-const subjectsENA = <Subject>[
-  Subject('Culture Générale', [
-    Chapter('Côte d’Ivoire'),
-  ]),
-  Subject('Droit Constitutionnel', [
-    Chapter('Institutions & principes'),
-  ]),
-  Subject('Problèmes Économiques & Sociaux', [
-    Chapter('Notions clés'),
-  ]),
-  Subject('Aptitude Numérique', [
-    Chapter('Bases & proportionnalité'),
-  ]),
-  Subject('Aptitude Verbale', [
-    Chapter('Vocabulaire & règles'),
-  ]),
-  Subject('Organisation & Logique', [
-    Chapter('Classements & déductions'),
-  ]),
-];
+/// Liste dynamique des matières ENA (remplie à partir du JSON).
+List<Subject> subjectsENA = const <Subject>[];
+
+String _canon(String s) {
+  return removeDiacritics(s)
+      .toLowerCase()
+      .replaceAll(RegExp(r"[’`´‘]"), "'")
+      .trim();
+}
+
+/// Construit [subjectsENA] à partir de la liste de [questions].
+void buildSubjectsENA(List<Question> questions) {
+  final Map<String, String> subjectNames = {};
+  final Map<String, Map<String, String>> chapterNames = {};
+
+  for (final q in questions) {
+    final subjKey = _canon(q.subject);
+    final chapKey = _canon(q.chapter);
+    if (subjKey.isEmpty || chapKey.isEmpty) continue;
+    subjectNames.putIfAbsent(subjKey, () => q.subject);
+    final chapters = chapterNames.putIfAbsent(subjKey, () => <String, String>{});
+    chapters.putIfAbsent(chapKey, () => q.chapter);
+  }
+
+  final list = <Subject>[
+    for (final key in subjectNames.keys)
+      Subject(
+        subjectNames[key]!,
+        [
+          for (final c in chapterNames[key]!.values)
+            Chapter(c),
+        ]..sort((a, b) => a.name.compareTo(b.name)),
+      ),
+  ]..sort((a, b) => a.name.compareTo(b.name));
+
+  subjectsENA = list;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'app/theme.dart';
 import 'firebase_options.dart';
 import 'services/design_prefs.dart';
 import 'services/design_bus.dart';
+import 'services/question_loader.dart';
 import 'widgets/design_background.dart';
 import 'models/design_config.dart';
 import 'screens/splash_screen.dart';
@@ -18,6 +19,7 @@ Future<void> main() async {
           options: DefaultFirebaseOptions.currentPlatform);
       final cfg = await DesignPrefs.load();
       DesignBus.push(cfg);
+      await QuestionLoader.loadENA();
       runApp(const CivExamApp());
     } catch (e, st) {
       debugPrint('App initialization failed: $e\n$st');

--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -15,6 +15,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import '../models/question.dart';
 import 'exam_blueprint.dart';
+import '../data/ena_taxonomy.dart';
 
 String _norm(String s) {
   final base = removeDiacritics(s)
@@ -29,8 +30,12 @@ String _norm(String s) {
 
 class QuestionLoader {
   static String canon(String s) => _norm(s);
+  static List<Question>? _cache;
+
   /// Tente de charger la banque principale puis, en fallback, un échantillon.
   static Future<List<Question>> loadENA() async {
+    if (_cache != null) return _cache!;
+
     final paths = <String>[
       'assets/questions/civexam_questions_ena_core.json', // principal
       'assets/questions/ena_sample.json', // fallback
@@ -53,6 +58,8 @@ class QuestionLoader {
         }
 
         // OK
+        buildSubjectsENA(out);
+        _cache = out;
         return out;
       } catch (e) {
         final msg = 'Failed to load ENA questions from $path: $e';

--- a/test/question_bank_validation_test.dart
+++ b/test/question_bank_validation_test.dart
@@ -3,9 +3,11 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:civexam_pro/data/ena_taxonomy.dart';
+import 'package:civexam_pro/services/question_loader.dart';
 
 void main() {
   test('all questions have valid subject/chapter and no duplicates', () async {
+    await QuestionLoader.loadENA();
     // Prefer the full bank, but fall back to the sample when absent.
     final candidates = [
       'assets/questions/civexam_questions_ena_core.json',


### PR DESCRIPTION
## Summary
- Parse ENA question bank during app initialization via `QuestionLoader.loadENA`
- Build `subjectsENA` dynamically from parsed questions and cache results
- Refactor taxonomy into dynamic builder and adjust tests

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c734940b2c832f8651eed267820052