### PR TITLE
Ensure SnackBar visible after splash navigation

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -42,11 +42,12 @@ class _SplashScreenState extends State<SplashScreen> {
 
   void _goToLogin(String message) {
     if (!mounted) return;
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const LoginScreen()),
-    );
+    // Show the message before navigating so it remains visible afterwards.
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(message)),
+    );
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
     );
   }
 


### PR DESCRIPTION
## Summary
- Show SnackBar before replacing SplashScreen with LoginScreen so message persists after navigation

## Testing
- `dart format lib/screens/splash_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c753842534832f95739cb6363d62fe