### PR TITLE
Center welcome header on play screen

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -170,7 +170,7 @@ class _PlayScreenState extends State<PlayScreen> {
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
                   child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       Image.asset(
                         'assets/images/logo_splash.png',
@@ -185,6 +185,7 @@ class _PlayScreenState extends State<PlayScreen> {
                           fontSize: welcomeFontSize,
                           fontWeight: FontWeight.w700,
                         ),
+                        textAlign: TextAlign.center,
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- center the logo and welcome message at the top of the play screen
- ensure the welcome text aligns centrally with the new layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cda66ad018832f8d9c0e0b5d5a5fe6