### PR TITLE
Fix competition feedback area spacing

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -249,7 +249,11 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                           ),
                         ),
                       )
-                    : const SizedBox.shrink(),
+                    : SizedBox(
+                        key: const ValueKey<String>(
+                            'selected-chip-placeholder'),
+                        height: chipMinHeight,
+                      ),
               ),
               const SizedBox(height: 24),
               // Answer options list.


### PR DESCRIPTION
## Summary
- keep a fixed-height placeholder where the selected-answer chip appears in the competition screen to prevent layout jumps when feedback toggles

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c87645c044832f8eb2845dc1dc9b4c