### PR TITLE
Use fixed-length history list in question randomizer

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -64,7 +64,7 @@ Future<List<Question>> pickAndShuffle(
   // Prepare data for the isolate.
   final args = _PickAndShuffleArgs(
     pool: pool.map((q) => q.toMap()).toList(),
-    history: history.toList(),
+    history: history.toList(growable: false),
     take: take,
     dedupeByQuestion: dedupeByQuestion,
     rngSeed: r.nextInt(1 << 32),


### PR DESCRIPTION
## Summary
- ensure question history passed to isolate is an unmodifiable list

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fa5bcb08832fbcfe02b1eb007a49