### PR TITLE
Fix LoginScreen scaffold closing

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -230,7 +230,7 @@ class _LoginScreenState extends State<LoginScreen> {
                 ),
               ),
             ),
-          );
+        );
       },
     );
   }


### PR DESCRIPTION
## Summary
- ensure the login screen builder closes only the Scaffold at the end of the widget tree

## Testing
- flutter analyze *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc58bb98e4832f87a7cfd9e1b7296e