### PR TITLE
Adjust welcome spacing on play screen

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -206,7 +206,7 @@ class _PlayScreenState extends State<PlayScreen> {
                           fit: BoxFit.contain,
                         ),
                         const SizedBox(
-                          height: 8,
+                          height: 5,
                         ), // Reduced spacing between logo and welcome text
                         Text(
                           'Bienvenue 👋',


### PR DESCRIPTION
## Summary
- reduce the spacer between the play screen logo and welcome text to the requested 5 pixels

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cebab691b8832f87e572e911434c0e