### PR TITLE
Add loading indicator to exam history

### DIFF
--- a/lib/screens/exam_history_screen.dart
+++ b/lib/screens/exam_history_screen.dart
@@ -13,6 +13,7 @@ class ExamHistoryScreen extends StatefulWidget {
 
 class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
   List<ExamHistoryEntry> _items = const [];
+  bool _loading = true;
 
   @override
   void initState() {
@@ -21,9 +22,13 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
   }
 
   Future<void> _load() async {
+    setState(() => _loading = true);
     final list = await HistoryStore.load();
     if (!mounted) return;
-    setState(() => _items = list);
+    setState(() {
+      _items = list;
+      _loading = false;
+    });
   }
 
   Future<void> _clearAll() async {
@@ -69,10 +74,12 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
                 )
             ],
           ),
-          body: _items.isEmpty
-              ? const Center(
-                  child: Text('Aucun examen enregistré pour le moment.'))
-              : ListView.builder(
+          body: _loading
+              ? const Center(child: CircularProgressIndicator())
+              : _items.isEmpty
+                  ? const Center(
+                      child: Text('Aucun examen enregistré pour le moment.'))
+                  : ListView.builder(
                   itemCount: _items.length,
                   itemBuilder: (context, i) {
                     final e = _items[i];


### PR DESCRIPTION
## Summary
- add a loading state to the exam history screen and toggle it after fetching history entries
- display a progress indicator while loading and only show the empty history message once loading completes

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bdc91608832fbae1e1a01849dd49