### PR TITLE
Remove nickname prompt in competition leaderboard dialog

### DIFF
--- a/lib/widgets/leaderboard_save_dialog.dart
+++ b/lib/widgets/leaderboard_save_dialog.dart
@@ -44,68 +44,8 @@ Future<void> showSaveScoreDialog({
       debugPrint('Failed to load profile for $uid: $e\n$st');
       profile = null;
     }
-    String nickname = profile?.nickname ?? '';
-
-    // Demande le pseudonyme si absent
-    if (nickname.trim().isEmpty && context.mounted) {
-      final controller = TextEditingController();
-      try {
-        await showDialog(
-          context: context,
-          barrierDismissible: false,
-          builder: (_) => AlertDialog(
-            title: const Text('Votre pseudonyme'),
-            content: TextField(
-              controller: controller,
-              decoration: const InputDecoration(
-                  labelText: 'Pseudonyme', border: OutlineInputBorder()),
-            ),
-            actions: [
-              TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('OK')),
-            ],
-          ),
-        );
-        nickname = controller.text.trim();
-      } finally {
-        controller.dispose();
-      }
-      if (nickname.isNotEmpty) {
-        final toSave = UserProfile(
-          firstName: profile?.firstName ?? '',
-          lastName: profile?.lastName ?? '',
-          nickname: nickname,
-          profession: profile?.profession ?? '',
-          photoUrl: profile?.photoUrl ?? '',
-        );
-        try {
-          await profileService.saveProfile(toSave);
-        } catch (e, st) {
-          debugPrint('Error saving profile: $e\n$st');
-          if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: const Text(
-                    "Échec de l'enregistrement du pseudonyme. Réessayez."),
-                action: SnackBarAction(
-                  label: 'Réessayer',
-                  onPressed: () async {
-                    try {
-                      await profileService.saveProfile(toSave);
-                    } catch (e, st) {
-                      debugPrint('Failed to save profile: $e\n$st');
-                    }
-                  },
-                ),
-              ),
-            );
-          }
-        }
-      }
-    }
-
-    if (nickname.isNotEmpty) {
+    final nickname = profile?.nickname?.trim();
+    if (nickname != null && nickname.isNotEmpty) {
       name = nickname;
     }
 


### PR DESCRIPTION
## Summary
- stop prompting for a nickname in the competition leaderboard save dialog
- rely on the existing profile nickname or fall back to the user's display name, email, or "Joueur"

## Testing
- flutter analyze *(fails: command not found)*
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc37bd4b54832fb5e431a3b511b28e