### PR TITLE
Improve competition chip animation

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -184,28 +184,54 @@ class _CompetitionScreenState extends State<CompetitionScreen>
               ),
               const SizedBox(height: 24),
               // Chip displaying the selected answer when user taps an option.
-              AnimatedOpacity(
-                duration: const Duration(milliseconds: 200),
-                opacity: _selected >= 0 ? 1 : 0,
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        vertical: 8, horizontal: 16),
-                    decoration: BoxDecoration(
-                      color: theme.selectedChipBackgroundColor,
-                      borderRadius:
-                          BorderRadius.circular(theme.selectedChipRadius),
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 250),
+                switchInCurve: Curves.easeOutBack,
+                switchOutCurve: Curves.easeInCubic,
+                transitionBuilder: (child, animation) {
+                  final curved = CurvedAnimation(
+                    parent: animation,
+                    curve: Curves.easeOutCubic,
+                    reverseCurve: Curves.easeInCubic,
+                  );
+                  return FadeTransition(
+                    opacity: animation,
+                    child: SlideTransition(
+                      position: Tween<Offset>(
+                        begin: const Offset(0, 0.1),
+                        end: Offset.zero,
+                      ).animate(curved),
+                      child: ScaleTransition(
+                        scale: Tween<double>(begin: 0.92, end: 1).animate(curved),
+                        child: child,
+                      ),
                     ),
-                    constraints: BoxConstraints(minHeight: chipMinHeight),
-                    child: Text(
-                      _selected >= 0
-                          ? _currentQuestion.choices[_selected]
-                          : '',
-                      style: theme.selectedChipTextStyle,
-                    ),
-                  ),
-                ),
+                  );
+                },
+                child: _selected >= 0
+                    ? AnimatedAlign(
+                        key: ValueKey<int>(_selected),
+                        alignment: Alignment.center,
+                        duration: const Duration(milliseconds: 250),
+                        curve: Curves.easeOutCubic,
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              vertical: 8, horizontal: 16),
+                          decoration: BoxDecoration(
+                            color: theme.selectedChipBackgroundColor,
+                            borderRadius: BorderRadius.circular(
+                              theme.selectedChipRadius,
+                            ),
+                          ),
+                          constraints:
+                              BoxConstraints(minHeight: chipMinHeight),
+                          child: Text(
+                            _currentQuestion.choices[_selected],
+                            style: theme.selectedChipTextStyle,
+                          ),
+                        ),
+                      )
+                    : const SizedBox.shrink(),
               ),
               const SizedBox(height: 24),
               // Answer options list.

--- a/lib/theme/competition_theme.dart
+++ b/lib/theme/competition_theme.dart
@@ -88,7 +88,7 @@ class CompetitionTheme {
       fontWeight: FontWeight.w600,
     ),
     this.selectedChipBackgroundColor = Colors.pinkAccent,
-    this.selectedChipRadius = 20.0,
+    this.selectedChipRadius = 24.0,
   });
 
   /// Builds a [CompetitionTheme] that matches the global [ThemeData].


### PR DESCRIPTION
## Summary
- replace the competition answer chip fade with an AnimatedSwitcher that slides and scales into view while keeping it centered
- harmonize the chip radius in the competition theme to match the new animation styling

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c86f329284832f835de920e73becef