### PR TITLE
Add spacing between login form fields

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -85,18 +85,22 @@ class _LoginScreenState extends State<LoginScreen> {
                           return null;
                         },
                       ),
+                      const SizedBox(height: 16),
                       if (!_isLogin)
-                        TextFormField(
-                          controller: _nameController,
-                          decoration: const InputDecoration(labelText: 'Nom'),
-                          validator: (value) {
-                            if (!_isLogin &&
-                                (value == null || value.trim().isEmpty)) {
-                              return 'Nom requis';
-                            }
-                            return null;
-                          },
-                        ),
+                        ...[
+                          TextFormField(
+                            controller: _nameController,
+                            decoration: const InputDecoration(labelText: 'Nom'),
+                            validator: (value) {
+                              if (!_isLogin &&
+                                  (value == null || value.trim().isEmpty)) {
+                                return 'Nom requis';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 16),
+                        ],
                       TextFormField(
                         controller: _passwordController,
                         decoration:


### PR DESCRIPTION
## Summary
- insert consistent vertical spacing between email, name, and password fields on the login screen
- ensure the optional name field maintains the same spacing when displayed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc171bcf50832fa7a9dac947915034