### PR TITLE
Guard FlutterWindowManager calls on Android only

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -77,7 +77,9 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
       WakelockPlus.enable();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
       SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
-      FlutterWindowManager.addFlags(FlutterWindowManager.FLAG_SECURE);
+      if (!kIsWeb && Platform.isAndroid) {
+        FlutterWindowManager.addFlags(FlutterWindowManager.FLAG_SECURE);
+      }
       _checkEmulator();
       _pageController = PageController();
     }
@@ -103,7 +105,9 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
       WakelockPlus.disable();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
       SystemChrome.setPreferredOrientations(DeviceOrientation.values);
-      FlutterWindowManager.clearFlags(FlutterWindowManager.FLAG_SECURE);
+      if (!kIsWeb && Platform.isAndroid) {
+        FlutterWindowManager.clearFlags(FlutterWindowManager.FLAG_SECURE);
+      }
     }
     _pageController?.dispose();
     super.dispose();


### PR DESCRIPTION
## Summary
- Wrap `FlutterWindowManager` flag calls with `kIsWeb` and `Platform.isAndroid` checks
- Prevent FLAG_SECURE from being set or cleared on unsupported platforms

## Testing
- `dart format lib/screens/exam_full_screen.dart` *(fails: command not found)*
- `flutter format lib/screens/exam_full_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c77a56cf7c832f88f7449cd3f3bb86