### PR TITLE
Add Droit public course screen

### DIFF
--- a/assets/courses/droit_public_constit_admin.json
+++ b/assets/courses/droit_public_constit_admin.json
@@ -1,0 +1,34 @@
+{
+  "sections": [
+    {
+      "title": "Principes constitutionnels",
+      "description": "Fondements de l'État de droit ivoirien : souveraineté, hiérarchie des normes et droits fondamentaux garantis par la Constitution.",
+      "highlights": [
+        "Définition du préambule, des valeurs de la République et de la forme de l'État.",
+        "Place de la Constitution dans la hiérarchie des normes : supériorité sur les lois et règlements.",
+        "Garantie des libertés publiques et des droits fondamentaux : droits civils, politiques, économiques et sociaux.",
+        "Procédures de révision constitutionnelle et limites matérielles (respect de la forme républicaine, intégrité du territoire)."
+      ]
+    },
+    {
+      "title": "Institutions de la République",
+      "description": "Organisation et fonctionnement des organes constitutionnels : exécutif, législatif, judiciaire et autorités indépendantes.",
+      "highlights": [
+        "Rôle du Président de la République, du Gouvernement et du Premier Ministre dans la conduite de la politique nationale.",
+        "Parlement bicaméral : Assemblée nationale et Sénat, compétences législatives et procédures d'adoption des lois.",
+        "Indépendance du pouvoir judiciaire : Conseil supérieur de la magistrature, cours et tribunaux.",
+        "Institutions de contrôle et de régulation (Cour des comptes, CEI, autorités administratives indépendantes)."
+      ]
+    },
+    {
+      "title": "Administration publique et contrôle",
+      "description": "Structures administratives centrales, déconcentrées et décentralisées ainsi que les mécanismes de contrôle administratif et juridictionnel.",
+      "highlights": [
+        "Organisation de l'administration centrale : ministères, services rattachés, autorités administratives.",
+        "Déconcentration et décentralisation : préfets, conseils régionaux, communaux et district autonome d'Abidjan.",
+        "Responsabilité de l'administration : faute de service, faute personnelle et régimes d'indemnisation.",
+        "Contrôles : tutelle administrative, inspections, Chambre des comptes, juge administratif et voies de recours des usagers."
+      ]
+    }
+  ]
+}

--- a/lib/screens/courses/droit_public_screen.dart
+++ b/lib/screens/courses/droit_public_screen.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Modélise une section du cours de droit public.
+class DroitPublicSection {
+  final String title;
+  final String description;
+  final List<String> highlights;
+
+  const DroitPublicSection({
+    required this.title,
+    required this.description,
+    required this.highlights,
+  });
+
+  factory DroitPublicSection.fromJson(Map<String, dynamic> json) {
+    final highlights = json['highlights'];
+    return DroitPublicSection(
+      title: json['title'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      highlights: highlights is List
+          ? highlights.whereType<String>().toList()
+          : const <String>[],
+    );
+  }
+}
+
+/// Chargement des sections depuis l'asset local.
+class DroitPublicRepository {
+  const DroitPublicRepository();
+
+  static const String assetPath =
+      'assets/courses/droit_public_constit_admin.json';
+
+  Future<List<DroitPublicSection>> loadSections() async {
+    final jsonStr = await rootBundle.loadString(assetPath);
+    final dynamic data = json.decode(jsonStr);
+    if (data is! Map<String, dynamic>) {
+      return const <DroitPublicSection>[];
+    }
+    final dynamic sectionsJson = data['sections'];
+    if (sectionsJson is! List) {
+      return const <DroitPublicSection>[];
+    }
+    return sectionsJson
+        .whereType<Map<String, dynamic>>()
+        .map(DroitPublicSection.fromJson)
+        .where((section) => section.title.isNotEmpty)
+        .toList(growable: false);
+  }
+}
+
+/// Écran Droit public (constitutionnel & administratif).
+class DroitPublicScreen extends StatelessWidget {
+  const DroitPublicScreen({
+    super.key,
+    this.sectionsFuture,
+  });
+
+  final Future<List<DroitPublicSection>>? sectionsFuture;
+
+  Future<List<DroitPublicSection>> _resolveFuture() {
+    return sectionsFuture ?? const DroitPublicRepository().loadSections();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Droit public (Constitutionnel & Administratif)'),
+      ),
+      body: FutureBuilder<List<DroitPublicSection>>(
+        future: _resolveFuture(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Impossible de charger le contenu pour le moment.\nRéessayez plus tard.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ),
+            );
+          }
+          final sections = snapshot.data ?? const <DroitPublicSection>[];
+          if (sections.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'Aucune section disponible pour le moment.',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ),
+            );
+          }
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final bool isWide = constraints.maxWidth >= 700;
+              final EdgeInsets padding = EdgeInsets.symmetric(
+                horizontal: isWide ? 32 : 16,
+                vertical: 16,
+              );
+              return ListView.builder(
+                padding: padding,
+                itemCount: sections.length,
+                itemBuilder: (context, index) {
+                  final section = sections[index];
+                  return Card(
+                    margin: EdgeInsets.only(
+                      bottom: index == sections.length - 1 ? 0 : 20,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    elevation: 3,
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: isWide ? 28 : 20,
+                        vertical: isWide ? 28 : 20,
+                      ),
+                      child: _DroitPublicSectionContent(section: section),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _DroitPublicSectionContent extends StatelessWidget {
+  const _DroitPublicSectionContent({required this.section});
+
+  final DroitPublicSection section;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleStyle = theme.textTheme.headlineSmall?.copyWith(
+      fontWeight: FontWeight.bold,
+    );
+    final bodyStyle = theme.textTheme.bodyMedium;
+    final highlightStyle = theme.textTheme.bodyMedium?.copyWith(
+      height: 1.4,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(section.title, style: titleStyle),
+        const SizedBox(height: 12),
+        Text(section.description, style: bodyStyle),
+        if (section.highlights.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Text(
+            'Points clés',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final item in section.highlights)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(top: 6),
+                    child: Icon(
+                      Icons.circle,
+                      size: 8,
+                      color: Color(0xFF1565C0),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      item,
+                      style: highlightStyle,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -21,6 +21,7 @@ import 'competition_screen.dart';
 import 'login_screen.dart';
 import 'courses/communication_administrative_screen.dart';
 import 'courses/culture_generale_screen.dart';
+import 'courses/droit_public_screen.dart';
 import '../services/question_loader.dart';
 import '../services/question_randomizer.dart';
 import '../services/question_history_store.dart';
@@ -943,7 +944,15 @@ class _PlayScreenState extends State<PlayScreen> {
           ),
         );
         break;
-      case 8:  await _showComingSoon(context, 'Droit public (Constitutionnel & Administratif)'); break;
+      case 8:
+        if (!mounted) return;
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => const DroitPublicScreen(),
+          ),
+        );
+        break;
       case 17: await _showComingSoon(context, 'TIC & Bureautique'); break;
       case 9:  await _showComingSoon(context, 'Finances publiques (CI)'); break;
       case 10: await _showComingSoon(context, 'Économie & gestion'); break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,6 +50,7 @@ flutter:
     - assets/images/C4.png
     - assets/courses/culture_generale_ci_afrique.json
     - assets/courses/communication_administrative.json
+    - assets/courses/droit_public_constit_admin.json
 
     - assets/icons/
     - assets/icons/mono/

--- a/test/droit_public_screen_test.dart
+++ b/test/droit_public_screen_test.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:civexam_pro/screens/courses/droit_public_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DroitPublicScreen affiche les sections Constitution et Administration',
+      (WidgetTester tester) async {
+    const sections = [
+      DroitPublicSection(
+        title: 'Constitution',
+        description: 'Principes fondamentaux.',
+        highlights: ['Hiérarchie des normes'],
+      ),
+      DroitPublicSection(
+        title: 'Administration',
+        description: 'Organisation des services.',
+        highlights: ['Contrôles administratifs'],
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DroitPublicScreen(
+          sectionsFuture: Future<List<DroitPublicSection>>.value(sections),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Constitution'), findsOneWidget);
+    expect(find.text('Administration'), findsOneWidget);
+    expect(find.byType(Card), findsNWidgets(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add a Droit public course asset covering constitutional and administrative law topics
- implement a DroitPublicScreen and repository to load and display the new course sections
- register the asset, wire the play screen navigation, and add a widget test for rendering

## Testing
- flutter test test/droit_public_screen_test.dart *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d00350f5b4832fadc21e2234233ef2