### PR TITLE
Add Google sign-in option to login screen

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,8 @@ dependencies:
   confetti: ^0.7.0
   image_picker: ^1.0.5
   diacritic: ^0.1.3
+  google_sign_in: ^6.1.5
+  font_awesome_flutter: ^10.6.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a Google login button to the login screen with shared loading state and navigation on success
- extend `AuthService` with Google sign-in support and provider-specific error handling
- add the `google_sign_in` and `font_awesome_flutter` dependencies for the new flow

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68c8a39c5a00832fbb40ceaa8021258c