### PR TITLE
Adjust play screen logo height

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -63,10 +63,10 @@ class _PlayScreenState extends State<PlayScreen> {
           max: 28,
         );
         final logoHeight = scaledDimension(
-          base: 56,
+          base: 100,
           scale: scale,
-          min: 44,
-          max: 72,
+          min: 100,
+          max: 100,
         );
 
         return Scaffold(
@@ -164,6 +164,7 @@ class _PlayScreenState extends State<PlayScreen> {
           ),
           body: SafeArea(
             bottom: false,
+            minimum: const EdgeInsets.only(top: 16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [


### PR DESCRIPTION
## Summary
- lock the play screen logo image to a consistent 100 px height across devices
- add a small SafeArea top minimum to give the enlarged logo breathing room

## Testing
- `flutter test` *(fails: Flutter SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cda66ff4e8832fad57fd7a44f8437d