### PR TITLE
Simplify competition screen navigation routes

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -256,9 +256,8 @@ class _CompetitionScreenState extends State<CompetitionScreen>
       // Continue to the next question by replacing the current screen.
       Navigator.pushReplacement(
         context,
-        PageRouteBuilder(
-          transitionDuration: const Duration(milliseconds: 300),
-          pageBuilder: (_, animation, secondaryAnimation) => CompetitionScreen(
+        MaterialPageRoute(
+          builder: (_) => CompetitionScreen(
             questions: widget.questions,
             timePerQuestion: widget.timePerQuestion,
             currentIndex: widget.currentIndex + 1,
@@ -268,15 +267,6 @@ class _CompetitionScreenState extends State<CompetitionScreen>
             startTime: widget.startTime,
             theme: widget.theme,
           ),
-          transitionsBuilder: (_, animation, secondaryAnimation, child) {
-            final offsetAnimation = animation.drive(
-              Tween<Offset>(
-                begin: const Offset(1.0, 0.0),
-                end: Offset.zero,
-              ),
-            );
-            return SlideTransition(position: offsetAnimation, child: child);
-          },
         ),
       );
     } else {
@@ -285,10 +275,8 @@ class _CompetitionScreenState extends State<CompetitionScreen>
           DateTime.now().difference(widget.startTime).inSeconds;
       Navigator.pushReplacement(
         context,
-        PageRouteBuilder(
-          transitionDuration: const Duration(milliseconds: 300),
-          pageBuilder: (_, animation, secondaryAnimation) =>
-              CompetitionResultScreen(
+        MaterialPageRoute(
+          builder: (_) => CompetitionResultScreen(
             total: widget.questions.length,
             correct: totalCorrect,
             wrong: totalWrong,
@@ -296,15 +284,6 @@ class _CompetitionScreenState extends State<CompetitionScreen>
             durationSec: durationSec,
             theme: widget.theme,
           ),
-          transitionsBuilder: (_, animation, secondaryAnimation, child) {
-            final offsetAnimation = animation.drive(
-              Tween<Offset>(
-                begin: const Offset(1.0, 0.0),
-                end: Offset.zero,
-              ),
-            );
-            return SlideTransition(position: offsetAnimation, child: child);
-          },
         ),
       );
     }


### PR DESCRIPTION
## Summary
- replace the competition flow's custom PageRouteBuilder usage with MaterialPageRoute
- preserve all parameters when navigating to the next question and the results screen

## Testing
- dart format lib/screens/competition_screen.dart *(fails: `dart` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8684704fc832f9d8c2bbda97a14f5