### PR TITLE
chore: override js dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dev_dependencies:
   flutter_native_splash: ^2.4.2
   flutter_launcher_icons: ^0.13.1
 
+dependency_overrides:
+  js: 0.6.7
+
 flutter:
   uses-material-design: true
   assets:


### PR DESCRIPTION
## Summary
- add `dependency_overrides` for `js` at version `0.6.7`

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter run -d chrome` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c75aaf7c4c832f9861d5a7fbd13cd1