### PR TITLE
Make login app bar transparent

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -80,7 +80,13 @@ class _LoginScreenState extends State<LoginScreen> {
           child: Scaffold(
             backgroundColor: Colors.transparent,
             appBar: AppBar(
-                title: Text(_isLogin ? 'Se connecter' : "Créer un compte")),
+              backgroundColor: Colors.transparent,
+              elevation: 0,
+              scrolledUnderElevation: 0,
+              surfaceTintColor: Colors.transparent,
+              foregroundColor: Colors.white,
+              title: Text(_isLogin ? 'Se connecter' : "Créer un compte"),
+            ),
             body: Center(
               child: SingleChildScrollView(
                 padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- make the login screen app bar transparent so the gradient background remains visible
- ensure the app bar uses a white foreground color for text and icons to keep them legible

## Testing
- flutter test *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc43e73408832f8c4c985a3d9f7965