### PR TITLE
Handle profile save failure with retry

### DIFF
--- a/lib/widgets/leaderboard_save_dialog.dart
+++ b/lib/widgets/leaderboard_save_dialog.dart
@@ -62,7 +62,27 @@ Future<void> showSaveScoreDialog({
         );
         try {
           await profileService.saveProfile(toSave);
-        } catch (_) {}
+        } catch (e, st) {
+          debugPrint('Error saving profile: $e\n$st');
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: const Text(
+                    "Échec de l'enregistrement du pseudonyme. Réessayez."),
+                action: SnackBarAction(
+                  label: 'Réessayer',
+                  onPressed: () async {
+                    try {
+                      await profileService.saveProfile(toSave);
+                    } catch (e) {
+                      debugPrint('Retry saving profile failed: $e');
+                    }
+                  },
+                ),
+              ),
+            );
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Log profile save errors in competition mode and inform users via SnackBar with retry option

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7544fa6e4832f8235e0198babb4e7