### PR TITLE
Wrap Flutter app initialization in runZonedGuarded

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,9 +11,9 @@ import 'models/design_config.dart';
 import 'screens/splash_screen.dart';
 
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
   await runZonedGuarded<Future<void>>(() async {
     try {
+      WidgetsFlutterBinding.ensureInitialized();
       await Firebase.initializeApp(
           options: DefaultFirebaseOptions.currentPlatform);
       final cfg = await DesignPrefs.load();


### PR DESCRIPTION
## Summary
- remove the top-level call to WidgetsFlutterBinding.ensureInitialized
- wrap the app initialization sequence in runZonedGuarded so binding, Firebase init, prefs load, and runApp execute in the same zone

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84ceddfe4832f857aff82c228dfa2