### PR TITLE
Handle unverified users on splash

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -10,7 +10,9 @@ import '../widgets/primary_button.dart';
 import 'play_screen.dart';
 
 class LoginScreen extends StatefulWidget {
-  const LoginScreen({super.key});
+  const LoginScreen({super.key, this.initialUnverifiedUser});
+
+  final User? initialUnverifiedUser;
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -28,6 +30,12 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _isGoogleLoading = false;
   User? _unverifiedUser;
   static const Color _logoOrange = Color(0xFFFF7F00);
+
+  @override
+  void initState() {
+    super.initState();
+    _unverifiedUser = widget.initialUnverifiedUser;
+  }
 
   @override
   void dispose() {


### PR DESCRIPTION
## Summary
- reload the current Firebase user on the splash screen before routing, signing out unverified accounts, and showing an email verification reminder
- allow the login screen to accept an initial unverified user so the resend verification flow remains available after the splash sign-out

## Testing
- flutter test *(fails: `flutter` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4e2841d0832fafb05cb675ee02db