### PR TITLE
Adjust play screen white box height

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -205,7 +205,7 @@ class _PlayScreenState extends State<PlayScreen> {
                 Align(
                   alignment: Alignment.bottomCenter,
                   child: FractionallySizedBox(
-                    heightFactor: 0.75,
+                    heightFactor: 0.7,
                     widthFactor: 1,
                     child: ClipRRect(
                       borderRadius: const BorderRadius.only(


### PR DESCRIPTION
## Summary
- lower the play screen white panel FractionallySizedBox height factor to 0.7 to keep the overlay balanced on more displays

## Testing
- not run (flutter tooling unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceaf26e9f4832f99a9cb417ac9a3f3