### PR TITLE
Increase play screen logo height

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -63,10 +63,10 @@ class _PlayScreenState extends State<PlayScreen> {
           max: 28,
         );
         final logoHeight = scaledDimension(
-          base: 100,
+          base: 200,
           scale: scale,
-          min: 100,
-          max: 100,
+          min: 200,
+          max: 200,
         );
 
         return Scaffold(


### PR DESCRIPTION
## Summary
- increase the play screen logo height scaling parameters to 200px so the splash logo renders larger while keeping the existing usage

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdab3260e4832fb80c66e2b0c83bbf