### PR TITLE
Handle question randomizer without isolates

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -70,7 +70,18 @@ Future<List<Question>> pickAndShuffle(
     rngSeed: r.nextInt(1 << 32),
   );
 
-  final result = await compute(_pickAndShuffleIsolate, args.toMap());
+  final argsMap = args.toMap();
+
+  Map<String, dynamic> result;
+  if (kIsWeb) {
+    result = _pickAndShuffleIsolate(argsMap);
+  } else {
+    try {
+      result = await compute(_pickAndShuffleIsolate, argsMap);
+    } on UnsupportedError {
+      result = _pickAndShuffleIsolate(argsMap);
+    }
+  }
 
   final selectedMaps = List<Map<String, dynamic>>.from(
       (result['selected'] as List).map((e) => Map<String, dynamic>.from(e)));


### PR DESCRIPTION
## Summary
- add a synchronous fallback for pickAndShuffle so it works when isolates are unavailable (e.g. on the web)
- keep the existing return structure and retry flow while still using compute when supported

## Testing
- Unable to run flutter run -d chrome (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc9483419c832fbae0a82fe3d7bcf3