### PR TITLE
Cast FileImage source to dynamic for dashboard avatar

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -163,7 +163,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
     if (!kIsWeb) {
       final file = io.File(photoUrl);
       if (file.existsSync()) {
-        return FileImage(file);
+        return FileImage(file as dynamic);
       }
     }
     final base64Data = _extractBase64(photoUrl);


### PR DESCRIPTION
## Summary
- update the dashboard avatar resolver to cast the local File to dynamic when building a FileImage on non-web targets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c83bafc86c832face87d2305d6601a