### PR TITLE
Fix closing parentheses in login screen

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -230,7 +230,7 @@ class _LoginScreenState extends State<LoginScreen> {
                 ),
               ),
             ),
-          ));
+          );
       },
     );
   }


### PR DESCRIPTION
## Summary
- fix the closing parentheses in the login screen's ValueListenableBuilder so the Scaffold and builder close correctly

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc55f86b34832faa1537ae4e4b6b8c