### PR TITLE
Relax leaderboard read access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -15,7 +15,8 @@ service cloud.firestore {
     }
 
     match /competition_scores/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == userId;
     }
   }
 }


### PR DESCRIPTION
## Summary
- broaden read access on competition_scores collection rules to allow any authenticated user to view competition results
- keep write operations restricted to the score owner for safety

## Testing
- Not run (Firestore deployment requires project credentials)


------
https://chatgpt.com/codex/tasks/task_e_68cbd42e08bc832f93d20073dd7016fb