### PR TITLE
Adjust PlayScreen welcome spacing

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -198,7 +198,7 @@ class _PlayScreenState extends State<PlayScreen> {
                           height: logoHeight,
                           fit: BoxFit.contain,
                         ),
-                        const SizedBox(height: 16),
+                        const SizedBox(height: 8),
                         Text(
                           welcomeText,
                           style: TextStyle(


### PR DESCRIPTION
## Summary
- reduce the vertical gap between the PlayScreen logo and welcome text to match product expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceb3c84588832fa8b3f2773585ca30