### PR TITLE
Require positive score for multi exam pass

### DIFF
--- a/README_QuestionCount_Shuffle.md
+++ b/README_QuestionCount_Shuffle.md
@@ -22,4 +22,4 @@
 
 ## Notes
 - Si la banque ne contient pas assez de questions pour une matière, l’épreuve prendra **autant que possible** (sans planter).
-- Tu peux régler le seuil de réussite dans `MultiExamFlowScreen` via `PASS_MIN_WEIGHTED`.
+- Tu peux régler le seuil de réussite dans `MultiExamFlowScreen` via `PASS_MIN_WEIGHTED` (valeur par défaut `1` pour exiger un score positif).

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -110,7 +110,10 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
 
   ExamDifficulty _difficulty = ExamDifficulty.normal;
 
-  static const int PASS_MIN_WEIGHTED = 0;
+  /// Minimum weighted score required to pass the exam.
+  /// A strictly positive value ensures that a non‑zero score is needed
+  /// to succeed.
+  static const int PASS_MIN_WEIGHTED = 1;
 
   @override
   void initState() {


### PR DESCRIPTION
## Summary
- Demand a strictly positive weighted score to pass multi-exam flow
- Document default positive threshold for PASS_MIN_WEIGHTED

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c73ce8d36c832f994bee6d728e9fef