### PR TITLE
Simplify cross-platform page transitions

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -65,16 +65,21 @@ ThemeData buildAppTheme(DesignConfig cfg) {
     inputDecorationTheme: InputDecorationTheme(
       filled: true,
       fillColor: Colors.grey.shade100,
-      border: OutlineInputBorder(borderRadius: BorderRadius.circular(12), borderSide: BorderSide.none),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(12),
+        borderSide: BorderSide.none,
+      ),
       contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
     ),
     chipTheme: base.chipTheme.copyWith(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
     ),
-    pageTransitionsTheme: const PageTransitionsTheme(builders: {
-      TargetPlatform.android: ZoomPageTransitionsBuilder(),
-      TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
-      TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
-    }),
+    pageTransitionsTheme: const PageTransitionsTheme(
+      builders: {
+        TargetPlatform.android: ZoomPageTransitionsBuilder(),
+        TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
+        TargetPlatform.macOS: ZoomPageTransitionsBuilder(),
+      },
+    ),
   );
 }


### PR DESCRIPTION
## Summary
- replace the Cupertino page transitions on iOS and macOS with the same simple zoom transition used on Android
- expand the input decoration border definition onto multiple lines for readability

## Testing
- `dart format lib/app/theme.dart` *(fails: dart is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8684a4040832f9f53636a5f9ce56b