### PR TITLE
Fix RNG seed generation for web compatibility

### DIFF
--- a/lib/services/question_randomizer.dart
+++ b/lib/services/question_randomizer.dart
@@ -62,12 +62,15 @@ Future<List<Question>> pickAndShuffle(
   final history = await QuestionHistoryStore.load();
 
   // Prepare data for the isolate.
+  int rngSeed = (r.nextDouble() * 0x100000000).floor();
+  if (rngSeed == 0) rngSeed = 1;
+
   final args = _PickAndShuffleArgs(
     pool: pool.map((q) => q.toMap()).toList(),
     history: history,
     take: take,
     dedupeByQuestion: dedupeByQuestion,
-    rngSeed: r.nextInt(1 << 32),
+    rngSeed: rngSeed,
   );
 
   final argsMap = args.toMap();


### PR DESCRIPTION
## Summary
- replace use of `1 << 32` when generating the random seed for isolates
- derive a 32-bit seed from `nextDouble()` and guard against zero on the web target

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc97d9eb74832f85bb49ae45196042