### PR TITLE
Add communication administrative course screen

### DIFF
--- a/assets/courses/communication_administrative.json
+++ b/assets/courses/communication_administrative.json
@@ -1,0 +1,34 @@
+{
+  "sections": [
+    {
+      "title": "Fondamentaux de la communication administrative",
+      "description": "Objectifs, valeurs et cadre juridique qui structurent la relation entre l'administration et les usagers.",
+      "highlights": [
+        "Respect des principes de légalité, d'égalité de traitement et de transparence dans tout échange.",
+        "Clarté et accessibilité : langage simple, structuration logique, suppression du jargon inutile.",
+        "Traçabilité : chaque message doit pouvoir être retrouvé, daté, signé et archivé conformément aux normes en vigueur.",
+        "Prise en compte de la diversité des publics (alphabétisation, langues, canaux digitaux ou physiques)."
+      ]
+    },
+    {
+      "title": "Communication écrite",
+      "description": "Méthodologie et formats types : note, compte rendu, courrier, rapport, email institutionnel.",
+      "highlights": [
+        "Structure en trois temps : contexte/objet, développement synthétique, conclusion opérationnelle.",
+        "Usage des modèles officiels : en-têtes normalisés, formules d'appel et de politesse adaptées au destinataire.",
+        "Relecture systématique (orthographe, chiffres, références réglementaires) avant diffusion.",
+        "Maîtrise des annexes : tableaux, indicateurs, fiches synthèses pour faciliter la décision de la hiérarchie."
+      ]
+    },
+    {
+      "title": "Communication orale et numérique",
+      "description": "Préparer une présentation, animer une réunion, gérer un accueil téléphonique ou digital.",
+      "highlights": [
+        "Avant la prise de parole : clarifier l'objectif, identifier les messages clés, anticiper questions et objections.",
+        "Pendant l'échange : posture professionnelle, écoute active, reformulation, respect du temps imparti.",
+        "Suivi : compte rendu rapide, plan d'actions et distribution des responsabilités auprès des participants.",
+        "Outils numériques : rédaction de publications institutionnelles, webinaires, messagerie instantanée sécurisée."
+      ]
+    }
+  ]
+}

--- a/lib/screens/courses/communication_administrative_screen.dart
+++ b/lib/screens/courses/communication_administrative_screen.dart
@@ -1,0 +1,208 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Modélise une section du cours de communication administrative.
+class CommunicationAdministrativeSection {
+  final String title;
+  final String description;
+  final List<String> highlights;
+
+  const CommunicationAdministrativeSection({
+    required this.title,
+    required this.description,
+    required this.highlights,
+  });
+
+  factory CommunicationAdministrativeSection.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final highlights = json['highlights'];
+    return CommunicationAdministrativeSection(
+      title: json['title'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      highlights: highlights is List
+          ? highlights.whereType<String>().toList()
+          : const <String>[],
+    );
+  }
+}
+
+/// Chargement des sections depuis l'asset local.
+class CommunicationAdministrativeRepository {
+  const CommunicationAdministrativeRepository();
+
+  static const String assetPath =
+      'assets/courses/communication_administrative.json';
+
+  Future<List<CommunicationAdministrativeSection>> loadSections() async {
+    final jsonStr = await rootBundle.loadString(assetPath);
+    final dynamic data = json.decode(jsonStr);
+    if (data is! Map<String, dynamic>) {
+      return const <CommunicationAdministrativeSection>[];
+    }
+    final dynamic sectionsJson = data['sections'];
+    if (sectionsJson is! List) {
+      return const <CommunicationAdministrativeSection>[];
+    }
+    return sectionsJson
+        .whereType<Map<String, dynamic>>()
+        .map(CommunicationAdministrativeSection.fromJson)
+        .where((section) => section.title.isNotEmpty)
+        .toList(growable: false);
+  }
+}
+
+/// Écran Communication administrative.
+class CommunicationAdministrativeScreen extends StatelessWidget {
+  const CommunicationAdministrativeScreen({
+    super.key,
+    this.sectionsFuture,
+  });
+
+  final Future<List<CommunicationAdministrativeSection>>? sectionsFuture;
+
+  Future<List<CommunicationAdministrativeSection>> _resolveFuture() {
+    return sectionsFuture ??
+        const CommunicationAdministrativeRepository().loadSections();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Communication administrative'),
+      ),
+      body: FutureBuilder<List<CommunicationAdministrativeSection>>(
+        future: _resolveFuture(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Impossible de charger le contenu pour le moment.\n'
+                  'Réessayez plus tard.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ),
+            );
+          }
+          final sections =
+              snapshot.data ?? const <CommunicationAdministrativeSection>[];
+          if (sections.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Aucune section disponible pour le moment.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ),
+            );
+          }
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final bool isWide = constraints.maxWidth >= 700;
+              final EdgeInsets padding = EdgeInsets.symmetric(
+                horizontal: isWide ? 32 : 16,
+                vertical: 16,
+              );
+              return ListView.builder(
+                padding: padding,
+                itemCount: sections.length,
+                itemBuilder: (context, index) {
+                  final section = sections[index];
+                  return Card(
+                    margin: EdgeInsets.only(
+                      bottom: index == sections.length - 1 ? 0 : 20,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    elevation: 3,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: isWide ? 28 : 20,
+                        vertical: isWide ? 28 : 20,
+                      ),
+                      child: _CommunicationSectionContent(section: section),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CommunicationSectionContent extends StatelessWidget {
+  const _CommunicationSectionContent({required this.section});
+
+  final CommunicationAdministrativeSection section;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleStyle = theme.textTheme.headlineSmall?.copyWith(
+      fontWeight: FontWeight.bold,
+    );
+    final bodyStyle = theme.textTheme.bodyMedium;
+    final highlightStyle = theme.textTheme.bodyMedium?.copyWith(
+      height: 1.4,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(section.title, style: titleStyle),
+        const SizedBox(height: 12),
+        Text(section.description, style: bodyStyle),
+        if (section.highlights.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Text(
+            'Points clés',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final item in section.highlights)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(top: 6),
+                    child: Icon(
+                      Icons.circle,
+                      size: 8,
+                      color: Color(0xFF1565C0),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      item,
+                      style: highlightStyle,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -19,6 +19,7 @@ import 'dashboard_screen.dart';
 import 'design_settings_screen.dart';
 import 'competition_screen.dart';
 import 'login_screen.dart';
+import 'courses/communication_administrative_screen.dart';
 import 'courses/culture_generale_screen.dart';
 import '../services/question_loader.dart';
 import '../services/question_randomizer.dart';
@@ -933,7 +934,15 @@ class _PlayScreenState extends State<PlayScreen> {
           ),
         );
         break;
-      case 16: await _showComingSoon(context, 'Communication administrative'); break;
+      case 16:
+        if (!mounted) return;
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => const CommunicationAdministrativeScreen(),
+          ),
+        );
+        break;
       case 8:  await _showComingSoon(context, 'Droit public (Constitutionnel & Administratif)'); break;
       case 17: await _showComingSoon(context, 'TIC & Bureautique'); break;
       case 9:  await _showComingSoon(context, 'Finances publiques (CI)'); break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ flutter:
     - assets/images/C3.png
     - assets/images/C4.png
     - assets/courses/culture_generale_ci_afrique.json
+    - assets/courses/communication_administrative.json
 
     - assets/icons/
     - assets/icons/mono/

--- a/test/communication_administrative_screen_test.dart
+++ b/test/communication_administrative_screen_test.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:civexam_pro/screens/courses/communication_administrative_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'CommunicationAdministrativeScreen affiche les sections fournies',
+    (WidgetTester tester) async {
+      const sections = [
+        CommunicationAdministrativeSection(
+          title: 'Principes',
+          description: 'Règles de base.',
+          highlights: ['Clarté', 'Traçabilité'],
+        ),
+        CommunicationAdministrativeSection(
+          title: 'Communication écrite',
+          description: 'Méthodologie.',
+          highlights: ['Structure', 'Relecture'],
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: CommunicationAdministrativeScreen(
+            sectionsFuture:
+                Future<List<CommunicationAdministrativeSection>>.value(
+              sections,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Principes'), findsOneWidget);
+      expect(find.text('Communication écrite'), findsOneWidget);
+      expect(find.byType(Card), findsNWidgets(2));
+    },
+  );
+
+  test(
+    'CommunicationAdministrativeRepository charge les sections depuis l\'asset',
+    () async {
+      final sections =
+          await const CommunicationAdministrativeRepository().loadSections();
+      expect(sections, isNotEmpty);
+      expect(sections.first.title, isNotEmpty);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- add the communication administrative course asset and repository-driven screen
- register the new asset and expose the screen from the play screen navigation
- cover the screen and repository with widget tests that exercise the loading flow

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf7b246964832fa340f2589e915e99