### PR TITLE
Wrap login scaffold with gradient background

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -42,19 +42,19 @@ class _LoginScreenState extends State<LoginScreen> {
       builder: (context, cfg, _) {
         final errorStyle = TextStyle(color: Theme.of(context).colorScheme.error);
         final isBusy = _isLoading || _isGoogleLoading;
-        return Scaffold(
-          backgroundColor: Colors.transparent,
-          appBar:
-              AppBar(title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
-          body: Container(
-            decoration: const BoxDecoration(
-              gradient: LinearGradient(
-                colors: [Color(0xFF40E0D0), Color(0xFFFF5F6D)],
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-              ),
+        return Container(
+          decoration: const BoxDecoration(
+            gradient: LinearGradient(
+              colors: [Color(0xFF40E0D0), Color(0xFFFF69B4)],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
             ),
-            child: Center(
+          ),
+          child: Scaffold(
+            backgroundColor: Colors.transparent,
+            appBar: AppBar(
+                title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
+            body: Center(
               child: SingleChildScrollView(
                 padding: const EdgeInsets.all(16),
                 child: Form(
@@ -175,9 +175,7 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
             ),
           ),
-        ),
-      ),
-    );
+        );
       },
     );
   }


### PR DESCRIPTION
## Summary
- wrap the login screen's scaffold in a container that paints the requested gradient background
- keep the scaffold background transparent so the gradient remains visible across the screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b3474124832fbcb9655c56ad48a5