### PR TITLE
Update play screen app bar to show logo and welcome text

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -71,8 +71,28 @@ class _PlayScreenState extends State<PlayScreen> {
             backgroundColor: Colors.transparent,
             elevation: 0,
             foregroundColor: textColor,
-            title: const Text('CivExam'),
-            centerTitle: true,
+            title: Center(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Image.asset(
+                    'assets/images/logo_splash.png',
+                    height: 32,
+                    fit: BoxFit.contain,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    welcomeText,
+                    style: TextStyle(
+                      color: textColor,
+                      fontSize: welcomeFontSize,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
           ),
           bottomNavigationBar: Container(
             decoration: const BoxDecoration(


### PR DESCRIPTION
## Summary
- replace the play screen app bar title with a centered combination of the splash logo and welcome text
- apply the existing welcome text styling so the greeting uses the configured palette color

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd781e0f64832f862d86b18605806d