### PR TITLE
feat: colorize difficulty picker icons

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -331,31 +331,43 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
 
   Widget _difficultyPicker() {
     final items = ExamDifficulty.values;
+    final theme = Theme.of(context);
     return Wrap(
       spacing: 8,
       runSpacing: 8,
       children: items.map((d) {
         final selected = _difficulty == d;
-        IconData icon;
+        late final IconData icon;
+        late final Color accent;
         switch (d) {
           case ExamDifficulty.facile:
             icon = Icons.sentiment_satisfied_alt;
+            accent = Colors.green.shade600;
             break;
           case ExamDifficulty.normal:
             icon = Icons.sentiment_neutral;
+            accent = Colors.blue.shade600;
             break;
           case ExamDifficulty.difficile:
             icon = Icons.sentiment_dissatisfied;
+            accent = Colors.orange.shade600;
             break;
           case ExamDifficulty.expert:
             icon = Icons.bolt;
+            accent = Colors.purple.shade600;
             break;
         }
         return ChoiceChip(
-          avatar: Icon(icon, size: 18),
+          avatar: Icon(icon, size: 18, color: accent),
           label: Text(difficultyLabel(d)),
           selected: selected,
           tooltip: difficultyHint(d),
+          labelStyle: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurface,
+            fontWeight: selected ? FontWeight.w600 : null,
+          ),
+          backgroundColor: accent.withOpacity(0.08),
+          selectedColor: accent.withOpacity(0.18),
           onSelected: (_) => setState(() => _difficulty = d),
         );
       }).toList(),


### PR DESCRIPTION
## Summary
- assign dedicated accent colors to each exam difficulty option
- tint the difficulty picker icons and chip backgrounds with their accent colors for better readability

## Testing
- flutter analyze *(fails: Flutter is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7ff6cdb8832fa7457f4dfbdaf387