### PR TITLE
Remove play screen subtitle text

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -198,16 +198,6 @@ class _PlayScreenState extends State<PlayScreen> {
                             ),
                             textAlign: TextAlign.center,
                           ),
-                          const SizedBox(height: 8),
-                          Text(
-                            'Sélectionne un mode pour démarrer ta session.',
-                            style: TextStyle(
-                              color: textColor.withOpacity(0.8),
-                              fontSize: subtitleFontSize,
-                              fontWeight: FontWeight.w500,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
                         ],
                       ),
                     ),


### PR DESCRIPTION
## Summary
- remove the subtitle text "Sélectionne un mode pour démarrer ta session." from the Play screen header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdb17525f0832fbf7d20b801dda639