### PR TITLE
Adjust history store path

### DIFF
--- a/lib/services/history_store.dart
+++ b/lib/services/history_store.dart
@@ -9,7 +9,11 @@ class HistoryStore {
   static DocumentReference<Map<String, dynamic>>? _docForCurrentUser() {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return null;
-    return FirebaseFirestore.instance.collection(_collectionName).doc(uid);
+    return FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .collection(_collectionName)
+        .doc('summary');
   }
 
   static Future<List<ExamHistoryEntry>> load() async {


### PR DESCRIPTION
## Summary
- store exam history documents under each user's `/users/{uid}/examHistory` subcollection
- keep history load/add/clear operations targeting the new summary document

## Testing
- `flutter test` *(fails: Flutter is not installed in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6b62f734832f9168b8c8f0d4a30c