### PR TITLE
Bypass compute for web ENA question loading

### DIFF
--- a/lib/services/question_loader.dart
+++ b/lib/services/question_loader.dart
@@ -48,7 +48,12 @@ class QuestionLoader {
       final path = paths[i];
       try {
         final raw = await rootBundle.loadString(path);
-        final out = await _parseQuestionsIsolateAware(raw);
+        final List<Question> out;
+        if (kIsWeb) {
+          out = _parseQuestions(raw);
+        } else {
+          out = await _parseQuestionsIsolateAware(raw);
+        }
         if (out.isEmpty) continue;
 
         if (i == 0 && out.length < ExamBlueprint.totalTarget) {


### PR DESCRIPTION
## Summary
- update `QuestionLoader.loadENA` to parse questions directly on web builds
- preserve compute usage on non-web platforms while keeping caching and subject initialization intact

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc96148274832fb4567b82e7933676