### PR TITLE
Update splash and launcher assets configuration

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,9 +41,7 @@ flutter:
   assets:
     - assets/questions/
     - assets/questions/ena_sample.json
-    - assets/images/logo_splash_square.png
     - assets/images/logo_splash.png
-    - assets/images/logo_icon_square.png
     - assets/icons/
     - assets/icons/mono/
     - assets/icons/sets/amber/
@@ -55,7 +53,7 @@ flutter:
 flutter_native_splash:
   color: "#FFFFFF"
   color_dark: "#FFFFFF"
-  image: assets/images/logo_splash_square.png
+  image: assets/images/logo_splash.png
   fullscreen: true
   android: true
   ios: false
@@ -63,7 +61,7 @@ flutter_native_splash:
 
 flutter_icons:
   android: "launcher_icon"
-  image_path: "assets/images/logo_icon_square.png"
+  image_path: "assets/images/logo_splash.png"
   adaptive_icon_background: "#37478F"
-  adaptive_icon_foreground: "assets/images/logo_icon_square.png"
+  adaptive_icon_foreground: "assets/images/logo_splash.png"
   min_sdk_android: 23


### PR DESCRIPTION
## Summary
- point the splash and launcher configuration to assets/images/logo_splash.png
- remove unused square logo asset declarations from pubspec

## Testing
- flutter pub run flutter_native_splash:create *(fails: Flutter SDK not installed in container)*
- flutter pub run flutter_launcher_icons *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3def9b5c832f805e63eda40e8f79