### PR TITLE
Use Firestore for exam history storage

### DIFF
--- a/lib/services/history_store.dart
+++ b/lib/services/history_store.dart
@@ -1,29 +1,59 @@
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import '../models/exam_history_entry.dart';
 
 class HistoryStore {
-  static const String _key = 'examHistoryV1';
+  static const String _collectionName = 'examHistory';
+  static const String _entriesField = 'entries';
+
+  static DocumentReference<Map<String, dynamic>>? _docForCurrentUser() {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return null;
+    return FirebaseFirestore.instance.collection(_collectionName).doc(uid);
+  }
 
   static Future<List<ExamHistoryEntry>> load() async {
-    final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key);
-    if (raw == null || raw.isEmpty) return <ExamHistoryEntry>[];
     try {
-      return ExamHistoryEntry.decodeList(raw);
+      final doc = _docForCurrentUser();
+      if (doc == null) return <ExamHistoryEntry>[];
+      final snapshot = await doc.get();
+      final data = snapshot.data();
+      if (data == null) return <ExamHistoryEntry>[];
+      final entries = data[_entriesField];
+      if (entries == null) return <ExamHistoryEntry>[];
+      return ExamHistoryEntry.decodeList(entries);
     } catch (_) {
       return <ExamHistoryEntry>[];
     }
   }
 
   static Future<void> add(ExamHistoryEntry entry) async {
-    final prefs = await SharedPreferences.getInstance();
-    final list = await load();
-    list.insert(0, entry); // plus récent en premier
-    await prefs.setString(_key, ExamHistoryEntry.encodeList(list));
+    final doc = _docForCurrentUser();
+    if (doc == null) return;
+    try {
+      await FirebaseFirestore.instance.runTransaction((transaction) async {
+        final snapshot = await transaction.get(doc);
+        final data = snapshot.data();
+        final currentEntries = data == null
+            ? <ExamHistoryEntry>[]
+            : ExamHistoryEntry.decodeList(data[_entriesField]);
+        currentEntries.insert(0, entry); // plus récent en premier
+        transaction.set(doc, <String, dynamic>{
+          _entriesField: ExamHistoryEntry.encodeList(currentEntries),
+        });
+      });
+    } catch (_) {
+      // Ignoré : l'ajout dans l'historique ne doit pas bloquer l'application.
+    }
   }
 
   static Future<void> clear() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_key);
+    final doc = _docForCurrentUser();
+    if (doc == null) return;
+    try {
+      await doc.delete();
+    } catch (_) {
+      // Ignoré.
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace the SharedPreferences-based history persistence with a Firestore collection keyed by the authenticated uid
- adapt ExamHistoryEntry encoding and decoding to work with Firestore documents and tolerate legacy JSON payloads

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ac31e0ec832fa6d86471534609d0