### PR TITLE
Restrict leaderboard writes to the score owner

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,5 +13,10 @@ service cloud.firestore {
     match /trainingHistory/{userId}/{document=**} {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
+
+    match /competition_scores/{userId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow anyone to read the `competition_scores` leaderboard
- restrict writes to authenticated users whose UID matches the leaderboard entry

## Testing
- `firebase deploy --only firestore:rules` *(fails: `firebase` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb5cae198832f83b06f5cce80eaf8