### PR TITLE
Raise Android minSdk to 23

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         applicationId = "com.company.civexam_pro"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,4 +68,4 @@ flutter_icons:
   image_path: "assets/images/logo_icon_square.png"
   adaptive_icon_background: "#37478F"
   adaptive_icon_foreground: "assets/images/logo_icon_square.png"
-  min_sdk_android: 21
+  min_sdk_android: 23


### PR DESCRIPTION
## Summary
- set Android minSdk to 23 in Gradle config
- align tooling by updating `min_sdk_android` to 23 in `pubspec.yaml`

## Testing
- `flutter clean` *(fails: command not found)*
- `flutter build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7602782fc832f9af3a9d5dc7f3ac8