### PR TITLE
Ensure profile photo upload uses dynamic file on non-web

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -117,8 +117,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
         bytes,
         SettableMetadata(contentType: 'image/jpeg'),
       );
-    } else if (!kIsWeb) {
-      await ref.putFile(io.File(file.path));
+    }
+    if (!kIsWeb) {
+      await ref.putFile(io.File(file.path) as dynamic);
     }
     final url = await ref.getDownloadURL();
 


### PR DESCRIPTION
## Summary
- guard the file-based profile photo upload so it only runs on non-web platforms
- cast the file upload argument to dynamic to satisfy the Firebase Storage API

## Testing
- flutter analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c83ba82ebc832fb1dd640510237980