### PR TITLE
Ensure competition scores use authenticated user

### DIFF
--- a/lib/services/competition_service.dart
+++ b/lib/services/competition_service.dart
@@ -1,5 +1,6 @@
 // lib/services/competition_service.dart
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
 import '../models/leaderboard_entry.dart';
@@ -14,11 +15,24 @@ class CompetitionService {
 
   /// Sauvegarde ou met à jour un résultat de compétition pour l'utilisateur.
   Future<void> saveEntry(LeaderboardEntry entry) async {
+    const reconnectMessage =
+        'Votre session a expiré, veuillez vous reconnecter pour enregistrer votre score.';
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      throw Exception(reconnectMessage);
+    }
+    final uid = user.uid;
+    if (entry.userId.isNotEmpty && entry.userId != uid) {
+      debugPrint(
+          'saveEntry aborted: mismatched userId (entry=${entry.userId}, uid=$uid)');
+      throw Exception(reconnectMessage);
+    }
     final data = entry.toJson();
+    data['userId'] = uid;
     data['updatedAt'] = FieldValue.serverTimestamp();
     data['mode'] = 'competition';
     try {
-      await _col.doc(entry.userId).set(data);
+      await _col.doc(uid).set(data);
     } catch (e) {
       throw Exception("Échec de l'enregistrement du score: $e");
     }


### PR DESCRIPTION
## Summary
- require a signed-in FirebaseAuth user before saving competition scores
- abort saves with a reconnect-friendly error when the leaderboard entry user mismatches the session
- write competition results under the authenticated UID and sync the stored `userId`

## Testing
- flutter test *(fails: `flutter` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdbf70890832fba6600b93d5b1bcc