### PR TITLE
Enable Firestore persistence

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'app/theme.dart';
 import 'firebase_options.dart';
 import 'services/design_prefs.dart';
@@ -41,6 +42,8 @@ class _CivExamAppState extends State<CivExamApp> {
       await Firebase.initializeApp(
         options: DefaultFirebaseOptions.currentPlatform,
       );
+      FirebaseFirestore.instance.settings =
+          const Settings(persistenceEnabled: true);
       final cfg = await DesignPrefs.load();
       DesignBus.push(cfg);
     } catch (error, stackTrace) {


### PR DESCRIPTION
## Summary
- enable Firestore persistence immediately after Firebase initialization to allow offline caching

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8b6262424832f9c9072689bd6c9e5