### PR TITLE
chore: pin Firebase packages to pre JS interop versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,14 @@ dependencies:
     sdk: flutter
   shared_preferences: ^2.2.2
   flutter_svg: ^2.0.10
-  firebase_core: ^2.15.1
-  firebase_auth: ^4.9.0
-  cloud_firestore: ^4.9.0
-  firebase_storage: ^11.2.5
+  firebase_core: 2.15.1
+  firebase_core_web: 2.8.0
+  firebase_auth: 4.15.3
+  firebase_auth_web: 5.7.3
+  cloud_firestore: 4.8.5
+  cloud_firestore_web: 3.7.0
+  firebase_storage: 11.2.4
+  firebase_storage_web: 3.6.16
   wakelock_plus: ^1.3.2
   flutter_windowmanager:
     path: third_party/flutter_windowmanager


### PR DESCRIPTION
## Summary
- pin Firebase packages to versions before typed JS interop migration

## Testing
- `flutter clean && flutter pub get` *(fails: command not found)*
- `flutter build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7586e6928832f834dccd8b0fe89b1