### PR TITLE
Restrict access to competition score documents

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -15,8 +15,7 @@ service cloud.firestore {
     }
 
     match /competition_scores/{userId} {
-      allow read: if true;
-      allow write: if request.auth != null && request.auth.uid == userId;
+      allow read, write: if request.auth != null && request.auth.uid == userId;
     }
   }
 }


### PR DESCRIPTION
## Summary
- restrict access to competition score documents by requiring authenticated access matching the user document id

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbb7df3fec832f9bc2573ff3e1a6bb