### PR TITLE
Add culture generale course screen

### DIFF
--- a/assets/courses/culture_generale_ci_afrique.json
+++ b/assets/courses/culture_generale_ci_afrique.json
@@ -1,0 +1,24 @@
+{
+  "sections": [
+    {
+      "title": "Côte d’Ivoire",
+      "description": "Panorama institutionnel, économique et social de la République de Côte d’Ivoire pour replacer les sujets des concours ENA dans leur contexte national.",
+      "highlights": [
+        "Institutions : Constitution de 2016, exécutif bicéphale (Président et Vice-Président), gouvernement dirigé par un Premier ministre et Parlement bicaméral (Assemblée nationale et Sénat).",
+        "Économie : première puissance d’Afrique de l’Ouest francophone avec un PIB porté par l’agriculture (cacao, anacarde), l’industrie agroalimentaire et les services, plans nationaux de développement successifs.",
+        "Société : population estimée à plus de 28 millions d’habitants, diversité culturelle et linguistique, défis en matière d’urbanisation, d’éducation, de cohésion nationale et de gouvernance locale.",
+        "Ressources recommandées : Portail du Gouvernement ivoirien, rapports de la Primature, documents de planification (PND) et statistiques de l’INS."
+      ]
+    },
+    {
+      "title": "Afrique",
+      "description": "Repères continentaux et organisations régionales à maîtriser pour relier l’actualité africaine aux thématiques de culture générale des concours.",
+      "highlights": [
+        "Organisations régionales : Union africaine (UA), CEDEAO, UEMOA, Banque africaine de développement et partenariats stratégiques panafricains.",
+        "Enjeux socio-économiques : croissance démographique, transitions énergétiques, industrialisation, sécurité alimentaire, intégration commerciale (ZLECAf).",
+        "Gouvernance et sécurité : dynamiques démocratiques contrastées, mécanismes de paix et sécurité de l’UA, opérations de maintien de la paix, coopération régionale contre le terrorisme.",
+        "Ressources recommandées : rapports de la Banque mondiale et de la BAD, Agenda 2063 de l’UA, bulletins de la CEDEAO, think tanks africains (WATHI, ISS)."
+      ]
+    }
+  ]
+}

--- a/lib/screens/courses/culture_generale_screen.dart
+++ b/lib/screens/courses/culture_generale_screen.dart
@@ -1,0 +1,201 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Modélise une section de culture générale (CI & Afrique).
+class CultureSection {
+  final String title;
+  final String description;
+  final List<String> highlights;
+
+  const CultureSection({
+    required this.title,
+    required this.description,
+    required this.highlights,
+  });
+
+  factory CultureSection.fromJson(Map<String, dynamic> json) {
+    final highlights = json['highlights'];
+    return CultureSection(
+      title: json['title'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      highlights: highlights is List
+          ? highlights.whereType<String>().toList()
+          : const <String>[],
+    );
+  }
+}
+
+/// Chargement des sections depuis l'asset local.
+class CultureGeneraleRepository {
+  const CultureGeneraleRepository();
+
+  static const String assetPath =
+      'assets/courses/culture_generale_ci_afrique.json';
+
+  Future<List<CultureSection>> loadSections() async {
+    final jsonStr = await rootBundle.loadString(assetPath);
+    final dynamic data = json.decode(jsonStr);
+    if (data is! Map<String, dynamic>) {
+      return const <CultureSection>[];
+    }
+    final dynamic sectionsJson = data['sections'];
+    if (sectionsJson is! List) {
+      return const <CultureSection>[];
+    }
+    return sectionsJson
+        .whereType<Map<String, dynamic>>()
+        .map(CultureSection.fromJson)
+        .where((section) => section.title.isNotEmpty)
+        .toList(growable: false);
+  }
+}
+
+/// Écran Culture générale (Côte d'Ivoire & Afrique).
+class CultureGeneraleScreen extends StatelessWidget {
+  const CultureGeneraleScreen({super.key, this.sectionsFuture});
+
+  final Future<List<CultureSection>>? sectionsFuture;
+
+  Future<List<CultureSection>> _resolveFuture() {
+    return sectionsFuture ?? const CultureGeneraleRepository().loadSections();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Culture générale'),
+      ),
+      body: FutureBuilder<List<CultureSection>>(
+        future: _resolveFuture(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Impossible de charger le contenu pour le moment.\n'
+                  'Réessayez plus tard.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ),
+            );
+          }
+          final sections = snapshot.data ?? const <CultureSection>[];
+          if (sections.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Aucune section disponible pour le moment.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ),
+            );
+          }
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final bool isWide = constraints.maxWidth >= 700;
+              final EdgeInsets padding = EdgeInsets.symmetric(
+                horizontal: isWide ? 32 : 16,
+                vertical: 16,
+              );
+              return ListView.builder(
+                padding: padding,
+                itemCount: sections.length,
+                itemBuilder: (context, index) {
+                  final section = sections[index];
+                  return Card(
+                    margin: EdgeInsets.only(
+                      bottom: index == sections.length - 1 ? 0 : 20,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    elevation: 3,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: isWide ? 28 : 20,
+                        vertical: isWide ? 28 : 20,
+                      ),
+                      child: _SectionContent(section: section),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SectionContent extends StatelessWidget {
+  const _SectionContent({required this.section});
+
+  final CultureSection section;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleStyle = theme.textTheme.headlineSmall?.copyWith(
+      fontWeight: FontWeight.bold,
+    );
+    final bodyStyle = theme.textTheme.bodyMedium;
+    final highlightStyle = theme.textTheme.bodyMedium?.copyWith(
+      height: 1.4,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(section.title, style: titleStyle),
+        const SizedBox(height: 12),
+        Text(section.description, style: bodyStyle),
+        if (section.highlights.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Text(
+            'Idées clés',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final item in section.highlights)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(top: 6),
+                    child: Icon(
+                      Icons.circle,
+                      size: 8,
+                      color: Color(0xFF1565C0),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      item,
+                      style: highlightStyle,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -19,6 +19,7 @@ import 'dashboard_screen.dart';
 import 'design_settings_screen.dart';
 import 'competition_screen.dart';
 import 'login_screen.dart';
+import 'courses/culture_generale_screen.dart';
 import '../services/question_loader.dart';
 import '../services/question_randomizer.dart';
 import '../services/question_history_store.dart';
@@ -923,7 +924,15 @@ class _PlayScreenState extends State<PlayScreen> {
         break;
 
     // ===== Cours ENA (CI)
-      case 7:  await _showComingSoon(context, 'Culture générale (CI & Afrique)'); break;
+      case 7:
+        if (!mounted) return;
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => const CultureGeneraleScreen(),
+          ),
+        );
+        break;
       case 16: await _showComingSoon(context, 'Communication administrative'); break;
       case 8:  await _showComingSoon(context, 'Droit public (Constitutionnel & Administratif)'); break;
       case 17: await _showComingSoon(context, 'TIC & Bureautique'); break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ flutter:
     - assets/images/C2.png
     - assets/images/C3.png
     - assets/images/C4.png
+    - assets/courses/culture_generale_ci_afrique.json
 
     - assets/icons/
     - assets/icons/mono/

--- a/test/culture_generale_screen_test.dart
+++ b/test/culture_generale_screen_test.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:civexam_pro/screens/courses/culture_generale_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('CultureGeneraleScreen affiche les sections CI et Afrique',
+      (WidgetTester tester) async {
+    const sections = [
+      CultureSection(
+        title: 'Côte d’Ivoire',
+        description: 'Repères nationaux.',
+        highlights: ['Institutions', 'Économie'],
+      ),
+      CultureSection(
+        title: 'Afrique',
+        description: 'Repères continentaux.',
+        highlights: ['Organisations régionales'],
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CultureGeneraleScreen(
+          sectionsFuture: Future<List<CultureSection>>.value(sections),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Côte d’Ivoire'), findsOneWidget);
+    expect(find.text('Afrique'), findsOneWidget);
+    expect(find.byType(Card), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add a Culture Générale screen that loads structured sections from a local asset and presents them in responsive cards
- introduce the CI & Afrique course data asset and register it in the Flutter assets list
- wire the Play screen navigation to the new screen and cover it with a widget test ensuring the key sections render

## Testing
- flutter test *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf75e0e284832f8960d73c570e905e