### PR TITLE
Add internet permission for Android build

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.company.civexam_pro">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="civexam_pro"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- add the INTERNET permission declaration to the Android manifest

## Testing
- flutter build apk *(fails: command not found: flutter)*
- ./gradlew assembleDebug *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c831e64d0c832fb85f720e00152335