### PR TITLE
Handle dashboard/profile avatars across platforms

### DIFF
--- a/lib/utils/io_stub.dart
+++ b/lib/utils/io_stub.dart
@@ -1,0 +1,5 @@
+class File {
+  File(String path);
+
+  bool existsSync() => false;
+}


### PR DESCRIPTION
## Summary
- update dashboard avatar picker to use conditional file handling and support base64/network sources
- refactor profile edit screen to manage avatar storage for mobile and web, including base64 persistence
- add a web stub for dart:io File to satisfy conditional imports

## Testing
- Not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68c834c25e54832fb401449c369967bb