### PR TITLE
Use iterable for question history in randomizer

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart';
 import '../models/question.dart';
 import 'question_history_store.dart';
 
-final _rng = Random();
+  final _rng = Random();
 
 /// Retourne une **copie** de la question avec les choix mélangés
 /// et un `answerIndex` recalculé.
@@ -64,7 +64,7 @@ Future<List<Question>> pickAndShuffle(
   // Prepare data for the isolate.
   final args = _PickAndShuffleArgs(
     pool: pool.map((q) => q.toMap()).toList(),
-    history: history.toList(),
+    history: history,
     take: take,
     dedupeByQuestion: dedupeByQuestion,
     rngSeed: r.nextInt(1 << 32),
@@ -90,7 +90,7 @@ Future<List<Question>> pickAndShuffle(
 
 class _PickAndShuffleArgs {
   final List<Map<String, dynamic>> pool;
-  final List<String> history;
+  final Iterable<String> history;
   final int take;
   final bool dedupeByQuestion;
   final int rngSeed;
@@ -105,7 +105,7 @@ class _PickAndShuffleArgs {
 
   Map<String, dynamic> toMap() => {
         'pool': pool,
-        'history': history,
+        'history': history.toList(),
         'take': take,
         'dedupeByQuestion': dedupeByQuestion,
         'rngSeed': rngSeed,


### PR DESCRIPTION
## Summary
- accept any iterable for question history when shuffling
- serialize history by converting to and from lists

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fa5d3cd8832f9ff3cf3373066eb6