### PR TITLE
Use background image on play screen

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -175,7 +175,17 @@ class _PlayScreenState extends State<PlayScreen> {
             child: Stack(
               fit: StackFit.expand,
               children: [
-                ColoredBox(color: bgColor),
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: bgColor,
+                    image: const DecorationImage(
+                      image: AssetImage(
+                        'assets/images/background_playscreen.png',
+                      ),
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
                 Align(
                   alignment: Alignment.topCenter,
                   child: Padding(


### PR DESCRIPTION
## Summary
- replace the colored background on the play screen with a decorated box that paints the play screen background image while keeping the foreground content unchanged

## Testing
- `flutter analyze` *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ceaf227fb8832f9adc51dc506b817f