### PR TITLE
Use conditional IO imports for web safety

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'dart:io'
-    if (dart.library.html) 'package:civexam_pro/utils/io_stub.dart';
+import 'package:civexam_pro/utils/io_stub.dart'
+    if (dart.library.io) 'dart:io' as io;
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/foundation.dart';
@@ -117,8 +117,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
         bytes,
         SettableMetadata(contentType: 'image/jpeg'),
       );
-    } else {
-      await ref.putFile(File(file.path));
+    } else if (!kIsWeb) {
+      await ref.putFile(io.File(file.path));
     }
     final url = await ref.getDownloadURL();
 
@@ -160,9 +160,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
     if (photoUrl.startsWith('http')) {
       return NetworkImage(photoUrl);
     }
-    final file = File(photoUrl);
-    if (file.existsSync()) {
-      return FileImage(file);
+    if (!kIsWeb) {
+      final file = io.File(photoUrl);
+      if (file.existsSync()) {
+        return FileImage(file);
+      }
     }
     final base64Data = _extractBase64(photoUrl);
     if (base64Data != null) {

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'dart:io'
-    if (dart.library.html) 'package:civexam_pro/utils/io_stub.dart';
+import 'package:civexam_pro/utils/io_stub.dart'
+    if (dart.library.io) 'dart:io' as io;
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
@@ -150,8 +150,8 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
       }
       return null;
     }
-    if (_avatarPath != null && _avatarPath!.isNotEmpty) {
-      final file = File(_avatarPath!);
+    if (!kIsWeb && _avatarPath != null && _avatarPath!.isNotEmpty) {
+      final file = io.File(_avatarPath!);
       if (file.existsSync()) {
         return FileImage(file);
       }
@@ -164,9 +164,11 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
       if (base64Data != null) {
         return MemoryImage(base64Decode(base64Data));
       }
-      final file = File(_photoUrl!);
-      if (file.existsSync()) {
-        return FileImage(file);
+      if (!kIsWeb) {
+        final file = io.File(_photoUrl!);
+        if (file.existsSync()) {
+          return FileImage(file);
+        }
       }
     }
     return null;


### PR DESCRIPTION
## Summary
- switch dashboard and profile edit screens to use conditional io imports with a shared alias
- guard non-web file access behind kIsWeb checks while keeping web-friendly branches
- ensure Firebase uploads and avatar resolution use io.File only on non-web platforms

## Testing
- not run (flutter/dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c83914c474832fa3ac9b17275d4992