### PR TITLE
Add dashboard icon to PlayScreen app bar

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -18,6 +18,7 @@ import 'subject_list_screen.dart';
 import 'training_history_screen.dart';
 import 'exam_history_screen.dart';
 import 'leaderboard_screen.dart';
+import 'dashboard_screen.dart';
 import 'design_settings_screen.dart';
 import 'competition_screen.dart';
 import 'login_screen.dart';
@@ -88,6 +89,17 @@ class _PlayScreenState extends State<PlayScreen> {
                           if (mounted) setState(() => _signingOut = false);
                         }
                       },
+              ),
+              IconButton(
+                icon: const Icon(Icons.person_outline),
+                tooltip: 'Tableau de bord',
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const DashboardScreen()),
+                  );
+                },
               ),
               IconButton(
                 icon: const Icon(Icons.emoji_events_outlined),


### PR DESCRIPTION
## Summary
- add a dashboard icon button to the PlayScreen app bar
- wire the new icon to push the DashboardScreen via Navigator
- import the dashboard screen dependency

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc1d46d1c8832fa7022392c534169a