### PR TITLE
Align exam choice text alignment

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -243,15 +243,13 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                 groupValue: answers[i],
                 onChanged: _submitted ? null : (v) => _onAnswer(i, v!),
                 contentPadding: EdgeInsets.zero,
-                title: Center(
-                  child: Text(
-                    item.choices[c],
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                          fontSize: 18,
-                        ) ??
-                        const TextStyle(fontSize: 18),
-                  ),
+                title: Text(
+                  item.choices[c],
+                  textAlign: TextAlign.start,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontSize: 18,
+                      ) ??
+                      const TextStyle(fontSize: 18),
                 ),
               ),
           ],


### PR DESCRIPTION
## Summary
- remove the `Center` wrapper around question choice text in the exam view
- align radio list tile titles to start while preserving the existing typography

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8bdc59de8832f980a648edd639f12