### PR TITLE
Adjust play screen layout spacing

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -178,12 +178,13 @@ class _PlayScreenState extends State<PlayScreen> {
             ),
           ),
           body: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  GlassCard(
+            bottom: false,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                  child: GlassCard(
                     blur: cfg.glassBlur,
                     backgroundOpacity: cfg.glassBgOpacity,
                     borderOpacity: cfg.glassBorderOpacity,
@@ -215,59 +216,58 @@ class _PlayScreenState extends State<PlayScreen> {
                       ),
                     ),
                   ),
-                  const SizedBox(height: 18),
-                  Expanded(
-                    child: Align(
-                      alignment: Alignment.bottomCenter,
-                      child: FractionallySizedBox(
-                        heightFactor: 0.75,
-                        widthFactor: 1,
-                        child: Container(
-                          margin: const EdgeInsets.only(bottom: 8),
-                          decoration: const BoxDecoration(
-                            color: Colors.white,
-                            borderRadius: BorderRadius.only(
-                              topLeft: Radius.circular(28),
-                              topRight: Radius.circular(28),
-                            ),
+                ),
+                const SizedBox(height: 18),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.bottomCenter,
+                    child: FractionallySizedBox(
+                      heightFactor: 0.75,
+                      widthFactor: 1,
+                      child: Container(
+                        decoration: const BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.only(
+                            topLeft: Radius.circular(22),
+                            topRight: Radius.circular(22),
                           ),
-                          padding: const EdgeInsets.fromLTRB(16, 20, 16, 12),
-                          child: GridView.builder(
-                            padding: EdgeInsets.zero,
-                            physics: const BouncingScrollPhysics(),
-                            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                              crossAxisCount: 2,
-                              crossAxisSpacing: 14,
-                              mainAxisSpacing: 14,
-                              childAspectRatio: 1.05,
-                            ),
-                            itemCount: _items.length,
-                            itemBuilder: (context, i) {
-                              final item = _items[i];
-                              final iconColors = playIconColors(item.palette);
-                              return GlassTile(
-                                title: item.title,
-                                icon: item.icon,
-                                gradientColors: iconColors,
-                                blur: cfg.glassBlur,
-                                bgOpacity: cfg.glassBgOpacity,
-                                borderOpacity: cfg.glassBorderOpacity,
-                                iconSize: cfg.tileIconSize,
-                                scaleFactor: scale,
-                                centerContent: cfg.tileCenter,
-                                useMono: cfg.useMono,
-                                monoColor: cfg.monoColor,
-                                textColor: textColor,
-                                onTap: () => _navigate(context, i),
-                              );
-                            },
+                        ),
+                        padding: const EdgeInsets.fromLTRB(16, 20, 16, 16),
+                        child: GridView.builder(
+                          padding: EdgeInsets.zero,
+                          physics: const BouncingScrollPhysics(),
+                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 2,
+                            crossAxisSpacing: 14,
+                            mainAxisSpacing: 14,
+                            childAspectRatio: 1.05,
                           ),
+                          itemCount: _items.length,
+                          itemBuilder: (context, i) {
+                            final item = _items[i];
+                            final iconColors = playIconColors(item.palette);
+                            return GlassTile(
+                              title: item.title,
+                              icon: item.icon,
+                              gradientColors: iconColors,
+                              blur: cfg.glassBlur,
+                              bgOpacity: cfg.glassBgOpacity,
+                              borderOpacity: cfg.glassBorderOpacity,
+                              iconSize: cfg.tileIconSize,
+                              scaleFactor: scale,
+                              centerContent: cfg.tileCenter,
+                              useMono: cfg.useMono,
+                              monoColor: cfg.monoColor,
+                              textColor: textColor,
+                              onTap: () => _navigate(context, i),
+                            );
+                          },
                         ),
                       ),
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- remove the outer padding around the play screen column so the tile area can use the full width
- keep padding around the welcome card while adjusting the tile container styling to reach the bottom navigation bar
- tweak the tile container border radius and padding to maintain spacing after removing the margin

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7cda570c832f8d0eeaacd70a3135