### PR TITLE
Authorize Firestore exam and training history access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,16 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    match /examHistory/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     match /users/{userId}/{document=**} {
       // Anonymous users are treated like any other authenticated user.
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /trainingHistory/{userId}/{document=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
   }


### PR DESCRIPTION
## Summary
- extend Firestore security rules to cover the examHistory and trainingHistory collections
- ensure authenticated users can only access their own exam and training history documents

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb6d9d193c832f93fd69b10d78fceb