### PR TITLE
Remove dashboard shortcut from leaderboard

### DIFF
--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
 import '../services/private_scores_store.dart';
-import 'dashboard_screen.dart';
 
 class LeaderboardScreen extends StatefulWidget {
   const LeaderboardScreen({super.key});
@@ -46,16 +45,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Classement'), actions:[
-        IconButton(
-            icon: const Icon(Icons.person),
-            onPressed: () async {
-              await Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                      builder: (_) => const DashboardScreen()));
-              if (mounted) _load();
-            }),
-        IconButton(icon: const Icon(Icons.refresh), onPressed: _load)
+        IconButton(icon: const Icon(Icons.refresh), onPressed: _load),
       ]),
       body: Column(children: [
         Padding(


### PR DESCRIPTION
## Summary
- remove the dashboard shortcut icon from the leaderboard app bar, leaving only refresh
- drop the unused dashboard screen import

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc1d457468832f82d37ec6159607d0