### PR TITLE
Add auth guard for top-level Firestore user documents

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,6 +5,10 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
     }
 
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
     match /users/{userId}/{document=**} {
       // Anonymous users are treated like any other authenticated user.
       allow read, write: if request.auth != null && request.auth.uid == userId;


### PR DESCRIPTION
## Summary
- add a Firestore rules match block for `/users/{userId}` to require authenticated access by the owning user
- keep existing nested user document rules unchanged

## Testing
- firebase deploy --only firestore:rules *(fails: firebase command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc70841eb0832f9e64bbd9779609c9