### PR TITLE
Refine PlayScreen welcome header

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -8,9 +8,7 @@ import '../models/design_config.dart';
 import '../services/design_bus.dart';
 import '../services/auth_service.dart';
 import '../utils/palette_utils.dart';
-import '../widgets/glass_card.dart';
 import '../widgets/glass_tile.dart';
-import '../widgets/adaptive_text.dart';
 import '../utils/responsive_utils.dart';
 
 import 'official_intro_screen.dart';
@@ -48,9 +46,6 @@ class _PlayScreenState extends State<PlayScreen> {
             : 'Bienvenue 👋';
         final textColor =
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
-        final badgeColors = playIconColors(cfg.bgPaletteName);
-        final bgColor =
-            pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode).first;
 
         final mediaQuery = MediaQuery.of(context);
         final scale = computeScaleFactor(mediaQuery);
@@ -61,6 +56,12 @@ class _PlayScreenState extends State<PlayScreen> {
           textScaler: textScaler,
           min: 14,
           max: 22,
+        );
+        final logoHeight = scaledDimension(
+          base: 140,
+          scale: scale,
+          min: 110,
+          max: 190,
         );
 
         return Scaffold(
@@ -163,39 +164,29 @@ class _PlayScreenState extends State<PlayScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                      GlassCard(
-                        blur: cfg.glassBlur,
-                        backgroundOpacity: cfg.glassBgOpacity,
-                        borderOpacity: cfg.glassBorderOpacity,
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-                          child: Row(
-                            children: [
-                              _IconBadge(
-                                icon: Icons.grid_view_rounded,
-                                size: cfg.tileIconSize,
-                                useMono: cfg.useMono,
-                                monoColor: cfg.monoColor,
-                                gradientColors: badgeColors,
-                              ),
-                              const SizedBox(width: 12),
-                              Expanded(
-                                child: AdaptiveText(
-                                  welcomeText,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  backgroundColor: bgColor,
-                                  style: TextStyle(
-                                    fontSize: welcomeFontSize,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                              ),
-                            ],
+                  Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Image.asset(
+                          'assets/images/logo_splash.png',
+                          height: logoHeight,
+                          fit: BoxFit.contain,
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          welcomeText,
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: welcomeFontSize,
+                            fontWeight: FontWeight.w600,
+                            color: textColor,
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 18),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 18),
                   Expanded(
                     child: GridView.builder(
                       physics: const BouncingScrollPhysics(),
@@ -383,49 +374,6 @@ class _PlayScreenState extends State<PlayScreen> {
       ),
     );
     return proceed == true;
-  }
-}
-
-class _IconBadge extends StatelessWidget {
-  const _IconBadge({
-    required this.icon,
-    this.size = 52,
-    required this.useMono,
-    required this.monoColor,
-    required this.gradientColors,
-  });
-  final IconData icon;
-  final double size;
-  final bool useMono;
-  final Color monoColor;
-  final List<Color> gradientColors;
-  @override
-  Widget build(BuildContext context) {
-    final mediaQuery = MediaQuery.of(context);
-    final scale = computeScaleFactor(mediaQuery);
-    final badgeSize = scaledDimension(
-      base: size,
-      scale: scale,
-      min: 40,
-      max: 96,
-    );
-    final colors = useMono
-        ? [monoColor.withOpacity(0.15), monoColor.withOpacity(0.35)]
-        : gradientColors;
-    final iconColor = useMono ? monoColor : Colors.white;
-    return Container(
-      height: badgeSize,
-      width: badgeSize,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: colors,
-        ),
-      ),
-      child: Icon(icon, size: badgeSize * 0.58, color: iconColor),
-    );
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the GlassCard welcome banner and show the logo with centered greeting text on PlayScreen
- drop the unused _IconBadge helper and related imports

## Testing
- flutter test *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd780e3ac0832fb7482dc4dcb24acf