### PR TITLE
Align splash screen logo asset with login screen

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -58,11 +58,12 @@ class _SplashScreenState extends State<SplashScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       body: Center(
-        child: Image(
-          image: AssetImage('assets/images/logo_splash.png'),
-          width: 200,
+        child: Image.asset(
+          'assets/images/logo_splash.png',
+          height: 180,
+          fit: BoxFit.contain,
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- update the splash screen to use `Image.asset` with the same configuration as the login screen logo

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc43f1a8e8832faf934031ffdaacf8