### PR TITLE
Guard ENA loader dialog pop

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -222,6 +222,7 @@ class _PlayScreenState extends State<PlayScreen> {
         );
         break;
       case 5:
+        bool progressShown = false;
         try {
           const int desiredCount = 60;
           final all = await QuestionLoader.loadENA();
@@ -231,12 +232,13 @@ class _PlayScreenState extends State<PlayScreen> {
             barrierDismissible: false,
             builder: (_) => const Center(child: CircularProgressIndicator()),
           );
+          progressShown = true;
           final selected = await pickAndShuffle(
             all,
             desiredCount,
             dedupeByQuestion: true,
           );
-          if (mounted) Navigator.pop(context);
+          if (progressShown && mounted) Navigator.pop(context);
 
           final proceed = await _handleShortDraw(selected, desiredCount);
           if (!proceed) {
@@ -268,7 +270,7 @@ class _PlayScreenState extends State<PlayScreen> {
             ),
           );
         } catch (e) {
-          if (mounted) Navigator.pop(context);
+          if (progressShown && mounted) Navigator.pop(context);
           if (!mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/test/play_screen_failure_test.dart
+++ b/test/play_screen_failure_test.dart
@@ -1,0 +1,103 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:civexam_pro/screens/play_screen.dart';
+
+class _MockNavigatorObserver extends NavigatorObserver {
+  int popCount = 0;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    popCount++;
+    super.didPop(route, previousRoute);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel firebaseCoreChannel = MethodChannel('plugins.flutter.io/firebase_core');
+  const MethodChannel firebaseAuthChannel = MethodChannel('plugins.flutter.io/firebase_auth');
+
+  setUpAll(() async {
+    firebaseCoreChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      switch (methodCall.method) {
+        case 'Firebase#initializeCore':
+          return <Map<String, Object?>>[];
+        case 'Firebase#initializeApp':
+          final Map<Object?, Object?> app = methodCall.arguments['app'] as Map<Object?, Object?>;
+          return <Map<String, Object?>>[
+            <String, Object?>{
+              'name': app['name'],
+              'options': <String, Object?>{},
+              'pluginConstants': <String, Object?>{},
+            },
+          ];
+        case 'Firebase#appNamed':
+          final String name = methodCall.arguments['appName'] as String;
+          return <String, Object?>{
+            'name': name,
+            'options': <String, Object?>{},
+            'pluginConstants': <String, Object?>{},
+          };
+        case 'Firebase#apps':
+          return <Map<String, Object?>>[];
+      }
+      return null;
+    });
+
+    firebaseAuthChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+      switch (methodCall.method) {
+        case 'Auth#initialize':
+        case 'Auth#registerIdTokenListener':
+        case 'Auth#registerAuthStateListener':
+        case 'Auth#signOut':
+        case 'Auth#setLanguageCode':
+        case 'Auth#useAppLanguage':
+        case 'Auth#setSettings':
+          return null;
+        case 'Auth#currentUser':
+          return <String, Object?>{'user': null};
+      }
+      return null;
+    });
+
+    await Firebase.initializeApp();
+  });
+
+  tearDown(() {
+    ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(SystemChannels.assets.name, null);
+  });
+
+  testWidgets('shows snackbar and keeps PlayScreen when ENA load fails', (WidgetTester tester) async {
+    final BinaryMessenger messenger = ServicesBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMessageHandler(SystemChannels.assets.name, (ByteData? message) async {
+      throw Exception('asset-load-failure');
+    });
+
+    addTearDown(() {
+      messenger.setMockMessageHandler(SystemChannels.assets.name, null);
+    });
+
+    final _MockNavigatorObserver observer = _MockNavigatorObserver();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: const PlayScreen(),
+        navigatorObservers: <NavigatorObserver>[observer],
+      ),
+    );
+
+    expect(find.byType(PlayScreen), findsOneWidget);
+
+    await tester.tap(find.text('Compétition'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(find.textContaining('Unable to load question bank'), findsOneWidget);
+    expect(observer.popCount, 0);
+    expect(find.byType(PlayScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- track whether the ENA competition loader dialog has been presented before dismissing it
- prevent Navigator.pop calls when the dialog was never shown so the PlayScreen route stays mounted
- add a widget test that simulates a QuestionLoader failure and asserts the snackbar appears without popping the screen

## Testing
- flutter test test/play_screen_failure_test.dart *(fails: flutter tool unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4e2dedd0832f8cec657b95cc5607