### PR TITLE
Run question shuffling on background isolate and add loading indicators

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -72,11 +72,21 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
       );
       return;
     }
-    final selected = await pickAndShuffle(
-      _pool,
-      _questionCount,
-      dedupeByQuestion: true,
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: CircularProgressIndicator()),
     );
+    List<Question> selected;
+    try {
+      selected = await pickAndShuffle(
+        _pool,
+        _questionCount,
+        dedupeByQuestion: true,
+      );
+    } finally {
+      if (mounted) Navigator.pop(context);
+    }
     if (selected.length < _questionCount) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -189,11 +189,21 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
         }
         takeCount = pool.length;
       }
-      final qs = await pickAndShuffle(
-        pool,
-        takeCount,
-        dedupeByQuestion: true,
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(child: CircularProgressIndicator()),
       );
+      List<Question> qs;
+      try {
+        qs = await pickAndShuffle(
+          pool,
+          takeCount,
+          dedupeByQuestion: true,
+        );
+      } finally {
+        if (mounted) Navigator.pop(context);
+      }
       if (qs.isEmpty) {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -215,11 +215,18 @@ class _PlayScreenState extends State<PlayScreen> {
         try {
           const int desiredCount = 60;
           final all = await QuestionLoader.loadENA();
+          if (!mounted) return;
+          showDialog(
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => const Center(child: CircularProgressIndicator()),
+          );
           final selected = await pickAndShuffle(
             all,
             desiredCount,
             dedupeByQuestion: true,
           );
+          if (mounted) Navigator.pop(context);
 
           final proceed = await _handleShortDraw(selected, desiredCount);
           if (!proceed) {
@@ -239,6 +246,7 @@ class _PlayScreenState extends State<PlayScreen> {
             ),
           );
         } catch (e) {
+          if (mounted) Navigator.pop(context);
           if (!mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -29,11 +29,18 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
     setState(() => _loading = true);
     try {
       final List<Question> all = await QuestionLoader.loadENA();
+      if (!mounted) return;
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(child: CircularProgressIndicator()),
+      );
       final List<Question> selected = await pickAndShuffle(
         all,
         _questionCount,
         dedupeByQuestion: true,
       );
+      if (mounted) Navigator.pop(context);
 
       final proceed = await _handleShortDraw(selected, _questionCount);
       if (!proceed) {
@@ -109,12 +116,15 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
         );
       }
     } catch (e) {
+      if (mounted) Navigator.pop(context);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Échec du lancement de l\'entraînement : $e')),
       );
     } finally {
-      if (mounted) setState(() => _loading = false);
+      if (mounted) {
+        setState(() => _loading = false);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Move heavy question filtering/shuffling logic to a background isolate via `compute`
- Add serializable argument class for isolate communication
- Show modal loading indicators when drawing questions in various screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f49faf5c832f9991af6b459e7c39