### PR TITLE
Clear local stores during sign out

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -4,6 +4,11 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
+import 'history_store.dart';
+import 'leaderboard_store.dart';
+import 'question_history_store.dart';
+import 'training_history_store.dart';
+
 /// Exception thrown for authentication failures with a user-friendly message.
 class AuthException implements Exception {
   final String message;
@@ -48,6 +53,12 @@ class AuthService {
   Future<void> signOut() async {
     try {
       await _auth.signOut();
+      await Future.wait([
+        HistoryStore.clear(),
+        TrainingHistoryStore.clear(),
+        QuestionHistoryStore.clear(),
+        LeaderboardStore.clear(),
+      ]);
       if (!kIsWeb) {
         try {
           await _googleSignIn.signOut();


### PR DESCRIPTION
## Summary
- clear the local history and leaderboard stores when signing out
- ensure the clear operations are awaited before performing additional sign-out steps

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8ac33914c832fa527fa259bcd8dc2