### PR TITLE
Update flutter_windowmanager plugin build settings

### DIFF
--- a/third_party/flutter_windowmanager/android/build.gradle
+++ b/third_party/flutter_windowmanager/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
     }
 }
 
@@ -30,7 +30,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
## Summary
- update the flutter_windowmanager plugin build script to use Android Gradle Plugin 8.1.0
- align the plugin's minimum SDK version with the host application

## Testing
- flutter clean *(fails: flutter command not available in container)*
- flutter build apk *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c831e9d724832fb8337dab1853682e