### PR TITLE
Handle null image selection in profile edit

### DIFF
--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -130,23 +130,25 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
       _showImagePickerUnavailableMessage();
       return;
     }
-    if (picked != null) {
-      if (kIsWeb) {
-        final bytes = await picked.readAsBytes();
-        if (!mounted) return;
-        setState(() {
-          _avatarBytes = bytes;
-          _avatarPath = null;
-          _photoUrl = null;
-        });
-      } else {
-        if (!mounted) return;
-        setState(() {
-          _avatarPath = picked.path;
-          _avatarBytes = null;
-          _photoUrl = null;
-        });
-      }
+    if (picked == null) {
+      return;
+    }
+    if (kIsWeb) {
+      final bytes = await picked.readAsBytes();
+      if (!mounted) return;
+      setState(() {
+        _avatarBytes = bytes;
+        _avatarPath = null;
+        _photoUrl = null;
+      });
+    } else {
+      final avatarPath = picked.path;
+      if (!mounted) return;
+      setState(() {
+        _avatarPath = avatarPath;
+        _avatarBytes = null;
+        _photoUrl = null;
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- handle the case where no image is selected from the picker before updating the avatar
- capture the selected path before setState to avoid accessing a nullable XFile inside the closure

## Testing
- flutter analyze *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c843f723d4832fbe36a71e241932bc