### PR TITLE
Configure Google Sign-In support

### DIFF
--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -16,6 +16,13 @@
         {
           "client_id": "522640251078-des4gu7sc12sfq7dfkpfonaklevpr50j.apps.googleusercontent.com",
           "client_type": 3
+        },
+        {
+          "client_id": "522640251078-des4gu7sc12sfq7dfkpfonaklevpr50j.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.company.civexam_pro"
+          }
         }
       ],
       "api_key": [

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CLIENT_ID</key>
+<string>522640251078-rtj679r8biudv9ri3v77ne8lh6j0eth0.apps.googleusercontent.com</string>
+<key>REVERSED_CLIENT_ID</key>
+<string>com.googleusercontent.apps.522640251078-rtj679r8biudv9ri3v77ne8lh6j0eth0</string>
+<key>API_KEY</key>
+<string>AIzaSyBWAIrkydvaNel2li2mKwrF2qbBag7M98Q</string>
+<key>GCM_SENDER_ID</key>
+<string>522640251078</string>
+<key>PLIST_VERSION</key>
+<string>1</string>
+<key>BUNDLE_ID</key>
+<string>com.company.civexam</string>
+<key>PROJECT_ID</key>
+<string>civexam-54e17</string>
+<key>STORAGE_BUCKET</key>
+<string>civexam-54e17.firebasestorage.app</string>
+<key>IS_ADS_ENABLED</key>
+<false/>
+<key>IS_ANALYTICS_ENABLED</key>
+<false/>
+<key>IS_APPINVITE_ENABLED</key>
+<true/>
+<key>IS_GCM_ENABLED</key>
+<true/>
+<key>IS_SIGNIN_ENABLED</key>
+<true/>
+<key>GOOGLE_APP_ID</key>
+<string>1:522640251078:ios:c59b78f08fbdde5870dfc7</string>
+<key>DATABASE_URL</key>
+<string></string>
+</dict>
+</plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,18 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleTypeRole</key>
+                        <string>Editor</string>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>com.googleusercontent.apps.522640251078-rtj679r8biudv9ri3v77ne8lh6j0eth0</string>
+                        </array>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -43,11 +43,14 @@ class DefaultFirebaseOptions {
   );
 
   static const FirebaseOptions ios = FirebaseOptions(
-    apiKey: '',
-    appId: '',
-    messagingSenderId: '',
-    projectId: '',
-    iosBundleId: '',
+    apiKey: 'AIzaSyBWAIrkydvaNel2li2mKwrF2qbBag7M98Q',
+    appId: '1:522640251078:ios:c59b78f08fbdde5870dfc7',
+    messagingSenderId: '522640251078',
+    projectId: 'civexam-54e17',
+    storageBucket: 'civexam-54e17.firebasestorage.app',
+    iosClientId:
+        '522640251078-rtj679r8biudv9ri3v77ne8lh6j0eth0.apps.googleusercontent.com',
+    iosBundleId: 'com.company.civexam',
   );
 
   static const FirebaseOptions macos = FirebaseOptions(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_svg: ^2.0.10
   firebase_core: ^3.4.0
   firebase_auth: ^5.2.0
+  google_sign_in: ^6.1.0
   cloud_firestore: ^5.4.0
   firebase_storage: ^12.1.0
   wakelock_plus: ^1.3.2

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,8 @@
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="A new Flutter project.">
+  <meta name="google-signin-client_id" content="522640251078-des4gu7sc12sfq7dfkpfonaklevpr50j.apps.googleusercontent.com">
+  <meta name="google-signin-scope" content="profile email">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- add the `google_sign_in` dependency for the application
- add Google Sign-In Firebase configuration for Android and iOS and expose the reversed client ID to Info.plist
- update Firebase iOS options and web metadata so Google Sign-In works across platforms

## Testing
- `flutter pub get` *(fails: `flutter` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a399703c832f8bdc0dba6e750578