### PR TITLE
feat: cache question history prefs

### DIFF
--- a/lib/services/question_history_store.dart
+++ b/lib/services/question_history_store.dart
@@ -4,10 +4,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// across quiz sessions.
 class QuestionHistoryStore {
   static const String _key = 'questionHistoryV1';
+  static SharedPreferences? _prefs;
+
+  static Future<SharedPreferences> _prefsInstance() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
 
   /// Loads the set of question IDs already used.
   static Future<Set<String>> load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _prefsInstance();
     final list = prefs.getStringList(_key);
     if (list == null || list.isEmpty) return <String>{};
     return list.toSet();
@@ -17,7 +22,7 @@ class QuestionHistoryStore {
   static Future<void> add(String id) async {
     final ids = await load();
     ids.add(id);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _prefsInstance();
     await prefs.setStringList(_key, ids.toList());
   }
 
@@ -25,13 +30,13 @@ class QuestionHistoryStore {
   static Future<void> addAll(Iterable<String> ids) async {
     final current = await load();
     current.addAll(ids);
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _prefsInstance();
     await prefs.setStringList(_key, current.toList());
   }
 
   /// Clears the stored question IDs.
   static Future<void> clear() async {
-    final prefs = await SharedPreferences.getInstance();
+    final prefs = await _prefsInstance();
     await prefs.remove(_key);
   }
 }


### PR DESCRIPTION
## Summary
- cache SharedPreferences instance for question history store to avoid repeated lookups

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7551894d0832fa58619cadb864c08