### PR TITLE
Guard FileImage usage on profile edit screen

### DIFF
--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -150,10 +150,12 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
       }
       return null;
     }
-    if (!kIsWeb && _avatarPath != null && _avatarPath!.isNotEmpty) {
-      final file = io.File(_avatarPath!);
-      if (file.existsSync()) {
-        return FileImage(file);
+    if (!kIsWeb) {
+      if (_avatarPath != null && _avatarPath!.isNotEmpty) {
+        final file = io.File(_avatarPath!);
+        if (file.existsSync()) {
+          return FileImage(file as dynamic);
+        }
       }
     }
     if (_photoUrl != null && _photoUrl!.isNotEmpty) {
@@ -167,7 +169,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
       if (!kIsWeb) {
         final file = io.File(_photoUrl!);
         if (file.existsSync()) {
-          return FileImage(file);
+          return FileImage(file as dynamic);
         }
       }
     }


### PR DESCRIPTION
## Summary
- guard local avatar FileImage creation on the profile edit screen to avoid web usage
- cast to dynamic when instantiating FileImage for compatibility

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c83bb8ec90832f9c6fdb13dde78685