### PR TITLE
Increase login screen logo size

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -65,7 +65,8 @@ class _LoginScreenState extends State<LoginScreen> {
                     children: [
                       Image.asset(
                         'assets/images/logo_splash.png',
-                        height: 120,
+                        height: 180,
+                        fit: BoxFit.contain,
                       ),
                       const SizedBox(height: 24),
                       TextFormField(


### PR DESCRIPTION
## Summary
- increase the login screen logo height for better visibility
- ensure the image uses BoxFit.contain to avoid cropping when larger

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc17167e04832fb9e7fa499ab1a7ca