### PR TITLE
Add auth domain to Firebase web options

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -29,6 +29,7 @@ class DefaultFirebaseOptions {
   static const FirebaseOptions web = FirebaseOptions(
     apiKey: 'AIzaSyBWAIrkydvaNel2li2mKwrF2qbBag7M98Q',
     appId: '1:522640251078:web:8157ff3781f38b4b0b9f86',
+    authDomain: 'civexam-54e17.firebaseapp.com',
     messagingSenderId: '522640251078',
     projectId: 'civexam-54e17',
     storageBucket: 'civexam-54e17.firebasestorage.app',


### PR DESCRIPTION
## Summary
- specify the Firebase Authentication domain for the web configuration so hosted apps can initialize Firebase Auth correctly

## Testing
- `flutter build web` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc90715c90832f89fb82960da93bdc