### PR TITLE
Convert question history to list in question randomizer

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -64,7 +64,7 @@ Future<List<Question>> pickAndShuffle(
   // Prepare data for the isolate.
   final args = _PickAndShuffleArgs(
     pool: pool.map((q) => q.toMap()).toList(),
-    history: history,
+    history: history.toList(),
     take: take,
     dedupeByQuestion: dedupeByQuestion,
     rngSeed: r.nextInt(1 << 32),


### PR DESCRIPTION
## Summary
- ensure history passed to `_PickAndShuffleArgs` is a `List` by calling `history.toList()`

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7f6a6e060832f97d97579a116c522