### PR TITLE
Ensure competition navigation respects mounted state

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -350,10 +350,14 @@ class _CompetitionScreenState extends State<CompetitionScreen>
     });
     // Pause the timer and move to next question shortly after.
     _controller.stop();
-    Future.delayed(const Duration(milliseconds: 300), () => _goNext(i));
+    Future.delayed(const Duration(milliseconds: 300), () {
+      if (!mounted) return;
+      _goNext(i);
+    });
   }
 
   void _goNext([int? selected]) {
+    if (!mounted) return;
     // Determine whether the chosen option (if any) is correct, wrong or blank.
     final bool isBlank = selected == null;
     final bool isCorrect =


### PR DESCRIPTION
## Summary
- guard delayed navigation from calling into a disposed competition screen
- short-circuit `_goNext` when the state object has been disposed before navigation

## Testing
- flutter test test/competition_navigation_test.dart *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf3138008832f92c95d374ae0b1c6