### PR TITLE
Increase welcome header sizes

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -56,11 +56,11 @@ class _PlayScreenState extends State<PlayScreen> {
         final scale = computeScaleFactor(mediaQuery);
         final textScaler = MediaQuery.textScalerOf(context);
         final welcomeFontSize = scaledFontSize(
-          base: 20,
+          base: 27,
           scale: scale,
           textScaler: textScaler,
-          min: 18,
-          max: 28,
+          min: 24,
+          max: 36,
         );
 
         return Scaffold(
@@ -79,7 +79,12 @@ class _PlayScreenState extends State<PlayScreen> {
                 children: [
                   Image.asset(
                     'assets/images/logo_splash.png',
-                    height: 56,
+                    height: scaledDimension(
+                      base: 72,
+                      scale: scale,
+                      min: 64,
+                      max: 96,
+                    ),
                     fit: BoxFit.contain,
                   ),
                   const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- enlarge the PlayScreen welcome text by raising the responsive font size bounds
- scale the header logo height responsively so it grows on larger displays

## Testing
- flutter analyze *(fails: `flutter` is not installed in the execution environment)*
- flutter test *(fails: `flutter` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9cf8d5a0832f996c717a50901f28