### PR TITLE
Reduce spacing under logo on play screen

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -188,7 +188,7 @@ class _PlayScreenState extends State<PlayScreen> {
                             height: logoHeight,
                             fit: BoxFit.contain,
                           ),
-                          const SizedBox(height: 16),
+                          const SizedBox(height: 8),
                           Text(
                             welcomeText,
                             style: TextStyle(


### PR DESCRIPTION
## Summary
- decrease the SizedBox spacing under the play screen logo so the welcome text sits closer

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cdb173f77c832fa76f09830ecc0742