### PR TITLE
feat: restyle login screen layout

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -46,114 +46,149 @@ class _LoginScreenState extends State<LoginScreen> {
           backgroundColor: Colors.transparent,
           appBar:
               AppBar(title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
-          body: SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
-            child: Form(
-              key: _formKey,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  TextFormField(
-                    controller: _emailController,
-                    keyboardType: TextInputType.emailAddress,
-                    autofillHints: const [AutofillHints.email],
-                    decoration: const InputDecoration(labelText: 'Email'),
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return 'Email requis';
-                      }
-                      final email = value.trim();
-                      final emailRegex = RegExp(r'^[^@]+@[^@]+[.][^@]+$');
-                      if (!emailRegex.hasMatch(email)) {
-                        return 'Email invalide';
-                      }
-                      return null;
-                    },
-                  ),
-                  if (!_isLogin)
-                    TextFormField(
-                      controller: _nameController,
-                      decoration: const InputDecoration(labelText: 'Nom'),
-                      validator: (value) {
-                        if (!_isLogin &&
-                            (value == null || value.trim().isEmpty)) {
-                          return 'Nom requis';
-                        }
-                        return null;
-                      },
-                    ),
-                  TextFormField(
-                    controller: _passwordController,
-                    decoration:
-                        const InputDecoration(labelText: 'Mot de passe'),
-                    keyboardType: TextInputType.visiblePassword,
-                    autocorrect: false,
-                    enableSuggestions: false,
-                    obscureText: true,
-                    validator: (value) {
-                      final pwd = value?.trim() ?? '';
-                      if (pwd.isEmpty) {
-                        return 'Mot de passe requis';
-                      }
-                      if (pwd.length < 6) {
-                        return 'Le mot de passe doit contenir au moins 6 caractères';
-                      }
-                      final hasLetter = RegExp(r'[A-Za-z]').hasMatch(pwd);
-                      final hasDigit = RegExp(r'\d').hasMatch(pwd);
-                      if (!hasLetter || !hasDigit) {
-                        return 'Le mot de passe doit contenir des lettres et des chiffres';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 12),
-                  if (_error != null)
-                    Text(_error!, style: errorStyle),
-                  const SizedBox(height: 12),
-                  PrimaryButton(
-                    onPressed: isBusy ? null : _submit,
-                    child: _isLoading
-                        ? const SizedBox(
-                            width: 24,
-                            height: 24,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Text(_isLogin ? 'Connexion' : 'Inscription'),
-                  ),
-                  const SizedBox(height: 12),
-                  OutlinedButton.icon(
-                    onPressed: isBusy ? null : _signInWithGoogle,
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 14),
-                    ),
-                    icon: _isGoogleLoading
-                        ? const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child:
-                                CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(
-                            FontAwesomeIcons.google,
-                            color: Color(0xFF4285F4),
-                          ),
-                    label: const Text('Se connecter avec Google'),
-                  ),
-                  const SizedBox(height: 12),
-                  if (_unverifiedUser != null)
-                    TextButton(
-                      onPressed: _resendVerificationEmail,
-                      child: const Text('Renvoyer l\'email de vérification'),
-                    ),
-                  TextButton(
-                    onPressed: () => setState(() {
-                      _isLogin = !_isLogin;
-                      _unverifiedUser = null;
-                    }),
-                    child: Text(
-                        _isLogin ? "Créer un compte" : 'Déjà inscrit ?'),
-                  )
+          body: Container(
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  Color(0xFF40E0D0),
+                  Color(0xFFFF0080),
                 ],
+              ),
+            ),
+            child: Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 400),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: Form(
+                      key: _formKey,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Image.asset(
+                            'assets/images/logo_splash.png',
+                            height: 120,
+                          ),
+                          const SizedBox(height: 24),
+                          TextFormField(
+                            controller: _emailController,
+                            keyboardType: TextInputType.emailAddress,
+                            autofillHints: const [AutofillHints.email],
+                            decoration: const InputDecoration(labelText: 'Email'),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'Email requis';
+                              }
+                              final email = value.trim();
+                              final emailRegex =
+                                  RegExp(r'^[^@]+@[^@]+[.][^@]+$');
+                              if (!emailRegex.hasMatch(email)) {
+                                return 'Email invalide';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                          if (!_isLogin) ...[
+                            TextFormField(
+                              controller: _nameController,
+                              decoration: const InputDecoration(labelText: 'Nom'),
+                              validator: (value) {
+                                if (!_isLogin &&
+                                    (value == null || value.trim().isEmpty)) {
+                                  return 'Nom requis';
+                                }
+                                return null;
+                              },
+                            ),
+                            const SizedBox(height: 16),
+                          ],
+                          TextFormField(
+                            controller: _passwordController,
+                            decoration:
+                                const InputDecoration(labelText: 'Mot de passe'),
+                            keyboardType: TextInputType.visiblePassword,
+                            autocorrect: false,
+                            enableSuggestions: false,
+                            obscureText: true,
+                            validator: (value) {
+                              final pwd = value?.trim() ?? '';
+                              if (pwd.isEmpty) {
+                                return 'Mot de passe requis';
+                              }
+                              if (pwd.length < 6) {
+                                return 'Le mot de passe doit contenir au moins 6 caractères';
+                              }
+                              final hasLetter = RegExp(r'[A-Za-z]').hasMatch(pwd);
+                              final hasDigit = RegExp(r'\d').hasMatch(pwd);
+                              if (!hasLetter || !hasDigit) {
+                                return 'Le mot de passe doit contenir des lettres et des chiffres';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                          if (_error != null) ...[
+                            Text(_error!, style: errorStyle),
+                            const SizedBox(height: 16),
+                          ],
+                          PrimaryButton(
+                            onPressed: isBusy ? null : _submit,
+                            child: _isLoading
+                                ? const SizedBox(
+                                    width: 24,
+                                    height: 24,
+                                    child:
+                                        CircularProgressIndicator(strokeWidth: 2),
+                                  )
+                                : Text(_isLogin ? 'Connexion' : 'Inscription'),
+                          ),
+                          const SizedBox(height: 16),
+                          OutlinedButton.icon(
+                            onPressed: isBusy ? null : _signInWithGoogle,
+                            style: OutlinedButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(vertical: 14),
+                            ),
+                            icon: _isGoogleLoading
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child:
+                                        CircularProgressIndicator(strokeWidth: 2),
+                                  )
+                                : const Icon(
+                                    FontAwesomeIcons.google,
+                                    color: Color(0xFF4285F4),
+                                  ),
+                            label: const Text('Se connecter avec Google'),
+                          ),
+                          const SizedBox(height: 16),
+                          if (_unverifiedUser != null) ...[
+                            TextButton(
+                              onPressed: _resendVerificationEmail,
+                              child: const Text(
+                                  'Renvoyer l\'email de vérification'),
+                            ),
+                            const SizedBox(height: 12),
+                          ],
+                          TextButton(
+                            onPressed: () => setState(() {
+                              _isLogin = !_isLogin;
+                              _unverifiedUser = null;
+                            }),
+                            child: Text(
+                                _isLogin ? "Créer un compte" : 'Déjà inscrit ?'),
+                          )
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- wrap the login screen in a gradient container with a centered constrained form layout
- add the splash logo above the form inputs and refresh spacing between controls

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c8ab2163c8832fb570adf747ee3cea