### PR TITLE
Adjust input borders to square corners

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -65,11 +65,11 @@ ThemeData buildAppTheme(DesignConfig cfg) {
     inputDecorationTheme: InputDecorationTheme(
       filled: true,
       fillColor: Colors.grey.shade100,
-      border: OutlineInputBorder(
-        borderRadius: BorderRadius.circular(12),
+      border: const OutlineInputBorder(
+        borderRadius: BorderRadius.zero,
         borderSide: BorderSide.none,
       ),
-      contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
     ),
     chipTheme: base.chipTheme.copyWith(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -48,7 +48,12 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
           padding: const EdgeInsets.fromLTRB(12,12,12,6),
           child: Row(children: [
             Expanded(child: TextField(
-              decoration: const InputDecoration(isDense:true, prefixIcon: Icon(Icons.search), hintText:'Nom / matière', border: OutlineInputBorder()),
+              decoration: const InputDecoration(
+                isDense: true,
+                prefixIcon: Icon(Icons.search),
+                hintText: 'Nom / matière',
+                border: OutlineInputBorder(borderRadius: BorderRadius.zero),
+              ),
               onChanged: (v)=>setState(()=>_query=v),
             )),
             const SizedBox(width:12),

--- a/lib/widgets/leaderboard_save_dialog.dart
+++ b/lib/widgets/leaderboard_save_dialog.dart
@@ -138,7 +138,8 @@ Future<void> showSaveScoreDialog({
         content: Column(mainAxisSize: MainAxisSize.min, children: [
           TextField(
               decoration: const InputDecoration(
-                  labelText: 'Votre nom', border: OutlineInputBorder()),
+                  labelText: 'Votre nom',
+                  border: OutlineInputBorder(borderRadius: BorderRadius.zero)),
               controller: controller),
           const SizedBox(height: 12),
           Text('Mode : $mode  •  Score : ${percent.toStringAsFixed(1)}%'),


### PR DESCRIPTION
## Summary
- update the global input decoration theme to use square borders and tuned padding
- ensure leaderboard search and save dialog inputs also opt into square corners

## Testing
- flutter analyze *(fails: flutter: command not found)*
- flutter test *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3df246f4832fa165837110a6afc4