### PR TITLE
Update login gradient to sky blue

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -45,7 +45,7 @@ class _LoginScreenState extends State<LoginScreen> {
         return Container(
           decoration: const BoxDecoration(
             gradient: LinearGradient(
-              colors: [Color(0xFF40E0D0), Color(0xFFFF69B4)],
+              colors: [Color(0xFF40E0D0), Color(0xFF87CEEB)],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
             ),


### PR DESCRIPTION
## Summary
- replace the pink color in the login screen gradient with a sky blue tone to refresh the look

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc1a55e288832fa78beb1aca51776b