### PR TITLE
Use splash logo on login screen

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -64,7 +64,7 @@ class _LoginScreenState extends State<LoginScreen> {
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       Image.asset(
-                        'assets/images/logo.png',
+                        'assets/images/logo_splash.png',
                         height: 120,
                       ),
                       const SizedBox(height: 24),


### PR DESCRIPTION
## Summary
- update the login screen to display the splash logo asset so it matches the dashboard visuals

## Testing
- `flutter run` *(fails: Flutter SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc146f040c832fba8b5c59bfedd7cd