### PR TITLE
Handle question parsing when isolates unavailable

### DIFF
--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -48,7 +48,7 @@ class QuestionLoader {
       final path = paths[i];
       try {
         final raw = await rootBundle.loadString(path);
-        final out = await compute(_parseQuestions, raw);
+        final out = await _parseQuestionsIsolateAware(raw);
         if (out.isEmpty) continue;
 
         if (i == 0 && out.length < ExamBlueprint.totalTarget) {
@@ -90,6 +90,17 @@ class QuestionLoader {
         return 3;
       default:
         return 2;
+    }
+  }
+
+  static Future<List<Question>> _parseQuestionsIsolateAware(String raw) async {
+    if (kIsWeb) {
+      return _parseQuestions(raw);
+    }
+    try {
+      return await compute(_parseQuestions, raw);
+    } on UnsupportedError {
+      return _parseQuestions(raw);
     }
   }
 


### PR DESCRIPTION
## Summary
- bypass the compute isolate when running on platforms without isolate support
- retain the existing ENA caching and subject building after parsing via a shared helper

## Testing
- flutter run -d chrome *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc947db984832fa7347cc7a950d2ee