### PR TITLE
chore: remove explicit cloud_firestore_web dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   firebase_auth: ^5.2.0
   firebase_auth_web: ^5.8.13
   cloud_firestore: ^5.4.0
-  cloud_firestore_web: ^3.12.5
   firebase_storage: ^12.1.0
   firebase_storage_web: ^3.6.16
   wakelock_plus: ^1.3.2


### PR DESCRIPTION
## Summary
- remove direct `cloud_firestore_web` dependency so it resolves via `cloud_firestore`

## Testing
- `flutter pub get` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c75ea1d3c4832fa2dca6bd7fd9c25d