### PR TITLE
Initialize EmojiCompat before FlutterActivity

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,3 +54,7 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    implementation("androidx.emoji2:emoji2:1.5.0")
+}

--- a/android/app/src/main/kotlin/com/company/civexam_pro/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/company/civexam_pro/MainActivity.kt
@@ -1,5 +1,13 @@
 package com.company.civexam_pro
 
+import android.os.Bundle
+import androidx.emoji2.bundled.BundledEmojiCompatConfig
+import androidx.emoji2.text.EmojiCompat
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        EmojiCompat.init(BundledEmojiCompatConfig(this))
+        super.onCreate(savedInstanceState)
+    }
+}


### PR DESCRIPTION
## Summary
- initialize EmojiCompat with the bundled config before calling into FlutterActivity
- add the androidx.emoji2:emoji2 dependency to the Android app module

## Testing
- bash gradlew app:assembleDebug *(fails: unable to download Gradle distribution due to HTTP 403 from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c854a5a650832fba61eff9ff36ffd9