### PR TITLE
Refactor play screen categories into dedicated pages

### DIFF
--- a/lib/screens/categories/aide_themes_screen.dart
+++ b/lib/screens/categories/aide_themes_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import 'category_definitions.dart';
+import 'category_helpers.dart';
+import 'widgets/category_menu_list.dart';
+
+class AideThemesScreen extends StatelessWidget {
+  final CategoryDefinition definition;
+
+  const AideThemesScreen({
+    super.key,
+    required this.definition,
+  });
+
+  Future<void> _handleTap(BuildContext context, int itemIndex) {
+    switch (itemIndex) {
+      case 4:
+        return showComingSoonDialog(
+          context,
+          'Comment ça marche ?',
+          message: 'Fiches d’utilisation et tutoriels arrivent.',
+        );
+      default:
+        return showComingSoonDialog(context, 'Bientôt disponible');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(definition.title)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              definition.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: CategoryMenuList(
+              definition: definition,
+              onItemSelected: (index) => _handleTap(context, index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/categories/banque_sujets_screen.dart
+++ b/lib/screens/categories/banque_sujets_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import 'category_definitions.dart';
+import 'category_helpers.dart';
+import 'widgets/category_menu_list.dart';
+
+class BanqueSujetsScreen extends StatelessWidget {
+  final CategoryDefinition definition;
+
+  const BanqueSujetsScreen({
+    super.key,
+    required this.definition,
+  });
+
+  Future<void> _handleTap(BuildContext context, int itemIndex) {
+    switch (itemIndex) {
+      case 20:
+        return showComingSoonDialog(context, 'Banque de sujets ENA CI');
+      case 21:
+        return showComingSoonDialog(context, 'Corrigés détaillés');
+      case 22:
+        return showComingSoonDialog(context, 'Sujets par filière (A/B/C)');
+      default:
+        return showComingSoonDialog(context, 'Contenu à venir');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(definition.title)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              definition.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: CategoryMenuList(
+              definition: definition,
+              onItemSelected: (index) => _handleTap(context, index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/categories/category_definitions.dart
+++ b/lib/screens/categories/category_definitions.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+
+enum HomeCategory {
+  quickPrep,
+  courses,
+  bank,
+  resources,
+  history,
+  challenge,
+  help,
+}
+
+class CategoryMenuItem {
+  final String title;
+  final String palette;
+  final IconData? icon;
+  final String? asset;
+
+  const CategoryMenuItem.icon(this.title, this.icon, this.palette) : asset = null;
+  const CategoryMenuItem.asset(this.title, this.asset, this.palette) : icon = null;
+}
+
+class CategoryDefinition {
+  final HomeCategory category;
+  final String keyName;
+  final String title;
+  final String description;
+  final List<int> itemIndexes;
+  final IconData? icon;
+  final String? asset;
+
+  const CategoryDefinition({
+    required this.category,
+    required this.keyName,
+    required this.title,
+    required this.description,
+    required this.itemIndexes,
+    this.icon,
+    this.asset,
+  });
+}
+
+const List<CategoryMenuItem> kCategoryMenuItems = <CategoryMenuItem>[
+  CategoryMenuItem.asset(
+    'Simulation concours ENA',
+    'assets/images/tuiles/Simulation concours ENA.png',
+    'violetRose',
+  ),
+  CategoryMenuItem.asset(
+    'Entraînement par matière',
+    'assets/images/tuiles/Entraînement par matière.png',
+    'sereneBlue',
+  ),
+  CategoryMenuItem.asset(
+    'Historique examens',
+    'assets/images/tuiles/Historique examens.png',
+    'lightGreen',
+  ),
+  CategoryMenuItem.asset(
+    'Historique entraînement',
+    'assets/images/tuiles/Historique entraînement.png',
+    'softYellow',
+  ),
+  CategoryMenuItem.asset(
+    'Comment ça marche ?',
+    'assets/images/tuiles/Comment ça marche.png',
+    'powderPink',
+  ),
+  CategoryMenuItem.asset(
+    'Classement',
+    'assets/images/tuiles/Classement.png',
+    'royalViolet',
+  ),
+  CategoryMenuItem.asset(
+    'Compétition',
+    'assets/images/tuiles/Compétition.png',
+    'forestGreen',
+  ),
+  CategoryMenuItem.asset(
+    'Culture générale (CI & Afrique)',
+    'assets/images/tuiles/Culture générale (CI & Afrique).png',
+    'sereneBlue',
+  ),
+  CategoryMenuItem.asset(
+    'Droit public (Consti/Administratif)',
+    'assets/images/tuiles/Droit public Consti Administratif.png',
+    'royalViolet',
+  ),
+  CategoryMenuItem.asset(
+    'Finances publiques (CI)',
+    'assets/images/tuiles/Finances publiques (CI).png',
+    'lightGreen',
+  ),
+  CategoryMenuItem.asset(
+    'Économie & gestion',
+    'assets/images/tuiles/Économie & gestion.png',
+    'softYellow',
+  ),
+  CategoryMenuItem.asset(
+    'Relations internationales & UE',
+    'assets/images/tuiles/Relations internationales & UE.png',
+    'violetRose',
+  ),
+  CategoryMenuItem.asset(
+    'Institutions de la Côte d’Ivoire',
+    "assets/images/tuiles/Institutions de la Côte d'ivoire.png",
+    'sereneBlue',
+  ),
+  CategoryMenuItem.icon('Note de synthèse', Icons.description_rounded, 'powderPink'),
+  CategoryMenuItem.icon('Méthodo QRC / QCM', Icons.checklist_rtl_rounded, 'forestGreen'),
+  CategoryMenuItem.icon('Examens blancs ENA', Icons.timer_rounded, 'royalViolet'),
+  CategoryMenuItem.icon(
+    'Communication administrative',
+    Icons.record_voice_over_rounded,
+    'powderPink',
+  ),
+  CategoryMenuItem.icon('TIC & Bureautique', Icons.computer_rounded, 'sereneBlue'),
+  CategoryMenuItem.icon('Comptabilité publique', Icons.request_quote_rounded, 'lightGreen'),
+  CategoryMenuItem.icon('Anglais (option)', Icons.translate_rounded, 'softYellow'),
+  CategoryMenuItem.icon('Banque de sujets ENA CI', Icons.folder_special_rounded, 'royalViolet'),
+  CategoryMenuItem.icon('Corrigés détaillés', Icons.task_rounded, 'violetRose'),
+  CategoryMenuItem.icon('Sujets par filière (A/B/C)', Icons.view_module_rounded, 'forestGreen'),
+  CategoryMenuItem.icon('Constitution & textes clés', Icons.menu_book_outlined, 'sereneBlue'),
+  CategoryMenuItem.icon('Programme officiel (PDF)', Icons.picture_as_pdf_rounded, 'powderPink'),
+  CategoryMenuItem.icon('Calendrier des concours', Icons.calendar_month_rounded, 'softYellow'),
+  CategoryMenuItem.icon(
+    'Textes ENA / Arrêtés / Guides',
+    Icons.library_books_rounded,
+    'lightGreen',
+  ),
+];
+
+const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
+  CategoryDefinition(
+    category: HomeCategory.quickPrep,
+    keyName: 'quick',
+    title: 'Prépa rapide',
+    description: 'Simulations, examens blancs et révisions ciblées.',
+    itemIndexes: [0, 15, 1],
+    asset: 'assets/images/tuiles/Simulation concours ENA.png',
+  ),
+  CategoryDefinition(
+    category: HomeCategory.courses,
+    keyName: 'courses',
+    title: 'Cours ENA (Côte d’Ivoire)',
+    description: 'Toutes les matières et méthodologies pour réussir l’ENA.',
+    itemIndexes: [7, 16, 8, 17, 9, 10, 18, 11, 12, 13, 14, 19],
+    asset: 'assets/images/tuiles/Culture générale (CI & Afrique).png',
+  ),
+  CategoryDefinition(
+    category: HomeCategory.bank,
+    keyName: 'bank',
+    title: 'Sujets & corrigés',
+    description: 'Accédez aux banques d’annales et corrigés thématiques.',
+    itemIndexes: [20, 21, 22],
+    icon: Icons.folder_special_rounded,
+  ),
+  CategoryDefinition(
+    category: HomeCategory.resources,
+    keyName: 'resources',
+    title: 'Ressources officielles (CI)',
+    description: 'Textes, calendriers et documents de référence.',
+    itemIndexes: [23, 24, 25, 26],
+    icon: Icons.menu_book_outlined,
+  ),
+  CategoryDefinition(
+    category: HomeCategory.history,
+    keyName: 'history',
+    title: 'Historique & suivi',
+    description: 'Retrouvez vos examens et entraînements précédents.',
+    itemIndexes: [2, 3],
+    asset: 'assets/images/tuiles/Historique examens.png',
+  ),
+  CategoryDefinition(
+    category: HomeCategory.challenge,
+    keyName: 'challenge',
+    title: 'Défis & classement',
+    description: 'Classements et compétitions chronométrées.',
+    itemIndexes: [5, 6],
+    asset: 'assets/images/tuiles/Classement.png',
+  ),
+  CategoryDefinition(
+    category: HomeCategory.help,
+    keyName: 'help',
+    title: 'Aide & thèmes',
+    description: 'Guides d’utilisation et futures thématiques.',
+    itemIndexes: [4],
+    icon: Icons.help_outline_rounded,
+  ),
+];

--- a/lib/screens/categories/category_helpers.dart
+++ b/lib/screens/categories/category_helpers.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+Future<void> showComingSoonDialog(
+  BuildContext context,
+  String title, {
+  String? message,
+}) {
+  return showDialog<void>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text(title),
+      content: Text(message ?? 'Bientôt disponible.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('OK'),
+        ),
+      ],
+    ),
+  );
+}

--- a/lib/screens/categories/cours_ena_screen.dart
+++ b/lib/screens/categories/cours_ena_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../courses/communication_administrative_screen.dart';
+import '../courses/culture_generale_screen.dart';
+import '../courses/droit_public_screen.dart';
+import 'category_definitions.dart';
+import 'category_helpers.dart';
+import 'widgets/category_menu_list.dart';
+
+class CoursEnaScreen extends StatelessWidget {
+  final CategoryDefinition definition;
+
+  const CoursEnaScreen({
+    super.key,
+    required this.definition,
+  });
+
+  Future<void> _handleTap(BuildContext context, int itemIndex) async {
+    switch (itemIndex) {
+      case 7:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const CultureGeneraleScreen()),
+        );
+        break;
+      case 16:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => const CommunicationAdministrativeScreen(),
+          ),
+        );
+        break;
+      case 8:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const DroitPublicScreen()),
+        );
+        break;
+      case 17:
+        await showComingSoonDialog(context, 'TIC & Bureautique');
+        break;
+      case 9:
+        await showComingSoonDialog(context, 'Finances publiques (CI)');
+        break;
+      case 10:
+        await showComingSoonDialog(context, 'Économie & gestion');
+        break;
+      case 18:
+        await showComingSoonDialog(context, 'Comptabilité publique');
+        break;
+      case 11:
+        await showComingSoonDialog(context, 'Relations internationales & UE');
+        break;
+      case 12:
+        await showComingSoonDialog(context, 'Institutions de la Côte d’Ivoire');
+        break;
+      case 13:
+        await showComingSoonDialog(context, 'Note de synthèse');
+        break;
+      case 14:
+        await showComingSoonDialog(context, 'Méthodologie QRC / QCM');
+        break;
+      case 19:
+        await showComingSoonDialog(context, 'Anglais (option)');
+        break;
+      default:
+        await showComingSoonDialog(context, 'Module en préparation');
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(definition.title)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              definition.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: CategoryMenuList(
+              definition: definition,
+              onItemSelected: (index) => _handleTap(context, index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/categories/defis_classement_screen.dart
+++ b/lib/screens/categories/defis_classement_screen.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../models/question.dart';
+import '../../services/question_history_store.dart';
+import '../../services/question_loader.dart';
+import '../../services/question_randomizer.dart';
+import '../competition_screen.dart';
+import '../leaderboard_screen.dart';
+import 'category_definitions.dart';
+import 'category_helpers.dart';
+import 'widgets/category_menu_list.dart';
+
+class DefisClassementScreen extends StatefulWidget {
+  final CategoryDefinition definition;
+
+  const DefisClassementScreen({
+    super.key,
+    required this.definition,
+  });
+
+  @override
+  State<DefisClassementScreen> createState() => _DefisClassementScreenState();
+}
+
+class _DefisClassementScreenState extends State<DefisClassementScreen> {
+  Future<void> _handleTap(int itemIndex) async {
+    switch (itemIndex) {
+      case 5:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const LeaderboardScreen()),
+        );
+        break;
+      case 6:
+        await _startCompetition();
+        break;
+      default:
+        await showComingSoonDialog(context, 'Défi à venir');
+        break;
+    }
+  }
+
+  Future<void> _startCompetition() async {
+    bool progressShown = false;
+    try {
+      const int desiredCount = 60;
+      final all = await QuestionLoader.loadENA();
+      if (!mounted) return;
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(child: CircularProgressIndicator()),
+      );
+      progressShown = true;
+      final selected = await pickAndShuffle(
+        all,
+        desiredCount,
+        dedupeByQuestion: true,
+      );
+      if (progressShown && mounted) Navigator.pop(context);
+
+      final proceed = await _handleShortDraw(selected, desiredCount);
+      if (!proceed || !mounted) return;
+
+      final messenger = ScaffoldMessenger.of(context);
+      unawaited(
+        QuestionHistoryStore.addAll(selected.map((q) => q.id)).catchError(
+          (Object error, _) {
+            if (!mounted) return;
+            messenger.showSnackBar(
+              const SnackBar(
+                content: Text(
+                    'Échec de l’enregistrement de l’historique des questions.'),
+              ),
+            );
+          },
+        ),
+      );
+
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => CompetitionScreen(
+            questions: selected,
+            timePerQuestion: 5,
+            startTime: DateTime.now(),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (progressShown && mounted) Navigator.pop(context);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Unable to load question bank: $e')),
+      );
+    }
+  }
+
+  Future<bool> _handleShortDraw(List<Question> selected, int requested) async {
+    if (selected.length >= requested) return true;
+    if (!mounted) return false;
+
+    if (selected.isEmpty) {
+      await showDialog<void>(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('Historique épuisé'),
+          content: const Text(
+              'Toutes les questions ont déjà été vues. Réinitialiser l\'historique pour recommencer.'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(_, null),
+              child: const Text('Fermer'),
+            ),
+            TextButton(
+              onPressed: () {
+                QuestionHistoryStore.clear();
+                Navigator.pop(_, null);
+              },
+              child: const Text('Réinitialiser'),
+            ),
+          ],
+        ),
+      );
+      return false;
+    }
+
+    final proceed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Commencer ?'),
+        content: Text('Vous avez déjà vu la plupart des questions — '
+            '${selected.length}/$requested disponibles.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(_, false),
+            child: const Text('Annuler'),
+          ),
+          TextButton(
+            onPressed: () {
+              QuestionHistoryStore.clear();
+              Navigator.pop(_, false);
+            },
+            child: const Text('Réinitialiser'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(_, true),
+            child: const Text('Continuer'),
+          ),
+        ],
+      ),
+    );
+    return proceed == true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final definition = widget.definition;
+    return Scaffold(
+      appBar: AppBar(title: Text(definition.title)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              definition.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: CategoryMenuList(
+              definition: definition,
+              onItemSelected: _handleTap,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/categories/historique_suivi_screen.dart
+++ b/lib/screens/categories/historique_suivi_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../exam_history_screen.dart';
+import '../training_history_screen.dart';
+import 'category_definitions.dart';
+import 'widgets/category_menu_list.dart';
+
+class HistoriqueSuiviScreen extends StatelessWidget {
+  final CategoryDefinition definition;
+
+  const HistoriqueSuiviScreen({
+    super.key,
+    required this.definition,
+  });
+
+  Future<void> _handleTap(BuildContext context, int itemIndex) async {
+    switch (itemIndex) {
+      case 2:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const ExamHistoryScreen()),
+        );
+        break;
+      case 3:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const TrainingHistoryScreen()),
+        );
+        break;
+      default:
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(definition.title)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              definition.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: CategoryMenuList(
+              definition: definition,
+              onItemSelected: (index) => _handleTap(context, index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/categories/prepa_ena_screen.dart
+++ b/lib/screens/categories/prepa_ena_screen.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../official_intro_screen.dart';
+import '../subject_list_screen.dart';
+import 'category_definitions.dart';
+import 'category_helpers.dart';
+import 'widgets/category_menu_list.dart';
+
+class PrepaEnaScreen extends StatelessWidget {
+  final CategoryDefinition definition;
+
+  const PrepaEnaScreen({
+    super.key,
+    required this.definition,
+  });
+
+  Future<void> _handleTap(BuildContext context, int itemIndex) async {
+    switch (itemIndex) {
+      case 0:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const OfficialIntroScreen()),
+        );
+        break;
+      case 1:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const SubjectListScreen()),
+        );
+        break;
+      case 15:
+        await showComingSoonDialog(
+          context,
+          'Examens blancs ENA',
+          message:
+              'Programmez des sessions complètes (durées, barèmes, corrigés).',
+        );
+        break;
+      default:
+        await showComingSoonDialog(context, 'Fonctionnalité à venir');
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(definition.title)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              definition.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: CategoryMenuList(
+              definition: definition,
+              onItemSelected: (index) => _handleTap(context, index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/categories/ressources_officielles_screen.dart
+++ b/lib/screens/categories/ressources_officielles_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import 'category_definitions.dart';
+import 'category_helpers.dart';
+import 'widgets/category_menu_list.dart';
+
+class RessourcesOfficiellesScreen extends StatelessWidget {
+  final CategoryDefinition definition;
+
+  const RessourcesOfficiellesScreen({
+    super.key,
+    required this.definition,
+  });
+
+  Future<void> _handleTap(BuildContext context, int itemIndex) {
+    switch (itemIndex) {
+      case 23:
+        return showComingSoonDialog(context, 'Constitution & textes clés');
+      case 24:
+        return showComingSoonDialog(context, 'Programme officiel (PDF)');
+      case 25:
+        return showComingSoonDialog(context, 'Calendrier des concours');
+      case 26:
+        return showComingSoonDialog(context, 'Textes ENA / Arrêtés / Guides');
+      default:
+        return showComingSoonDialog(context, 'Ressource en préparation');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(definition.title)),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Text(
+              definition.description,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ),
+          Expanded(
+            child: CategoryMenuList(
+              definition: definition,
+              onItemSelected: (index) => _handleTap(context, index),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/categories/widgets/category_menu_list.dart
+++ b/lib/screens/categories/widgets/category_menu_list.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+
+import '../../../utils/palette_utils.dart';
+import '../category_definitions.dart';
+
+class CategoryMenuList extends StatelessWidget {
+  final CategoryDefinition definition;
+  final ValueChanged<int> onItemSelected;
+
+  const CategoryMenuList({
+    super.key,
+    required this.definition,
+    required this.onItemSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final indexes = definition.itemIndexes;
+    return ListView.separated(
+      physics: const BouncingScrollPhysics(),
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      itemCount: indexes.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, position) {
+        final itemIndex = indexes[position];
+        final item = kCategoryMenuItems[itemIndex];
+        return _CategoryMenuCard(
+          item: item,
+          onTap: () => onItemSelected(itemIndex),
+        );
+      },
+    );
+  }
+}
+
+class _CategoryMenuCard extends StatelessWidget {
+  final CategoryMenuItem item;
+  final VoidCallback onTap;
+
+  const _CategoryMenuCard({
+    required this.item,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = playIconColors(item.palette);
+    final theme = Theme.of(context);
+    final Color accent = colors.isNotEmpty
+        ? colors.last
+        : theme.colorScheme.primary;
+    final Color background = colors.isNotEmpty
+        ? colors.first.withOpacity(0.15)
+        : theme.colorScheme.primary.withOpacity(0.08);
+    final textStyle = theme.textTheme.titleMedium?.copyWith(
+      fontWeight: FontWeight.w700,
+      color: theme.colorScheme.onSurface,
+    );
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: onTap,
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            color: background,
+            border: Border.all(color: accent.withOpacity(0.35), width: 1.2),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                _VisualIcon(item: item, accent: accent),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Text(
+                    item.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: textStyle,
+                  ),
+                ),
+                Icon(Icons.chevron_right_rounded, color: accent),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _VisualIcon extends StatelessWidget {
+  final CategoryMenuItem item;
+  final Color accent;
+
+  const _VisualIcon({
+    required this.item,
+    required this.accent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    const double size = 64;
+    if (item.asset != null) {
+      return ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: Image.asset(
+          item.asset!,
+          height: size,
+          width: size,
+          fit: BoxFit.cover,
+          filterQuality: FilterQuality.high,
+        ),
+      );
+    }
+
+    return Container(
+      height: size,
+      width: size,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: accent.withOpacity(0.15),
+      ),
+      alignment: Alignment.center,
+      child: Icon(item.icon, size: 32, color: accent),
+    );
+  }
+}

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -10,22 +10,18 @@ import '../services/auth_service.dart';
 import '../utils/palette_utils.dart';
 import '../utils/responsive_utils.dart';
 
-import 'official_intro_screen.dart';
-import 'subject_list_screen.dart';
-import 'training_history_screen.dart';
-import 'exam_history_screen.dart';
 import 'leaderboard_screen.dart';
 import 'dashboard_screen.dart';
 import 'design_settings_screen.dart';
-import 'competition_screen.dart';
 import 'login_screen.dart';
-import 'courses/communication_administrative_screen.dart';
-import 'courses/culture_generale_screen.dart';
-import 'courses/droit_public_screen.dart';
-import '../services/question_loader.dart';
-import '../services/question_randomizer.dart';
-import '../services/question_history_store.dart';
-import '../models/question.dart';
+import 'categories/category_definitions.dart';
+import 'categories/prepa_ena_screen.dart';
+import 'categories/cours_ena_screen.dart';
+import 'categories/banque_sujets_screen.dart';
+import 'categories/ressources_officielles_screen.dart';
+import 'categories/historique_suivi_screen.dart';
+import 'categories/defis_classement_screen.dart';
+import 'categories/aide_themes_screen.dart';
 
 /// ============================================================================
 /// === CONFIG UI (éditable facilement) ========================================
@@ -392,7 +388,7 @@ class _PlayScreenState extends State<PlayScreen> {
       precacheImage(AssetImage(p), context);
     }
     // Précharger les PNG des tuiles disponibles
-    for (final it in _items) {
+    for (final it in kCategoryMenuItems) {
       if (it.asset != null) {
         precacheImage(AssetImage(it.asset!), context);
       }
@@ -455,47 +451,7 @@ class _PlayScreenState extends State<PlayScreen> {
         );
 
         // ===== Orga des sections (ENA CI) =====
-        final sections = <_Section>[
-          _Section(
-              keyName: 'quick',
-              title: UI.quickPrepTitle,
-              itemIndexes: const [0, 15, 1]),
-          _Section(
-              keyName: 'courses',
-              title: UI.coursesTitle,
-              itemIndexes: const [
-                7,
-                16,
-                8,
-                17,
-                9,
-                10,
-                18,
-                11,
-                12,
-                13,
-                14,
-                19
-              ]),
-          _Section(
-              keyName: 'bank',
-              title: UI.bankTitle,
-              itemIndexes: const [20, 21, 22]),
-          _Section(
-              keyName: 'resources',
-              title: UI.resourcesTitle,
-              itemIndexes: const [23, 24, 25, 26]),
-          _Section(
-              keyName: 'history',
-              title: UI.historyTitle,
-              itemIndexes: const [2, 3]),
-          _Section(
-              keyName: 'challenge',
-              title: UI.challengeTitle,
-              itemIndexes: const [5, 6]),
-          _Section(
-              keyName: 'help', title: UI.helpTitle, itemIndexes: const [4]),
-        ];
+        final sections = kHomeCategories;
 
         return AnnotatedRegion<SystemUiOverlayStyle>(
           value: overlay,
@@ -531,10 +487,8 @@ class _PlayScreenState extends State<PlayScreen> {
                   nameFontSize: nameFontSize,
                 ),
                 _buildSections(
-                  cfg: cfg,
                   sections: sections,
                   scale: scale,
-                  textColor: textColor,
                   panelHeightFactor: UI.panelHeightFactor,
                 ),
               ],
@@ -698,10 +652,8 @@ class _PlayScreenState extends State<PlayScreen> {
 
   /// BOX BLANCHE + BACKGROUND_Playscreen2 + CONTENU SCROLLABLE
   Widget _buildSections({
-    required DesignConfig cfg,
-    required List<_Section> sections,
+    required List<CategoryDefinition> sections,
     required double scale,
-    required Color textColor,
     required double panelHeightFactor,
   }) {
     return Align(
@@ -798,137 +750,102 @@ class _PlayScreenState extends State<PlayScreen> {
                       // Sections
                       SliverList(
                         delegate: SliverChildBuilderDelegate(
-                              (context, index) {
-                            if (index.isOdd) return const SizedBox(height: 12);
-                            final si = index ~/ 2;
-                            final section = sections[si];
+                          (context, index) {
+                            final section = sections[index];
                             final style = UI.sectionStyles[section.keyName]!;
-
-                            final double itemWidth =
-                            (w * style.itemWidthFraction).clamp(80.0, w);
-                            final double itemHeight =
+                            final double cardHeight =
                                 style.itemHeight ?? baseCardHeight;
-
-                            final double viewportFraction =
-                            (itemWidth / w).clamp(0.1, 1.0);
-                            final controller = PageController(
-                                viewportFraction: viewportFraction);
+                            final Color accentColor =
+                                _pickTileMainColor(style);
+                            final Color iconColor =
+                                style.tileIconColor ?? Colors.white;
+                            final Color descriptionColor =
+                                style.tileTitleTextStyle?.color ??
+                                    Colors.white.withOpacity(0.85);
+                            final modulesCount = section.itemIndexes.length;
+                            final modulesLabel =
+                                '$modulesCount module${modulesCount > 1 ? 's' : ''}';
 
                             return Padding(
                               padding:
-                              const EdgeInsets.fromLTRB(16, 6, 16, 0),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(section.title,
-                                      style: style.sectionTitleStyle),
-                                  const SizedBox(height: 10),
-                                  SizedBox(
-                                    height: itemHeight,
-                                    child: PageView.builder(
-                                      controller: controller,
-                                      padEnds: false,
-                                      physics:
-                                      const BouncingScrollPhysics(),
-                                      itemCount: section.itemIndexes.length,
-                                      itemBuilder: (context, pi) {
-                                        final i = section.itemIndexes[pi];
-                                        final item = _items[i];
-                                        final trailing =
-                                        (pi ==
-                                            section.itemIndexes.length -
-                                                1)
-                                            ? 0.0
-                                            : style.tileSpacing;
-
-                                        final paletteColors =
-                                        playIconColors(item.palette);
-                                        final iconColor =
-                                            style.tileIconColor ??
-                                                (paletteColors.isNotEmpty
-                                                    ? paletteColors.last
-                                                    : Colors.white);
-
-                                        // --- Taille de la tuile vs légende (texte hors tuile)
-                                        const double captionHeight =
-                                        36.0; // zone texte
-                                        final double tileBodyHeight =
-                                        (itemHeight - captionHeight)
-                                            .clamp(110.0, itemHeight);
-
-                                        // --- Tuile avec icône/image seule
-                                        final iconOnlyTile = _TileCard(
-                                          borderColor: style.borderColor,
-                                          borderWidth: style.borderWidth,
-                                          borderRadius: style.borderRadius,
-                                          backgroundColor:
-                                          style.tileBackgroundColor,
-                                          gradient: style.tileGradient,
-                                          onTap: () => _navigate(context, i),
-                                          child: _IconOnlyTile(
-                                            icon: item.icon,
-                                            asset: item.asset,
-                                            iconSize: scale * 120,
-                                            iconColor: iconColor,
-                                          ),
-                                        );
-
-                                        // --- Légende (texte) sous la tuile : même couleur que la tuile
-                                        final Color captionColor =
-                                        _pickTileMainColor(style);
-
-                                        final captionStyle =
-                                        (style.tileTitleTextStyle ??
-                                            const TextStyle(
-                                              fontSize: 14,
-                                              fontWeight:
-                                              FontWeight.w800,
-                                            ))
-                                            .copyWith(
-                                          color: captionColor,
-                                        );
-
-                                        return Padding(
-                                          padding:
-                                          EdgeInsets.only(right: trailing),
-                                          child: SizedBox(
-                                            width: itemWidth,
-                                            height: itemHeight,
-                                            child: Column(
-                                              mainAxisAlignment:
-                                              MainAxisAlignment.start,
-                                              children: [
-                                                SizedBox(
-                                                  height: tileBodyHeight,
-                                                  child: iconOnlyTile,
+                                  const EdgeInsets.fromLTRB(16, 6, 16, 0),
+                              child: SizedBox(
+                                height: cardHeight,
+                                child: _TileCard(
+                                  borderColor: style.borderColor,
+                                  borderWidth: style.borderWidth,
+                                  borderRadius: style.borderRadius,
+                                  backgroundColor: style.tileBackgroundColor,
+                                  gradient: style.tileGradient,
+                                  onTap: () => _navigate(context, section.category),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(20.0),
+                                    child: Row(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.center,
+                                      children: [
+                                        Expanded(
+                                          child: Column(
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.center,
+                                            children: [
+                                              Text(
+                                                section.title,
+                                                style: style.sectionTitleStyle,
+                                              ),
+                                              const SizedBox(height: 8),
+                                              Text(
+                                                section.description,
+                                                style: TextStyle(
+                                                  color: descriptionColor,
+                                                  fontSize: 15 * scale,
+                                                  fontWeight: FontWeight.w500,
                                                 ),
-                                                const SizedBox(height: 6),
-                                                SizedBox(
-                                                  height: captionHeight - 6,
-                                                  child: Center(
-                                                    child: Text(
-                                                      item.title,
-                                                      textAlign:
-                                                      TextAlign.center,
-                                                      maxLines: 2,
-                                                      overflow: TextOverflow
-                                                          .ellipsis,
-                                                      style: captionStyle,
-                                                    ),
+                                                maxLines: 2,
+                                                overflow:
+                                                    TextOverflow.ellipsis,
+                                              ),
+                                              const SizedBox(height: 12),
+                                              Container(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                        horizontal: 12,
+                                                        vertical: 6),
+                                                decoration: BoxDecoration(
+                                                  color: accentColor
+                                                      .withOpacity(0.15),
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                          30),
+                                                ),
+                                                child: Text(
+                                                  modulesLabel,
+                                                  style: TextStyle(
+                                                    color: accentColor,
+                                                    fontWeight:
+                                                        FontWeight.w700,
                                                   ),
                                                 ),
-                                              ],
-                                            ),
+                                              ),
+                                            ],
                                           ),
-                                        );
-                                      },
+                                        ),
+                                        const SizedBox(width: 16),
+                                        _buildCategoryVisual(
+                                          section,
+                                          iconColor,
+                                          scale,
+                                        ),
+                                      ],
                                     ),
                                   ),
-                                ],
+                                ),
                               ),
                             );
                           },
-                          childCount: sections.length * 2 - 1,
+                          childCount: sections.length,
                         ),
                       ),
 
@@ -940,6 +857,36 @@ class _PlayScreenState extends State<PlayScreen> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildCategoryVisual(
+    CategoryDefinition section,
+    Color iconColor,
+    double scale,
+  ) {
+    final double size = (120 * scale).clamp(80.0, 140.0);
+    if (section.asset != null) {
+      return SizedBox(
+        height: size,
+        width: size,
+        child: Image.asset(
+          section.asset!,
+          fit: BoxFit.contain,
+          filterQuality: FilterQuality.high,
+        ),
+      );
+    }
+
+    return Container(
+      height: size,
+      width: size,
+      alignment: Alignment.center,
+      child: Icon(
+        section.icon ?? Icons.apps_rounded,
+        size: size * 0.7,
+        color: iconColor,
       ),
     );
   }
@@ -964,354 +911,71 @@ class _PlayScreenState extends State<PlayScreen> {
     return '$d/$m/$y  $time$suffix';
   }
 
-  /// Helper placeholder
-  Future<void> _showComingSoon(BuildContext context, String title,
-      [String? body]) {
-    return showDialog(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: Text(title),
-        content: Text(body ?? 'Bientôt disponible.'),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(_, null),
-              child: const Text('OK')),
-        ],
-      ),
-    );
-  }
-
   /// NAVIGATION
-  Future<void> _navigate(BuildContext context, int index) async {
-    switch (index) {
-    // ===== Prépa rapide & existants
-      case 0: // Simulation concours
-        Navigator.push(context,
-            MaterialPageRoute(builder: (_) => const OfficialIntroScreen()));
-        break;
-      case 1: // Entraînement par matière
-        Navigator.push(context,
-            MaterialPageRoute(builder: (_) => const SubjectListScreen()));
-        break;
-      case 2:
-        Navigator.push(context,
-            MaterialPageRoute(builder: (_) => const ExamHistoryScreen()));
-        break;
-      case 3:
-        Navigator.push(context,
-            MaterialPageRoute(builder: (_) => const TrainingHistoryScreen()));
-        break;
-      case 4:
-        await _showComingSoon(context, 'Comment ça marche ?',
-            'Fiches d’utilisation et tutoriels arrivent.');
-        break;
-      case 5:
-        Navigator.push(context,
-            MaterialPageRoute(builder: (_) => const LeaderboardScreen()));
-        break;
-      case 6:
-      // Compétition chronométrée (existant)
-        bool progressShown = false;
-        try {
-          const int desiredCount = 60;
-          final all = await QuestionLoader.loadENA();
-          if (!mounted) return;
-          showDialog(
-            context: context,
-            barrierDismissible: false,
-            builder: (_) => const Center(child: CircularProgressIndicator()),
-          );
-          progressShown = true;
-          final selected = await pickAndShuffle(
-            all,
-            desiredCount,
-            dedupeByQuestion: true,
-          );
-          if (progressShown && mounted) Navigator.pop(context);
+  Future<void> _navigate(BuildContext context, HomeCategory category) async {
+    final definition =
+        kHomeCategories.firstWhere((element) => element.category == category);
 
-          final proceed = await _handleShortDraw(selected, desiredCount);
-          if (!proceed) return;
-
-          if (!mounted) return;
-          final messenger = ScaffoldMessenger.of(context);
-          unawaited(
-            QuestionHistoryStore.addAll(selected.map((q) => q.id)).catchError(
-                  (Object error, _) {
-                if (!mounted) return;
-                messenger.showSnackBar(
-                  const SnackBar(
-                    content: Text(
-                        'Échec de l’enregistrement de l’historique des questions.'),
-                  ),
-                );
-              },
+    switch (category) {
+      case HomeCategory.quickPrep:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => PrepaEnaScreen(definition: definition),
+          ),
+        );
+        break;
+      case HomeCategory.courses:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => CoursEnaScreen(definition: definition),
+          ),
+        );
+        break;
+      case HomeCategory.bank:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => BanqueSujetsScreen(definition: definition),
+          ),
+        );
+        break;
+      case HomeCategory.resources:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => RessourcesOfficiellesScreen(
+              definition: definition,
             ),
-          );
-          Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => CompetitionScreen(
-                questions: selected,
-                timePerQuestion: 5,
-                startTime: DateTime.now(),
-              ),
-            ),
-          );
-        } catch (e) {
-          if (progressShown && mounted) Navigator.pop(context);
-          if (!mounted) return;
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Unable to load question bank: $e')),
-          );
-        }
-        break;
-      case 15: // Examens blancs (NOUVEAU)
-        await _showComingSoon(
-          context,
-          'Examens blancs ENA',
-          'Programmez des sessions complètes (durées, barèmes, corrigés).',
-        );
-        break;
-
-    // ===== Cours ENA (CI)
-      case 7:
-        if (!mounted) return;
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => const CultureGeneraleScreen(),
           ),
         );
         break;
-      case 16:
-        if (!mounted) return;
-        Navigator.push(
+      case HomeCategory.history:
+        await Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => const CommunicationAdministrativeScreen(),
+            builder: (_) => HistoriqueSuiviScreen(definition: definition),
           ),
         );
         break;
-      case 8:
-        if (!mounted) return;
-        Navigator.push(
+      case HomeCategory.challenge:
+        await Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => const DroitPublicScreen(),
+            builder: (_) => DefisClassementScreen(definition: definition),
           ),
         );
         break;
-      case 17:
-        await _showComingSoon(context, 'TIC & Bureautique');
-        break;
-      case 9:
-        await _showComingSoon(context, 'Finances publiques (CI)');
-        break;
-      case 10:
-        await _showComingSoon(context, 'Économie & gestion');
-        break;
-      case 18:
-        await _showComingSoon(context, 'Comptabilité publique');
-        break;
-      case 11:
-        await _showComingSoon(context, 'Relations internationales & UE');
-        break;
-      case 12:
-        await _showComingSoon(context, 'Institutions de la Côte d’Ivoire');
-        break;
-      case 13:
-        await _showComingSoon(context, 'Note de synthèse');
-        break;
-      case 14:
-        await _showComingSoon(context, 'Méthodologie QRC / QCM');
-        break;
-      case 19:
-        await _showComingSoon(context, 'Anglais (option)');
-        break;
-
-    // ===== Banque de sujets & corrigés
-      case 20:
-        await _showComingSoon(context, 'Banque de sujets ENA CI');
-        break;
-      case 21:
-        await _showComingSoon(context, 'Corrigés détaillés');
-        break;
-      case 22:
-        await _showComingSoon(context, 'Sujets par filière (A/B/C)');
-        break;
-
-    // ===== Ressources officielles
-      case 23:
-        await _showComingSoon(context, 'Constitution & textes clés');
-        break;
-      case 24:
-        await _showComingSoon(context, 'Programme officiel (PDF)');
-        break;
-      case 25:
-        await _showComingSoon(context, 'Calendrier des concours');
-        break;
-      case 26:
-        await _showComingSoon(context, 'Textes ENA / Arrêtés / Guides');
-        break;
-
-      default:
-      // sécurité
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Fonctionnalité à venir.')),
+      case HomeCategory.help:
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => AideThemesScreen(definition: definition),
+          ),
         );
         break;
     }
-  }
-
-  Future<bool> _handleShortDraw(List<Question> selected, int requested) async {
-    if (selected.length >= requested) return true;
-    if (!mounted) return false;
-
-    if (selected.isEmpty) {
-      await showDialog<void>(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Historique épuisé'),
-          content: const Text(
-              'Toutes les questions ont déjà été vues. Réinitialiser l\'historique pour recommencer.'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(_, null),
-              child: const Text('Fermer'),
-            ),
-            TextButton(
-              onPressed: () {
-                QuestionHistoryStore.clear();
-                Navigator.pop(_, null);
-              },
-              child: const Text('Réinitialiser'),
-            ),
-          ],
-        ),
-      );
-      return false;
-    }
-
-    final proceed = await showDialog<bool>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('Commencer ?'),
-        content: Text('Vous avez déjà vu la plupart des questions — '
-            '${selected.length}/$requested disponibles.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(_, false),
-            child: const Text('Annuler'),
-          ),
-          TextButton(
-            onPressed: () {
-              QuestionHistoryStore.clear();
-              Navigator.pop(_, false);
-            },
-            child: const Text('Réinitialiser'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(_, true),
-            child: const Text('Continuer'),
-          ),
-        ],
-      ),
-    );
-    return proceed == true;
-  }
-}
-
-/// ============================================================================
-/// === HELPERS / MODÈLES LOCAUX ===============================================
-/// ============================================================================
-
-class _Section {
-  final String keyName;
-  final String title;
-  final List<int> itemIndexes;
-  const _Section({
-    required this.keyName,
-    required this.title,
-    required this.itemIndexes,
-  });
-}
-
-class _BasicTile extends StatelessWidget {
-  final String title;
-  final IconData icon;
-  final double iconSize;
-  final Color iconColor;
-  final TextStyle titleStyle;
-
-  const _BasicTile({
-    super.key,
-    required this.title,
-    required this.icon,
-    required this.iconSize,
-    required this.iconColor,
-    required this.titleStyle,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(icon, size: iconSize, color: iconColor),
-            const SizedBox(height: 10),
-            Text(
-              title,
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: titleStyle,
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Nouveau : tuile icône OU image PNG
-class _IconOnlyTile extends StatelessWidget {
-  final IconData? icon;
-  final String? asset; // chemin PNG
-  final double iconSize;
-  final Color iconColor;
-
-  const _IconOnlyTile({
-    super.key,
-    required this.icon,
-    required this.asset,
-    required this.iconSize,
-    required this.iconColor,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    Widget child;
-    if (asset != null) {
-      child = Image.asset(
-        asset!,
-        height: iconSize,
-        width: iconSize,
-        fit: BoxFit.contain,
-        filterQuality: FilterQuality.high,
-      );
-    } else {
-      child = Icon(icon, size: iconSize, color: iconColor);
-    }
-
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: child,
-      ),
-    );
   }
 }
 
@@ -1448,69 +1112,3 @@ class _PromoCarousel extends StatelessWidget {
   }
 }
 
-/// ============================================================================
-/// === DONNÉES : tuiles affichées =============================================
-/// ============================================================================
-
-class _MenuItem {
-  final String title;
-  final String palette;
-  final IconData? icon; // fallback
-  final String? asset; // PNG dans assets/images/tuiles/
-
-  const _MenuItem.icon(this.title, this.icon, this.palette) : asset = null;
-  const _MenuItem.asset(this.title, this.asset, this.palette) : icon = null;
-}
-
-// Indices : 0..6 existants, 7..26 nouveaux
-const _items = <_MenuItem>[
-  // Base existante (branche les PNG disponibles)
-  _MenuItem.asset('Simulation concours ENA',
-      "assets/images/tuiles/Simulation concours ENA.png", 'violetRose'), // 0
-  _MenuItem.asset('Entraînement par matière',
-      "assets/images/tuiles/Entraînement par matière.png", 'sereneBlue'), // 1
-  _MenuItem.asset('Historique examens',
-      "assets/images/tuiles/Historique examens.png", 'lightGreen'), // 2
-  _MenuItem.asset('Historique entraînement',
-      "assets/images/tuiles/Historique entraînement.png", 'softYellow'), // 3
-  _MenuItem.asset('Comment ça marche ?',
-      "assets/images/tuiles/Comment ça marche.png", 'powderPink'), // 4
-  _MenuItem.asset('Classement',
-      "assets/images/tuiles/Classement.png", 'royalViolet'), // 5
-  _MenuItem.asset('Compétition',
-      "assets/images/tuiles/Compétition.png", 'forestGreen'), // 6
-
-  // Cours ENA (CI)
-  _MenuItem.asset('Culture générale (CI & Afrique)',
-      "assets/images/tuiles/Culture générale (CI & Afrique).png", 'sereneBlue'), // 7
-  _MenuItem.asset('Droit public (Consti/Administratif)',
-      "assets/images/tuiles/Droit public Consti Administratif.png", 'royalViolet'), // 8
-  _MenuItem.asset('Finances publiques (CI)',
-      "assets/images/tuiles/Finances publiques (CI).png", 'lightGreen'), // 9
-  _MenuItem.asset('Économie & gestion',
-      "assets/images/tuiles/Économie & gestion.png", 'softYellow'), // 10
-  _MenuItem.asset('Relations internationales & UE',
-      "assets/images/tuiles/Relations internationales & UE.png", 'violetRose'), // 11
-  _MenuItem.asset('Institutions de la Côte d’Ivoire',
-      "assets/images/tuiles/Institutions de la Côte d'ivoire.png", 'sereneBlue'), // 12
-
-  // Pas encore d’assets → fallback icônes
-  _MenuItem.icon('Note de synthèse', Icons.description_rounded, 'powderPink'), // 13
-  _MenuItem.icon('Méthodo QRC / QCM', Icons.checklist_rtl_rounded, 'forestGreen'), // 14
-  _MenuItem.icon('Examens blancs ENA', Icons.timer_rounded, 'royalViolet'), // 15
-  _MenuItem.icon('Communication administrative', Icons.record_voice_over_rounded, 'powderPink'), // 16
-  _MenuItem.icon('TIC & Bureautique', Icons.computer_rounded, 'sereneBlue'), // 17
-  _MenuItem.icon('Comptabilité publique', Icons.request_quote_rounded, 'lightGreen'), // 18
-  _MenuItem.icon('Anglais (option)', Icons.translate_rounded, 'softYellow'), // 19
-
-  // Banque de sujets & corrigés
-  _MenuItem.icon('Banque de sujets ENA CI', Icons.folder_special_rounded, 'royalViolet'), // 20
-  _MenuItem.icon('Corrigés détaillés', Icons.task_rounded, 'violetRose'), // 21
-  _MenuItem.icon('Sujets par filière (A/B/C)', Icons.view_module_rounded, 'forestGreen'), // 22
-
-  // Ressources officielles (CI)
-  _MenuItem.icon('Constitution & textes clés', Icons.menu_book_outlined, 'sereneBlue'), // 23
-  _MenuItem.icon('Programme officiel (PDF)', Icons.picture_as_pdf_rounded, 'powderPink'), // 24
-  _MenuItem.icon('Calendrier des concours', Icons.calendar_month_rounded, 'softYellow'), // 25
-  _MenuItem.icon('Textes ENA / Arrêtés / Guides', Icons.library_books_rounded, 'lightGreen'), // 26
-];


### PR DESCRIPTION
## Summary
- replace the play screen carousel sections with large category cards wired to dedicated category routes
- add shared category definitions and menu widgets used by new category detail pages
- implement category screens for quick prep, courses, history, resources, challenges, and more, moving detailed navigation there

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7dde2f2d0832fbe5dcd6fecde44c5