### PR TITLE
Update cloud sync platform detection

### DIFF
--- a/lib/services/cloud_sync.dart
+++ b/lib/services/cloud_sync.dart
@@ -1,7 +1,7 @@
 
 import 'dart:async';
-import 'dart:io' show Platform;
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart'
+    show debugPrint, defaultTargetPlatform, kDebugMode, kIsWeb;
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -15,14 +15,13 @@ class CloudSync {
   static const String _kAllowAnonymous = 'allowAnonymousSignIn';
 
   static String _currentPlatform() {
+    if (kIsWeb) {
+      return 'web';
+    }
     try {
-      return Platform.operatingSystem;
+      return defaultTargetPlatform.name.toLowerCase();
     } catch (_) {
-      try {
-        return defaultTargetPlatform.name.toLowerCase();
-      } catch (_) {
-        return 'unknown';
-      }
+      return 'unknown';
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the `dart:io` Platform import from the cloud sync service
- detect the current platform using Flutter's `kIsWeb` flag and `defaultTargetPlatform`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c84175a170832f8ed05b6511f2cea2