### PR TITLE
Improve responsive scaling across play and competition screens

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/question.dart';
 import '../theme/competition_theme.dart';
 import '../services/leaderboard_hooks.dart';
+import '../utils/responsive_utils.dart';
 
 /// Competition quiz screen with a circular countdown and progress tracking.
 class CompetitionScreen extends StatefulWidget {
@@ -99,15 +100,29 @@ class _CompetitionScreenState extends State<CompetitionScreen>
   @override
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
-    final theme = widget.theme ?? CompetitionTheme.fromTheme(Theme.of(context));
+    final scale = computeScaleFactor(mediaQuery);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final theme =
+        (widget.theme ?? CompetitionTheme.fromTheme(Theme.of(context)))
+            .scaled(scale, textScaler);
     final TextStyle resolvedChipTextStyle =
         DefaultTextStyle.of(context).style.merge(theme.selectedChipTextStyle);
+    final double optionFontSize = scaledFontSize(
+      base: 18,
+      scale: scale,
+      textScaler: textScaler,
+      min: 15,
+      max: 26,
+    );
     final double chipMinHeight =
         (resolvedChipTextStyle.fontSize ?? 16) *
                 (resolvedChipTextStyle.height ?? 1.0) +
             16;
-    final double topCardHeight =
-        (mediaQuery.size.height * 0.3).clamp(240.0, 320.0) as double;
+    final double topCardHeight = clampDouble(
+      mediaQuery.size.height * 0.3,
+      240.0,
+      320.0,
+    );
     return Scaffold(
       // Global background color comes from the theme.
       backgroundColor: theme.backgroundColor,
@@ -323,7 +338,7 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                                   _currentQuestion.choices[i],
                                   textAlign: TextAlign.center,
                                   style: theme.optionTextStyle
-                                      .copyWith(fontSize: 18),
+                                      .copyWith(fontSize: optionFontSize),
                                 ),
                               ),
                             ),

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -10,6 +10,7 @@ import '../models/design_config.dart';
 import '../services/design_bus.dart';
 import '../services/design_prefs.dart';
 import '../utils/palette_utils.dart';
+import '../utils/responsive_utils.dart';
 
 class DesignSettingsScreen extends StatefulWidget {
   const DesignSettingsScreen({super.key});
@@ -69,6 +70,23 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
         pastelColors(_cfg.bgPaletteName, darkMode: _cfg.darkMode);
     final previewTextColor =
         textColorForPalette(_cfg.bgPaletteName, darkMode: _cfg.darkMode);
+    final mediaQuery = MediaQuery.of(context);
+    final scale = computeScaleFactor(mediaQuery);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final double previewFontSize = scaledFontSize(
+      base: 20,
+      scale: scale,
+      textScaler: textScaler,
+      min: 18,
+      max: 28,
+    );
+    final double sectionTitleSize = scaledFontSize(
+      base: 16,
+      scale: scale,
+      textScaler: textScaler,
+      min: 14,
+      max: 22,
+    );
 
     return Scaffold(
       appBar: AppBar(title: const Text('Personnalisation')),
@@ -86,14 +104,14 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
               'Aperçu',
               style: TextStyle(
                 color: previewTextColor,
-                fontSize: 20,
+                fontSize: previewFontSize,
                 fontWeight: FontWeight.bold,
               ),
             ),
           ),
           const SizedBox(height: 24),
 
-          _sectionTitle('Thème'),
+          _sectionTitle('Thème', sectionTitleSize),
           SwitchListTile(
             title: const Text('Mode sombre'),
             value: _cfg.darkMode,
@@ -106,7 +124,7 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
           ),
           const Divider(height: 32),
 
-          _sectionTitle('Palette de couleurs'),
+          _sectionTitle('Palette de couleurs', sectionTitleSize),
           SizedBox(
             height: 200,
             child: GridView.count(
@@ -121,7 +139,7 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
           ),
           const Divider(height: 32),
 
-          _sectionTitle('Options'),
+          _sectionTitle('Options', sectionTitleSize),
           SwitchListTile(
             title: const Text('Effet "wave" (halo)'),
             value: _cfg.waveEnabled,
@@ -273,12 +291,12 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
     );
   }
 
-  Widget _sectionTitle(String text) => Padding(
+  Widget _sectionTitle(String text, double fontSize) => Padding(
         padding: const EdgeInsets.only(bottom: 8),
         child: Text(
           text,
-          style: const TextStyle(
-            fontSize: 16,
+          style: TextStyle(
+            fontSize: fontSize,
             fontWeight: FontWeight.bold,
           ),
         ),

--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -15,6 +15,7 @@ import 'package:device_info_plus/device_info_plus.dart';
 import '../models/question.dart';
 import '../services/scoring.dart';
 import '../app/theme.dart';
+import '../utils/responsive_utils.dart';
 
 class ExamResult {
   final int correctCount;
@@ -216,6 +217,16 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
   }
 
   Widget _questionCard(Question item, int i) {
+    final mediaQuery = MediaQuery.of(context);
+    final scale = computeScaleFactor(mediaQuery);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final double optionFontSize = scaledFontSize(
+      base: 18,
+      scale: scale,
+      textScaler: textScaler,
+      min: 16,
+      max: 26,
+    );
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(12),
@@ -247,9 +258,9 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                   item.choices[c],
                   textAlign: TextAlign.start,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontSize: 18,
+                        fontSize: optionFontSize,
                       ) ??
-                      const TextStyle(fontSize: 18),
+                      TextStyle(fontSize: optionFontSize),
                 ),
               ),
           ],

--- a/lib/screens/official_intro_screen.dart
+++ b/lib/screens/official_intro_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../services/scoring.dart';
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../utils/responsive_utils.dart';
 import 'multi_exam_flow.dart';
 
 class OfficialIntroScreen extends StatefulWidget {
@@ -50,6 +51,23 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
       valueListenable: DesignBus.notifier,
       builder: (context, cfg, _) {
         final overlayTextColor = Theme.of(context).colorScheme.onSurface;
+        final mediaQuery = MediaQuery.of(context);
+        final scale = computeScaleFactor(mediaQuery);
+        final textScaler = MediaQuery.textScalerOf(context);
+        final double introTitleSize = scaledFontSize(
+          base: 18,
+          scale: scale,
+          textScaler: textScaler,
+          min: 16,
+          max: 24,
+        );
+        final double countdownFontSize = scaledFontSize(
+          base: 96,
+          scale: scale,
+          textScaler: textScaler,
+          min: 72,
+          max: 132,
+        );
         return Scaffold(
           backgroundColor: Colors.transparent,
           appBar:
@@ -59,9 +77,12 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
               ListView(
                 padding: const EdgeInsets.all(16),
                 children: [
-                  const Text(
+                  Text(
                     'Simulation du concours ENA (pré‑sélection)',
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: introTitleSize,
+                    ),
                   ),
                   const SizedBox(height: 8),
                   const Text(
@@ -143,9 +164,10 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
                       child: Text(
                         '$_count',
                         style: TextStyle(
-                            fontSize: 96,
-                            color: overlayTextColor,
-                            fontWeight: FontWeight.bold),
+                          fontSize: countdownFontSize,
+                          color: overlayTextColor,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                     ),
                   ),

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -11,6 +11,7 @@ import '../utils/palette_utils.dart';
 import '../widgets/glass_card.dart';
 import '../widgets/glass_tile.dart';
 import '../widgets/adaptive_text.dart';
+import '../utils/responsive_utils.dart';
 
 import 'official_intro_screen.dart';
 import 'subject_list_screen.dart';
@@ -50,6 +51,17 @@ class _PlayScreenState extends State<PlayScreen> {
         final badgeColors = playIconColors(cfg.bgPaletteName);
         final bgColor =
             pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode).first;
+
+        final mediaQuery = MediaQuery.of(context);
+        final scale = computeScaleFactor(mediaQuery);
+        final textScaler = MediaQuery.textScalerOf(context);
+        final welcomeFontSize = scaledFontSize(
+          base: 16,
+          scale: scale,
+          textScaler: textScaler,
+          min: 14,
+          max: 22,
+        );
 
         return Scaffold(
           extendBody: true,
@@ -148,8 +160,8 @@ class _PlayScreenState extends State<PlayScreen> {
                                   maxLines: 1,
                                   overflow: TextOverflow.ellipsis,
                                   backgroundColor: bgColor,
-                                  style: const TextStyle(
-                                    fontSize: 16,
+                                  style: TextStyle(
+                                    fontSize: welcomeFontSize,
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
@@ -180,6 +192,7 @@ class _PlayScreenState extends State<PlayScreen> {
                           bgOpacity: cfg.glassBgOpacity,
                           borderOpacity: cfg.glassBorderOpacity,
                           iconSize: cfg.tileIconSize,
+                          scaleFactor: scale,
                           centerContent: cfg.tileCenter,
                           useMono: cfg.useMono,
                           monoColor: cfg.monoColor,
@@ -360,16 +373,24 @@ class _IconBadge extends StatelessWidget {
   final double size;
   final bool useMono;
   final Color monoColor;
-   final List<Color> gradientColors;
+  final List<Color> gradientColors;
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final scale = computeScaleFactor(mediaQuery);
+    final badgeSize = scaledDimension(
+      base: size,
+      scale: scale,
+      min: 40,
+      max: 96,
+    );
     final colors = useMono
         ? [monoColor.withOpacity(0.15), monoColor.withOpacity(0.35)]
         : gradientColors;
     final iconColor = useMono ? monoColor : Colors.white;
     return Container(
-      height: size,
-      width: size,
+      height: badgeSize,
+      width: badgeSize,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         gradient: LinearGradient(
@@ -378,7 +399,7 @@ class _IconBadge extends StatelessWidget {
           colors: colors,
         ),
       ),
-      child: Icon(icon, size: size * 0.58, color: iconColor),
+      child: Icon(icon, size: badgeSize * 0.58, color: iconColor),
     );
   }
 }

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -4,6 +4,7 @@ import '../models/design_config.dart';
 import '../services/design_bus.dart';
 import '../utils/palette_utils.dart';
 import '../widgets/glass_tile.dart';
+import '../utils/responsive_utils.dart';
 import 'chapter_list_screen.dart';
 
 /// Liste des matières ENA
@@ -21,6 +22,8 @@ class SubjectListScreen extends StatelessWidget {
       builder: (context, cfg, _) {
         final textColor =
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
+        final mediaQuery = MediaQuery.of(context);
+        final scale = computeScaleFactor(mediaQuery);
         return Scaffold(
           extendBody: true,
           extendBodyBehindAppBar: true,
@@ -53,6 +56,7 @@ class SubjectListScreen extends StatelessWidget {
                     bgOpacity: cfg.glassBgOpacity,
                     borderOpacity: cfg.glassBorderOpacity,
                     iconSize: cfg.tileIconSize,
+                    scaleFactor: scale,
                     centerContent: cfg.tileCenter,
                     useMono: cfg.useMono,
                     monoColor: cfg.monoColor,

--- a/lib/theme/competition_theme.dart
+++ b/lib/theme/competition_theme.dart
@@ -5,6 +5,8 @@
 /// be modified as needed.
 import 'package:flutter/material.dart';
 
+import '../utils/responsive_utils.dart';
+
 @immutable
 class CompetitionTheme {
   /// Background color of the whole screen.
@@ -121,6 +123,70 @@ class CompetitionTheme {
           ) ??
           const TextStyle(color: Colors.white, fontWeight: FontWeight.w600),
       selectedChipBackgroundColor: scheme.primary,
+    );
+  }
+
+  /// Returns a responsive copy of this theme using the provided scale factors.
+  CompetitionTheme scaled(double scale, TextScaler textScaler) {
+    TextStyle scaleText(
+      TextStyle style,
+      double fallback,
+      double min,
+      double max,
+    ) {
+      final baseSize = style.fontSize ?? fallback;
+      final fontSize = scaledFontSize(
+        base: baseSize,
+        scale: scale,
+        textScaler: textScaler,
+        min: min,
+        max: max,
+      );
+      return style.copyWith(fontSize: fontSize);
+    }
+
+    return copyWith(
+      questionCardRadius: scaledDimension(
+        base: questionCardRadius,
+        scale: scale,
+        min: 12,
+        max: 28,
+      ),
+      optionCardRadius: scaledDimension(
+        base: optionCardRadius,
+        scale: scale,
+        min: 16,
+        max: 32,
+      ),
+      timerSize: scaledDimension(
+        base: timerSize,
+        scale: scale,
+        min: 56,
+        max: 132,
+      ),
+      timerStrokeWidth: scaledDimension(
+        base: timerStrokeWidth,
+        scale: scale,
+        min: 4,
+        max: 9,
+      ),
+      timerContainerRadius: scaledDimension(
+        base: timerContainerRadius,
+        scale: scale,
+        min: 8,
+        max: 20,
+      ),
+      selectedChipRadius: scaledDimension(
+        base: selectedChipRadius,
+        scale: scale,
+        min: 18,
+        max: 32,
+      ),
+      timerTextStyle: scaleText(timerTextStyle, 24, 18, 36),
+      questionIndexTextStyle: scaleText(questionIndexTextStyle, 14, 12, 20),
+      questionTextStyle: scaleText(questionTextStyle, 20, 16, 28),
+      optionTextStyle: scaleText(optionTextStyle, 16, 14, 24),
+      selectedChipTextStyle: scaleText(selectedChipTextStyle, 16, 14, 24),
     );
   }
 

--- a/lib/utils/responsive_utils.dart
+++ b/lib/utils/responsive_utils.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/widgets.dart';
+
+/// Computes a UI scale factor based on the device's shortest side.
+///
+/// The layout was originally designed for phones around 390 px wide. We
+/// normalize the current shortest side against that baseline and clamp the
+/// result so very small or very large devices remain readable.
+double computeScaleFactor(
+  MediaQueryData mediaQuery, {
+  double baseWidth = 390,
+  double minScale = 0.85,
+  double maxScale = 1.25,
+}) {
+  final shortestSide = mediaQuery.size.shortestSide;
+  if (shortestSide <= 0) {
+    return 1.0;
+  }
+  final raw = shortestSide / baseWidth;
+  final clamped = raw.clamp(minScale, maxScale);
+  return clamped is double ? clamped : clamped.toDouble();
+}
+
+/// Clamps [value] between [min] and [max] and returns a double.
+double clampDouble(num value, double min, double max) {
+  final clamped = value.clamp(min, max);
+  return clamped is double ? clamped : clamped.toDouble();
+}
+
+/// Computes a responsive font size using the provided [scale] and [textScaler].
+///
+/// The [base] size corresponds to the design baseline. Optional [min] and
+/// [max] bounds keep the resulting value within a comfortable range.
+double scaledFontSize({
+  required double base,
+  required double scale,
+  required TextScaler textScaler,
+  double? min,
+  double? max,
+}) {
+  final scaled = textScaler.scale(base * scale);
+  if (min != null || max != null) {
+    return clampDouble(
+      scaled,
+      min ?? scaled,
+      max ?? scaled,
+    );
+  }
+  return scaled;
+}
+
+/// Scales a non-text dimension (icons, radii, etc.) while keeping it bounded.
+double scaledDimension({
+  required double base,
+  required double scale,
+  double? min,
+  double? max,
+}) {
+  final value = base * scale;
+  if (min != null || max != null) {
+    return clampDouble(
+      value,
+      min ?? value,
+      max ?? value,
+    );
+  }
+  return value;
+}

--- a/lib/widgets/glass_tile.dart
+++ b/lib/widgets/glass_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'glass_card.dart';
+import '../utils/responsive_utils.dart';
 
 class GlassTile extends StatefulWidget {
   const GlassTile({
@@ -16,6 +17,7 @@ class GlassTile extends StatefulWidget {
     required this.useMono,
     required this.monoColor,
     required this.textColor,
+    this.scaleFactor,
   });
 
   final String title;
@@ -30,6 +32,7 @@ class GlassTile extends StatefulWidget {
   final bool useMono;
   final Color monoColor;
   final Color textColor;
+  final double? scaleFactor;
 
   @override
   State<GlassTile> createState() => _GlassTileState();
@@ -40,6 +43,16 @@ class _GlassTileState extends State<GlassTile> {
 
   @override
   Widget build(BuildContext context) {
+    final mediaQuery = MediaQuery.of(context);
+    final scale = widget.scaleFactor ?? computeScaleFactor(mediaQuery);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final iconSize = scaledDimension(
+      base: widget.iconSize,
+      scale: scale,
+      min: 40,
+      max: 96,
+    );
+
     final gradientColors = widget.useMono
         ? [
             widget.monoColor.withOpacity(0.15),
@@ -48,10 +61,17 @@ class _GlassTileState extends State<GlassTile> {
         : widget.gradientColors;
 
     final iconColor = widget.useMono ? widget.monoColor : Colors.white;
+    final titleFontSize = scaledFontSize(
+      base: 20,
+      scale: scale,
+      textScaler: textScaler,
+      min: 16,
+      max: 28,
+    );
 
     final iconBadge = Container(
-      height: widget.iconSize,
-      width: widget.iconSize,
+      height: iconSize,
+      width: iconSize,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         gradient: LinearGradient(
@@ -61,14 +81,14 @@ class _GlassTileState extends State<GlassTile> {
         ),
         border: Border.all(color: Colors.white.withOpacity(0.25)),
       ),
-      child: Icon(widget.icon, size: widget.iconSize * 0.58, color: iconColor),
+      child: Icon(widget.icon, size: iconSize * 0.58, color: iconColor),
     );
 
     final title = Text(
       widget.title,
       textAlign: widget.centerContent ? TextAlign.center : TextAlign.left,
       style: TextStyle(
-        fontSize: 20,
+        fontSize: titleFontSize,
         height: 1.15,
         fontWeight: FontWeight.w800,
         color: widget.textColor,


### PR DESCRIPTION
## Summary
- add responsive scaling helpers to compute device-aware icon and text sizes
- apply the scaling to PlayScreen tiles, subject list tiles, and shared GlassTile badges
- scale CompetitionTheme-driven UIs and other exam screens using MediaQuery text scalers

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9d8e1f1c832fbef36406452091e3