### PR TITLE
Adjust option layout and styling

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -255,7 +255,7 @@ class _CompetitionScreenState extends State<CompetitionScreen>
               // Answer options list.
               Expanded(
                 child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: List.generate(_currentQuestion.choices.length, (i) {
                     final bool isSelected = _selected == i;
                     final bool isHighlighted = _highlighted == i;
@@ -271,9 +271,11 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                         : isHighlighted
                             ? Color.alphaBlend(highlightOverlay, baseColor)
                             : baseColor;
-                    return Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 8),
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      child: Container(
+                        width: double.infinity,
+                        constraints: const BoxConstraints(maxWidth: 400),
                         child: AnimatedScale(
                           scale: isHighlighted ? 0.97 : 1.0,
                           duration: const Duration(milliseconds: 140),
@@ -316,7 +318,8 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                                 child: Text(
                                   _currentQuestion.choices[i],
                                   textAlign: TextAlign.center,
-                                  style: theme.optionTextStyle,
+                                  style: theme.optionTextStyle
+                                      .copyWith(fontSize: 18),
                                 ),
                               ),
                             ),

--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -242,8 +242,17 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                 value: c,
                 groupValue: answers[i],
                 onChanged: _submitted ? null : (v) => _onAnswer(i, v!),
-                title: Text(item.choices[c]),
-                contentPadding: const EdgeInsets.symmetric(horizontal: 0),
+                contentPadding: EdgeInsets.zero,
+                title: Center(
+                  child: Text(
+                    item.choices[c],
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          fontSize: 18,
+                        ) ??
+                        const TextStyle(fontSize: 18),
+                  ),
+                ),
               ),
           ],
         ),


### PR DESCRIPTION
## Summary
- center competition option blocks and constrain their width for a tighter layout
- enlarge competition option text for better readability
- center exam radio option labels with zero padding and larger text

## Testing
- Not run (command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c87643dcd0832f9ca369414095964c