### PR TITLE
Refine welcome header styling in play screen

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -43,12 +43,12 @@ class _PlayScreenState extends State<PlayScreen> {
       builder: (context, cfg, _) {
         final user = FirebaseAuth.instance.currentUser;
         final name = user?.displayName ?? user?.email;
-        final welcomeText = name != null && name.isNotEmpty
-            ? 'Bienvenue $name 👋'
-            : 'Bienvenue 👋';
+        final hasName = name != null && name.isNotEmpty;
         final textColor =
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
         final badgeColors = playIconColors(cfg.bgPaletteName);
+        final nameColor =
+            badgeColors.length > 1 ? badgeColors.last : badgeColors.first;
         final bgColor =
             pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode).first;
 
@@ -61,6 +61,13 @@ class _PlayScreenState extends State<PlayScreen> {
           textScaler: textScaler,
           min: 18,
           max: 28,
+        );
+        final nameFontSize = scaledFontSize(
+          base: 26,
+          scale: scale,
+          textScaler: textScaler,
+          min: 20,
+          max: 36,
         );
         final subtitleFontSize = scaledFontSize(
           base: 16,
@@ -200,7 +207,7 @@ class _PlayScreenState extends State<PlayScreen> {
                         ),
                         const SizedBox(height: 8),
                         Text(
-                          welcomeText,
+                          'Bienvenue 👋',
                           style: TextStyle(
                             color: textColor,
                             fontSize: welcomeFontSize,
@@ -208,6 +215,18 @@ class _PlayScreenState extends State<PlayScreen> {
                           ),
                           textAlign: TextAlign.center,
                         ),
+                        if (hasName) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            name!,
+                            style: TextStyle(
+                              color: nameColor,
+                              fontSize: nameFontSize,
+                              fontWeight: FontWeight.w800,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
                       ],
                     ),
                   ),


### PR DESCRIPTION
## Summary
- always show the greeting text and add an optional second line when a user name is available
- reuse the existing greeting style while giving the name a larger, palette-driven accent style

## Testing
- Not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ceb5f5d2e0832fb9fd239351a32ccc