### PR TITLE
Adjust training screens typography and add tests

### DIFF
--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -193,6 +193,7 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
     return Scaffold(
       appBar: AppBar(title: Text('S’entraîner — ${widget.subjectName}')),
       body: _loading
@@ -202,7 +203,10 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Module : ${widget.chapterName}', style: const TextStyle(fontWeight: FontWeight.w700)),
+                  Text(
+                    'Module : ${widget.chapterName}',
+                    style: textTheme.titleLarge,
+                  ),
                   const SizedBox(height: 12),
                   Card(
                     child: Padding(
@@ -210,7 +214,7 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
-                          const Text('Temps par question', style: TextStyle(fontWeight: FontWeight.w600)),
+                          Text('Temps par question', style: textTheme.titleMedium),
                           const SizedBox(height: 8),
                           ChipSelector<int>(
                             options: _secondOptions,
@@ -221,7 +225,7 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
                             labelBuilder: (s) => '${s}s',
                           ),
                           const SizedBox(height: 16),
-                          const Text('Nombre de questions', style: TextStyle(fontWeight: FontWeight.w600)),
+                          Text('Nombre de questions', style: textTheme.titleMedium),
                           const SizedBox(height: 8),
                           ChipSelector<int>(
                             options: _countOptions,
@@ -231,7 +235,10 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
                             labelBuilder: (n) => '$n',
                           ),
                           const SizedBox(height: 12),
-                          Text('Questions dispo pour ce module : ${_pool.length}'),
+                          Text(
+                            'Questions dispo pour ce module : ${_pool.length}',
+                            style: textTheme.bodyLarge,
+                          ),
                         ],
                       ),
                     ),

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -206,6 +206,7 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
     final total = Duration(seconds: _perQuestionSeconds * _questionCount);
     String two(int x) => x.toString().padLeft(2, '0');
     final totalLabel = '${two(total.inMinutes)}:${two(total.inSeconds % 60)}';
+    final textTheme = Theme.of(context).textTheme;
 
     return Scaffold(
       appBar: AppBar(title: const Text('Entraînement (5–10s/question)')),
@@ -214,7 +215,7 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text('Temps par question', style: TextStyle(fontWeight: FontWeight.w700)),
+            Text('Temps par question', style: textTheme.titleMedium),
             const SizedBox(height: 8),
             ChipSelector<int>(
               options: _secondOptions,
@@ -225,7 +226,7 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
               labelBuilder: (s) => '${s}s',
             ),
             const SizedBox(height: 16),
-            const Text('Nombre de questions', style: TextStyle(fontWeight: FontWeight.w700)),
+            Text('Nombre de questions', style: textTheme.titleMedium),
             const SizedBox(height: 8),
             ChipSelector<int>(
               options: _countOptions,
@@ -235,7 +236,7 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
               labelBuilder: (n) => '$n',
             ),
             const SizedBox(height: 16),
-            Text('Temps total : $totalLabel', style: const TextStyle(fontWeight: FontWeight.w600)),
+            Text('Temps total : $totalLabel', style: textTheme.bodyLarge),
             const Spacer(),
             SizedBox(
               width: double.infinity,

--- a/test/chapter_list_screen_text_style_test.dart
+++ b/test/chapter_list_screen_text_style_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:civexam_pro/screens/chapter_list_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('ChapterListScreen uses themed hierarchy for settings and info', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: ChapterListScreen(subjectName: 'Test', chapterName: 'Module'),
+    ));
+
+    await tester.pump();
+    for (int i = 0; i < 10; i++) {
+      if (tester.any(find.text('Temps par question'))) {
+        break;
+      }
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    final BuildContext headingContext = tester.element(find.text('Temps par question'));
+    final textTheme = Theme.of(headingContext).textTheme;
+
+    final Text moduleHeading = tester.widget(find.text('Module : Module'));
+    expect(moduleHeading.style, textTheme.titleLarge);
+
+    final Text timeHeading = tester.widget(find.text('Temps par question'));
+    expect(timeHeading.style, textTheme.titleMedium);
+
+    final Text countHeading = tester.widget(find.text('Nombre de questions'));
+    expect(countHeading.style, textTheme.titleMedium);
+
+    final Text availability = tester.widget(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Text && widget.data != null && widget.data!.startsWith('Questions dispo pour ce module'),
+      ),
+    );
+    expect(availability.style, textTheme.bodyLarge);
+  });
+}

--- a/test/training_quick_start_text_style_test.dart
+++ b/test/training_quick_start_text_style_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:civexam_pro/screens/training_quick_start.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('TrainingQuickStartScreen uses themed hierarchy for settings and summary', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: TrainingQuickStartScreen(),
+    ));
+
+    await tester.pump();
+
+    final BuildContext headingContext = tester.element(find.text('Temps par question'));
+    final textTheme = Theme.of(headingContext).textTheme;
+
+    final Text timeHeading = tester.widget(find.text('Temps par question'));
+    expect(timeHeading.style, textTheme.titleMedium);
+
+    final Text countHeading = tester.widget(find.text('Nombre de questions'));
+    expect(countHeading.style, textTheme.titleMedium);
+
+    final Text summary = tester.widget(
+      find.byWidgetPredicate(
+        (widget) => widget is Text && widget.data != null && widget.data!.startsWith('Temps total'),
+      ),
+    );
+    expect(summary.style, textTheme.bodyLarge);
+  });
+}


### PR DESCRIPTION
## Summary
- align chapter list training settings with text theme hierarchy for headings and supporting text
- mirror the text theme usage on the quick start training screen
- add widget tests to ensure the themed typography is applied on both screens

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccafe75734832fb302d6fd0d1f2881