### PR TITLE
Add play background asset and apply image decoration

### DIFF
--- a/lib/widgets/design_background.dart
+++ b/lib/widgets/design_background.dart
@@ -28,6 +28,10 @@ class DesignBackground extends StatelessWidget {
                   )
                 : null,
             color: cfg.bgGradient ? null : baseColors.first,
+            image: const DecorationImage(
+              image: AssetImage('assets/images/play_background.png'),
+              fit: BoxFit.cover,
+            ),
           ),
           child: Stack(
             children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ flutter:
     - assets/questions/
     - assets/questions/ena_sample.json
     - assets/images/logo_splash.png
+    - assets/images/play_background.png
     - assets/icons/
     - assets/icons/mono/
     - assets/icons/sets/amber/


### PR DESCRIPTION
## Summary
- declare the play background image asset in pubspec so it can be bundled with the app
- update the design background widget to paint the new background image while retaining gradient and overlays

## Testing
- flutter pub get *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd660a0640832fb2eeb7f3d35801e3