### PR TITLE
Fix closing parentheses in login screen Scaffold

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -230,8 +230,7 @@ class _LoginScreenState extends State<LoginScreen> {
                 ),
               ),
             ),
-          ),
-        );
+          ));
       },
     );
   }


### PR DESCRIPTION
## Summary
- remove the stray closing line after the Center widget in the login screen
- close the Scaffold call correctly so the ValueListenableBuilder remains balanced

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc526c8174832f9a355e3b6f6e0caf