### PR TITLE
Adjust welcome spacing on PlayScreen

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -236,7 +236,7 @@ class _PlayScreenState extends State<PlayScreen> {
                             height: logoHeight,
                             fit: BoxFit.contain,
                           ),
-                          const SizedBox(height: 16),
+                          const SizedBox(height: 8),
                           Text(
                             welcomeText,
                             style: TextStyle(


### PR DESCRIPTION
## Summary
- reduce the vertical spacing between the Play screen logo and welcome text so the header feels more compact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cea2b9f040832fb3c385be7dcc068b