### PR TITLE
Update play screen welcome message

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -43,8 +43,8 @@ class _PlayScreenState extends State<PlayScreen> {
         final user = FirebaseAuth.instance.currentUser;
         final name = user?.displayName ?? user?.email;
         final welcomeText = name != null && name.isNotEmpty
-            ? 'Bienvenue $name 👋  •  Choisis un mode'
-            : 'Bienvenue 👋  •  Choisis un mode';
+            ? 'Bienvenue $name 👋'
+            : 'Bienvenue 👋';
         final textColor =
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
         final badgeColors = playIconColors(cfg.bgPaletteName);


### PR DESCRIPTION
## Summary
- remove the "• Choisis un mode" suffix from the play screen welcome message while keeping the greeting and emoji

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc8e90178c832fb8474c6d000a5b53