### PR TITLE
Add CRT secure warning suppression to Windows build

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -42,6 +42,7 @@ function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
   target_compile_options(${TARGET} PRIVATE /EHsc)
   target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
+  target_compile_definitions(${TARGET} PRIVATE "_CRT_SECURE_NO_WARNINGS")
   target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
 endfunction()
 


### PR DESCRIPTION
## Summary
- define _CRT_SECURE_NO_WARNINGS for Windows targets to silence deprecated CRT warnings

## Testing
- flutter build windows (fails: Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c848d554a0832faff26ed17ed39051