### PR TITLE
Log user profile load failures and handle upstream

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -46,7 +46,13 @@ class _DashboardScreenState extends State<DashboardScreen> {
     } else {
       entry = await service.entryForUser(uid);
     }
-    var profile = await _profileService.loadProfile(uid);
+    UserProfile? profile;
+    try {
+      profile = await _profileService.loadProfile(uid);
+    } catch (e, st) {
+      debugPrint('Failed to load profile for $uid: $e\n$st');
+      profile = null;
+    }
     profile ??= UserProfile(
         firstName: '',
         lastName: '',

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -45,8 +45,12 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
     _pseudoController.text = prefs.getString('nickname') ?? '';
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid != null) {
-      final profile = await _profileService.loadProfile(uid);
-      _pseudoController.text = profile?.nickname ?? _pseudoController.text;
+      try {
+        final profile = await _profileService.loadProfile(uid);
+        _pseudoController.text = profile?.nickname ?? _pseudoController.text;
+      } catch (e, st) {
+        debugPrint('Failed to load profile: $e\n$st');
+      }
     }
     _initialPseudo = _pseudoController.text;
   }

--- a/lib/services/user_profile_service.dart
+++ b/lib/services/user_profile_service.dart
@@ -1,6 +1,7 @@
 // lib/services/user_profile_service.dart
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import '../models/user_profile.dart';
 
 /// Service Firestore pour le profil utilisateur.
@@ -14,8 +15,9 @@ class UserProfileService {
       final data = doc.data();
       if (data == null) return null;
       return UserProfile.fromJson(data);
-    } catch (_) {
-      return null;
+    } catch (e, st) {
+      debugPrint('Error loading profile for $uid: $e\n$st');
+      rethrow;
     }
   }
 

--- a/lib/widgets/leaderboard_save_dialog.dart
+++ b/lib/widgets/leaderboard_save_dialog.dart
@@ -24,7 +24,15 @@ Future<void> showSaveScoreDialog({
 
     // Charge le profil pour récupérer le pseudonyme
     final profileService = UserProfileService();
-    final profile = uid.isEmpty ? null : await profileService.loadProfile(uid);
+    UserProfile? profile;
+    if (uid.isNotEmpty) {
+      try {
+        profile = await profileService.loadProfile(uid);
+      } catch (e, st) {
+        debugPrint('Failed to load profile for $uid: $e\n$st');
+        profile = null;
+      }
+    }
     String nickname = profile?.nickname ?? '';
 
     // Demande le pseudonyme si absent
@@ -136,9 +144,14 @@ Future<void> showSaveScoreDialog({
   final user = FirebaseAuth.instance.currentUser;
   String savedName = 'Joueur';
   if (user != null) {
-    final profile = await UserProfileService().loadProfile(user.uid);
-    savedName = profile?.nickname ?? 'Joueur';
-    await prefs.setString('nickname', savedName);
+    try {
+      final profile = await UserProfileService().loadProfile(user.uid);
+      savedName = profile?.nickname ?? 'Joueur';
+      await prefs.setString('nickname', savedName);
+    } catch (e, st) {
+      debugPrint('Failed to load profile for ${user.uid}: $e\n$st');
+      savedName = 'Joueur';
+    }
   } else {
     savedName = prefs.getString('nickname') ?? 'Joueur';
   }


### PR DESCRIPTION
## Summary
- Log and rethrow errors when loading user profiles
- Handle profile loading exceptions in profile editing, dashboard, and leaderboard save dialog

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7544e2ea0832f8142768028cb42ae