### PR TITLE
Remove firebase web dependencies from pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,12 +13,9 @@ dependencies:
   shared_preferences: ^2.2.2
   flutter_svg: ^2.0.10
   firebase_core: ^3.4.0
-  firebase_core_web: ^2.24.0
   firebase_auth: ^5.2.0
-  firebase_auth_web: ^5.8.13
   cloud_firestore: ^5.4.0
   firebase_storage: ^12.1.0
-  firebase_storage_web: ^3.6.16
   wakelock_plus: ^1.3.2
   flutter_windowmanager:
     path: third_party/flutter_windowmanager


### PR DESCRIPTION
## Summary
- remove the firebase_core_web, firebase_auth_web, and firebase_storage_web dependencies that are no longer required on mobile

## Testing
- `flutter pub get` *(fails: Flutter SDK is not installed in the container)*
- `flutter build apk` *(fails: Flutter SDK is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c831c66d80832fa64fd332f1f7f6ec