### PR TITLE
Simplify login screen scaffold

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -69,33 +69,25 @@ class _LoginScreenState extends State<LoginScreen> {
         final loginButtonTheme = ElevatedButtonThemeData(
           style: _loginButtonStyle(theme),
         );
-        return Container(
-          decoration: const BoxDecoration(
-            gradient: LinearGradient(
-              colors: [Color(0xFF40E0D0), Color(0xFF87CEEB)],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-          ),
-          child: Scaffold(
+        return Scaffold(
+          backgroundColor: Colors.transparent,
+          appBar: AppBar(
             backgroundColor: Colors.transparent,
-            appBar: AppBar(
-              backgroundColor: Colors.transparent,
-              elevation: 0,
-              scrolledUnderElevation: 0,
-              surfaceTintColor: Colors.transparent,
-              foregroundColor: Colors.white,
-              title: Text(_isLogin ? 'Se connecter' : "Créer un compte"),
-            ),
-            body: Center(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.all(16),
-                child: Form(
-                  key: _formKey,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
+            elevation: 0,
+            scrolledUnderElevation: 0,
+            surfaceTintColor: Colors.transparent,
+            foregroundColor: Colors.white,
+            title: Text(_isLogin ? 'Se connecter' : "Créer un compte"),
+          ),
+          body: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
                       Image.asset(
                         'assets/images/logo_splash.png',
                         height: 180,


### PR DESCRIPTION
## Summary
- remove the gradient Container so the login screen returns a transparent Scaffold directly
- keep the Scaffold and AppBar backgrounds transparent to allow the design background to show through

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc49954484832fb16fc70245855117