### PR TITLE
Add animated feedback for competition answers

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -51,6 +51,9 @@ class _CompetitionScreenState extends State<CompetitionScreen>
   /// Currently selected answer index. `-1` means no selection yet.
   int _selected = -1;
 
+  /// Index of the option currently highlighted by a press gesture.
+  int _highlighted = -1;
+
   /// Animation controller driving the countdown timer.
   late final AnimationController _controller;
 
@@ -211,29 +214,64 @@ class _CompetitionScreenState extends State<CompetitionScreen>
               // Answer options list.
               ...List.generate(_currentQuestion.choices.length, (i) {
                 final bool isSelected = _selected == i;
+                final bool isHighlighted = _highlighted == i;
+                final borderRadius =
+                    BorderRadius.circular(theme.optionCardRadius);
+                final Color baseColor = theme.optionCardColor;
+                final Color highlightOverlay =
+                    theme.optionSelectedBorderColor.withOpacity(0.06);
+                final Color selectedOverlay =
+                    theme.optionSelectedBorderColor.withOpacity(0.12);
+                final Color resolvedColor = isSelected
+                    ? Color.alphaBlend(selectedOverlay, baseColor)
+                    : isHighlighted
+                        ? Color.alphaBlend(highlightOverlay, baseColor)
+                        : baseColor;
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: GestureDetector(
-                    onTap: () => _onOptionTap(i),
-                    child: Container(
-                      width: double.infinity,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                      decoration: BoxDecoration(
-                        color: theme.optionCardColor,
-                        borderRadius:
-                            BorderRadius.circular(theme.optionCardRadius),
-                        boxShadow: theme.optionCardShadow,
-                        border: isSelected
-                            ? Border.all(
-                                color: theme.optionSelectedBorderColor,
-                                width: 2,
-                              )
-                            : null,
-                      ),
-                      child: Text(
-                        _currentQuestion.choices[i],
-                        textAlign: TextAlign.center,
-                        style: theme.optionTextStyle,
+                  child: AnimatedScale(
+                    scale: isHighlighted ? 0.97 : 1.0,
+                    duration: const Duration(milliseconds: 140),
+                    curve: Curves.easeOut,
+                    child: Material(
+                      color: Colors.transparent,
+                      borderRadius: borderRadius,
+                      child: InkWell(
+                        borderRadius: borderRadius,
+                        splashColor:
+                            theme.optionSelectedBorderColor.withOpacity(0.08),
+                        highlightColor:
+                            theme.optionSelectedBorderColor.withOpacity(0.04),
+                        onHighlightChanged: (value) {
+                          if (_selected >= 0) return;
+                          setState(() {
+                            _highlighted = value ? i : -1;
+                          });
+                        },
+                        onTap:
+                            _selected >= 0 ? null : () => _onOptionTap(i),
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 200),
+                          curve: Curves.easeOut,
+                          width: double.infinity,
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          decoration: BoxDecoration(
+                            color: resolvedColor,
+                            borderRadius: borderRadius,
+                            boxShadow: theme.optionCardShadow,
+                            border: Border.all(
+                              color: isSelected
+                                  ? theme.optionSelectedBorderColor
+                                  : Colors.transparent,
+                              width: 2,
+                            ),
+                          ),
+                          child: Text(
+                            _currentQuestion.choices[i],
+                            textAlign: TextAlign.center,
+                            style: theme.optionTextStyle,
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -250,7 +288,10 @@ class _CompetitionScreenState extends State<CompetitionScreen>
   void _onOptionTap(int i) {
     // Prevent selecting multiple answers.
     if (_selected >= 0) return;
-    setState(() => _selected = i);
+    setState(() {
+      _selected = i;
+      _highlighted = -1;
+    });
     // Pause the timer and move to next question shortly after.
     _controller.stop();
     Future.delayed(const Duration(milliseconds: 300), () => _goNext(i));


### PR DESCRIPTION
## Summary
- animate competition answer cards with InkWell, AnimatedContainer, and scale feedback for cohesive theming
- track highlighted option state to provide subtle overlay colors that blend with the existing competition theme

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68c86f345888832f910b6a5404a96e91