### PR TITLE
Decouple question history saves from navigation

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import '../services/question_loader.dart';
 import '../services/question_randomizer.dart';
@@ -124,7 +126,19 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
         return;
       }
     }
-    await QuestionHistoryStore.addAll(selected.map((q) => q.id));
+    if (!mounted) return;
+    unawaited(
+      QuestionHistoryStore.addAll(selected.map((q) => q.id)).catchError(
+        (Object error, _) {
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Échec de l’enregistrement de l’historique des questions.'),
+            ),
+          );
+        },
+      ),
+    );
     final totalSeconds = _perQuestionSeconds * selected.length;
 
     final scoring = const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 1);

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import '../models/question.dart';
 import '../services/scoring.dart';
@@ -217,7 +219,20 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
         );
         return;
       }
-      await QuestionHistoryStore.addAll(qs.map((q) => q.id));
+      if (!mounted) return;
+      final messenger = ScaffoldMessenger.of(context);
+      unawaited(
+        QuestionHistoryStore.addAll(qs.map((q) => q.id)).catchError(
+          (Object error, _) {
+            if (!mounted) return;
+            messenger.showSnackBar(
+              const SnackBar(
+                content: Text('Échec de l’enregistrement de l’historique des questions.'),
+              ),
+            );
+          },
+        ),
+      );
 
       // Choisir la durée en fonction de la difficulté
       final Duration effDuration;

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -1,4 +1,6 @@
 // lib/screens/play_screen.dart — Live design via DesignBus + centrage tuiles + taille icône
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
@@ -233,8 +235,20 @@ class _PlayScreenState extends State<PlayScreen> {
             return;
           }
 
-          await QuestionHistoryStore.addAll(selected.map((q) => q.id));
           if (!mounted) return;
+          final messenger = ScaffoldMessenger.of(context);
+          unawaited(
+            QuestionHistoryStore.addAll(selected.map((q) => q.id)).catchError(
+              (Object error, _) {
+                if (!mounted) return;
+                messenger.showSnackBar(
+                  const SnackBar(
+                    content: Text('Échec de l’enregistrement de l’historique des questions.'),
+                  ),
+                );
+              },
+            ),
+          );
           Navigator.push(
             context,
             MaterialPageRoute(

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import '../services/question_loader.dart';
 import '../models/question.dart';
@@ -47,7 +49,19 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
         return;
       }
 
-      await QuestionHistoryStore.addAll(selected.map((q) => q.id));
+      if (!mounted) return;
+      unawaited(
+        QuestionHistoryStore.addAll(selected.map((q) => q.id)).catchError(
+          (Object error, _) {
+            if (!mounted) return;
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Échec de l’enregistrement de l’historique des questions.'),
+              ),
+            );
+          },
+        ),
+      );
 
       final totalSeconds = _perQuestionSeconds * selected.length;
       final scoring = const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 1);

--- a/lib/services/question_history_store.dart
+++ b/lib/services/question_history_store.dart
@@ -101,6 +101,7 @@ class QuestionHistoryStore {
       if (kDebugMode) {
         debugPrint('QuestionHistoryStore.addAll failed: $e\n$st');
       }
+      rethrow;
     }
   }
 


### PR DESCRIPTION
## Summary
- make question history saves fire-and-forget in training, competition, and chapter entry points so navigation is not blocked
- surface write failures through catchError handlers and rethrow from QuestionHistoryStore.addAll so users see feedback when persistence fails

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8b624c77c832fa481cc9a63e2d196