### PR TITLE
Maintain competition chip height

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -96,6 +96,12 @@ class _CompetitionScreenState extends State<CompetitionScreen>
   @override
   Widget build(BuildContext context) {
     final theme = widget.theme ?? CompetitionTheme.fromTheme(Theme.of(context));
+    final TextStyle resolvedChipTextStyle =
+        DefaultTextStyle.of(context).style.merge(theme.selectedChipTextStyle);
+    final double chipMinHeight =
+        (resolvedChipTextStyle.fontSize ?? 16) *
+                (resolvedChipTextStyle.height ?? 1.0) +
+            16;
     return Scaffold(
       // Global background color comes from the theme.
       backgroundColor: theme.backgroundColor,
@@ -178,19 +184,29 @@ class _CompetitionScreenState extends State<CompetitionScreen>
               ),
               const SizedBox(height: 24),
               // Chip displaying the selected answer when user taps an option.
-              if (_selected >= 0)
-                Container(
-                  padding:
-                      const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-                  decoration: BoxDecoration(
-                    color: theme.selectedChipBackgroundColor,
-                    borderRadius: BorderRadius.circular(theme.selectedChipRadius),
-                  ),
-                  child: Text(
-                    _currentQuestion.choices[_selected],
-                    style: theme.selectedChipTextStyle,
+              AnimatedOpacity(
+                duration: const Duration(milliseconds: 200),
+                opacity: _selected >= 0 ? 1 : 0,
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        vertical: 8, horizontal: 16),
+                    decoration: BoxDecoration(
+                      color: theme.selectedChipBackgroundColor,
+                      borderRadius:
+                          BorderRadius.circular(theme.selectedChipRadius),
+                    ),
+                    constraints: BoxConstraints(minHeight: chipMinHeight),
+                    child: Text(
+                      _selected >= 0
+                          ? _currentQuestion.choices[_selected]
+                          : '',
+                      style: theme.selectedChipTextStyle,
+                    ),
                   ),
                 ),
+              ),
               const SizedBox(height: 24),
               // Answer options list.
               ...List.generate(_currentQuestion.choices.length, (i) {

--- a/test/competition_navigation_test.dart
+++ b/test/competition_navigation_test.dart
@@ -42,5 +42,41 @@ void main() {
       }
     }
   });
+
+  testWidgets('Selecting an option does not shift the answer list vertically',
+      (tester) async {
+    final questions = [
+      Question(
+        id: 'q0',
+        concours: 'ENA',
+        subject: 'Sujet',
+        chapter: 'Chap',
+        difficulty: 1,
+        question: 'Question',
+        choices: const ['Option 1', 'Option 2'],
+        answerIndex: 0,
+      ),
+    ];
+
+    await tester.pumpWidget(MaterialApp(
+      home: CompetitionScreen(
+        questions: questions,
+        timePerQuestion: 5,
+        startTime: DateTime.now(),
+      ),
+    ));
+
+    await tester.pumpAndSettle();
+
+    final Finder firstOptionFinder = find.text('Option 1').last;
+    final double initialTop = tester.getTopLeft(firstOptionFinder).dy;
+
+    await tester.tap(firstOptionFinder);
+    await tester.pumpAndSettle();
+
+    final double afterSelectionTop = tester.getTopLeft(firstOptionFinder).dy;
+
+    expect(afterSelectionTop, closeTo(initialTop, 0.1));
+  });
 }
 


### PR DESCRIPTION
## Summary
- reserve vertical space for the selected-answer chip with an AnimatedOpacity wrapper and computed minimum height
- add a widget test that verifies answer options do not shift vertically when an option is selected

## Testing
- flutter test *(fails: Flutter SDK is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c86bb8e9f8832fa6f3902a23271b81