### PR TITLE
Refactor home categories to use icon-based tiles

### DIFF
--- a/lib/screens/categories/category_definitions.dart
+++ b/lib/screens/categories/category_definitions.dart
@@ -12,12 +12,14 @@ enum HomeCategory {
 
 class CategoryMenuItem {
   final String title;
-  final String palette;
-  final IconData? icon;
-  final String? asset;
+  final IconData icon;
+  final Color accentColor;
 
-  const CategoryMenuItem.icon(this.title, this.icon, this.palette) : asset = null;
-  const CategoryMenuItem.asset(this.title, this.asset, this.palette) : icon = null;
+  const CategoryMenuItem({
+    required this.title,
+    required this.icon,
+    required this.accentColor,
+  });
 }
 
 class CategoryDefinition {
@@ -26,8 +28,8 @@ class CategoryDefinition {
   final String title;
   final String description;
   final List<int> itemIndexes;
-  final IconData? icon;
-  final String? asset;
+  final IconData icon;
+  final Color accentColor;
 
   const CategoryDefinition({
     required this.category,
@@ -35,98 +37,156 @@ class CategoryDefinition {
     required this.title,
     required this.description,
     required this.itemIndexes,
-    this.icon,
-    this.asset,
+    required this.icon,
+    required this.accentColor,
   });
 }
 
+const Color _violetAccent = Color(0xFF7C4DFF);
+const Color _deepVioletAccent = Color(0xFF5B2E91);
+const Color _blueAccent = Color(0xFF1A73E8);
+const Color _tealAccent = Color(0xFF00897B);
+const Color _emeraldAccent = Color(0xFF2E7D32);
+const Color _amberAccent = Color(0xFFFFB300);
+const Color _orangeAccent = Color(0xFFFF7043);
+const Color _pinkAccent = Color(0xFFEC407A);
+const Color _aquaAccent = Color(0xFF00ACC1);
+
 const List<CategoryMenuItem> kCategoryMenuItems = <CategoryMenuItem>[
-  CategoryMenuItem.asset(
-    'Simulation concours ENA',
-    'assets/images/tuiles/Simulation concours ENA.png',
-    'violetRose',
+  CategoryMenuItem(
+    title: 'Simulation concours ENA',
+    icon: Icons.auto_awesome_rounded,
+    accentColor: _violetAccent,
   ),
-  CategoryMenuItem.asset(
-    'Entraînement par matière',
-    'assets/images/tuiles/Entraînement par matière.png',
-    'sereneBlue',
+  CategoryMenuItem(
+    title: 'Entraînement par matière',
+    icon: Icons.menu_book_rounded,
+    accentColor: _blueAccent,
   ),
-  CategoryMenuItem.asset(
-    'Historique examens',
-    'assets/images/tuiles/Historique examens.png',
-    'lightGreen',
+  CategoryMenuItem(
+    title: 'Historique examens',
+    icon: Icons.history_edu_rounded,
+    accentColor: _emeraldAccent,
   ),
-  CategoryMenuItem.asset(
-    'Historique entraînement',
-    'assets/images/tuiles/Historique entraînement.png',
-    'softYellow',
+  CategoryMenuItem(
+    title: 'Historique entraînement',
+    icon: Icons.timeline_rounded,
+    accentColor: _amberAccent,
   ),
-  CategoryMenuItem.asset(
-    'Comment ça marche ?',
-    'assets/images/tuiles/Comment ça marche.png',
-    'powderPink',
+  CategoryMenuItem(
+    title: 'Comment ça marche ?',
+    icon: Icons.live_help_rounded,
+    accentColor: _pinkAccent,
   ),
-  CategoryMenuItem.asset(
-    'Classement',
-    'assets/images/tuiles/Classement.png',
-    'royalViolet',
+  CategoryMenuItem(
+    title: 'Classement',
+    icon: Icons.emoji_events_rounded,
+    accentColor: _amberAccent,
   ),
-  CategoryMenuItem.asset(
-    'Compétition',
-    'assets/images/tuiles/Compétition.png',
-    'forestGreen',
+  CategoryMenuItem(
+    title: 'Compétition',
+    icon: Icons.whatshot_rounded,
+    accentColor: _orangeAccent,
   ),
-  CategoryMenuItem.asset(
-    'Culture générale (CI & Afrique)',
-    'assets/images/tuiles/Culture générale (CI & Afrique).png',
-    'sereneBlue',
+  CategoryMenuItem(
+    title: 'Culture générale (CI & Afrique)',
+    icon: Icons.public_rounded,
+    accentColor: _blueAccent,
   ),
-  CategoryMenuItem.asset(
-    'Droit public (Consti/Administratif)',
-    'assets/images/tuiles/Droit public Consti Administratif.png',
-    'royalViolet',
+  CategoryMenuItem(
+    title: 'Droit public (Consti/Administratif)',
+    icon: Icons.gavel_rounded,
+    accentColor: _deepVioletAccent,
   ),
-  CategoryMenuItem.asset(
-    'Finances publiques (CI)',
-    'assets/images/tuiles/Finances publiques (CI).png',
-    'lightGreen',
+  CategoryMenuItem(
+    title: 'Finances publiques (CI)',
+    icon: Icons.account_balance_rounded,
+    accentColor: _emeraldAccent,
   ),
-  CategoryMenuItem.asset(
-    'Économie & gestion',
-    'assets/images/tuiles/Économie & gestion.png',
-    'softYellow',
+  CategoryMenuItem(
+    title: 'Économie & gestion',
+    icon: Icons.show_chart_rounded,
+    accentColor: _orangeAccent,
   ),
-  CategoryMenuItem.asset(
-    'Relations internationales & UE',
-    'assets/images/tuiles/Relations internationales & UE.png',
-    'violetRose',
+  CategoryMenuItem(
+    title: 'Relations internationales & UE',
+    icon: Icons.language_rounded,
+    accentColor: _aquaAccent,
   ),
-  CategoryMenuItem.asset(
-    'Institutions de la Côte d’Ivoire',
-    "assets/images/tuiles/Institutions de la Côte d'ivoire.png",
-    'sereneBlue',
+  CategoryMenuItem(
+    title: 'Institutions de la Côte d’Ivoire',
+    icon: Icons.flag_rounded,
+    accentColor: _emeraldAccent,
   ),
-  CategoryMenuItem.icon('Note de synthèse', Icons.description_rounded, 'powderPink'),
-  CategoryMenuItem.icon('Méthodo QRC / QCM', Icons.checklist_rtl_rounded, 'forestGreen'),
-  CategoryMenuItem.icon('Examens blancs ENA', Icons.timer_rounded, 'royalViolet'),
-  CategoryMenuItem.icon(
-    'Communication administrative',
-    Icons.record_voice_over_rounded,
-    'powderPink',
+  CategoryMenuItem(
+    title: 'Note de synthèse',
+    icon: Icons.description_rounded,
+    accentColor: _pinkAccent,
   ),
-  CategoryMenuItem.icon('TIC & Bureautique', Icons.computer_rounded, 'sereneBlue'),
-  CategoryMenuItem.icon('Comptabilité publique', Icons.request_quote_rounded, 'lightGreen'),
-  CategoryMenuItem.icon('Anglais (option)', Icons.translate_rounded, 'softYellow'),
-  CategoryMenuItem.icon('Banque de sujets ENA CI', Icons.folder_special_rounded, 'royalViolet'),
-  CategoryMenuItem.icon('Corrigés détaillés', Icons.task_rounded, 'violetRose'),
-  CategoryMenuItem.icon('Sujets par filière (A/B/C)', Icons.view_module_rounded, 'forestGreen'),
-  CategoryMenuItem.icon('Constitution & textes clés', Icons.menu_book_outlined, 'sereneBlue'),
-  CategoryMenuItem.icon('Programme officiel (PDF)', Icons.picture_as_pdf_rounded, 'powderPink'),
-  CategoryMenuItem.icon('Calendrier des concours', Icons.calendar_month_rounded, 'softYellow'),
-  CategoryMenuItem.icon(
-    'Textes ENA / Arrêtés / Guides',
-    Icons.library_books_rounded,
-    'lightGreen',
+  CategoryMenuItem(
+    title: 'Méthodo QRC / QCM',
+    icon: Icons.fact_check_rounded,
+    accentColor: _emeraldAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Examens blancs ENA',
+    icon: Icons.timer_rounded,
+    accentColor: _deepVioletAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Communication administrative',
+    icon: Icons.record_voice_over_rounded,
+    accentColor: _pinkAccent,
+  ),
+  CategoryMenuItem(
+    title: 'TIC & Bureautique',
+    icon: Icons.computer_rounded,
+    accentColor: _blueAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Comptabilité publique',
+    icon: Icons.request_quote_rounded,
+    accentColor: _amberAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Anglais (option)',
+    icon: Icons.translate_rounded,
+    accentColor: _aquaAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Banque de sujets ENA CI',
+    icon: Icons.folder_special_rounded,
+    accentColor: _deepVioletAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Corrigés détaillés',
+    icon: Icons.task_rounded,
+    accentColor: _emeraldAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Sujets par filière (A/B/C)',
+    icon: Icons.view_module_rounded,
+    accentColor: _tealAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Constitution & textes clés',
+    icon: Icons.menu_book_outlined,
+    accentColor: _blueAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Programme officiel (PDF)',
+    icon: Icons.picture_as_pdf_rounded,
+    accentColor: _pinkAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Calendrier des concours',
+    icon: Icons.calendar_month_rounded,
+    accentColor: _orangeAccent,
+  ),
+  CategoryMenuItem(
+    title: 'Textes ENA / Arrêtés / Guides',
+    icon: Icons.library_books_rounded,
+    accentColor: _emeraldAccent,
   ),
 ];
 
@@ -137,7 +197,8 @@ const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
     title: 'Prépa rapide',
     description: 'Simulations, examens blancs et révisions ciblées.',
     itemIndexes: [0, 15, 1],
-    asset: 'assets/images/tuiles/Simulation concours ENA.png',
+    icon: Icons.auto_awesome_rounded,
+    accentColor: _violetAccent,
   ),
   CategoryDefinition(
     category: HomeCategory.courses,
@@ -145,7 +206,8 @@ const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
     title: 'Cours ENA (Côte d’Ivoire)',
     description: 'Toutes les matières et méthodologies pour réussir l’ENA.',
     itemIndexes: [7, 16, 8, 17, 9, 10, 18, 11, 12, 13, 14, 19],
-    asset: 'assets/images/tuiles/Culture générale (CI & Afrique).png',
+    icon: Icons.school_rounded,
+    accentColor: _blueAccent,
   ),
   CategoryDefinition(
     category: HomeCategory.bank,
@@ -154,6 +216,7 @@ const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
     description: 'Accédez aux banques d’annales et corrigés thématiques.',
     itemIndexes: [20, 21, 22],
     icon: Icons.folder_special_rounded,
+    accentColor: _deepVioletAccent,
   ),
   CategoryDefinition(
     category: HomeCategory.resources,
@@ -162,6 +225,7 @@ const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
     description: 'Textes, calendriers et documents de référence.',
     itemIndexes: [23, 24, 25, 26],
     icon: Icons.menu_book_outlined,
+    accentColor: _emeraldAccent,
   ),
   CategoryDefinition(
     category: HomeCategory.history,
@@ -169,7 +233,8 @@ const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
     title: 'Historique & suivi',
     description: 'Retrouvez vos examens et entraînements précédents.',
     itemIndexes: [2, 3],
-    asset: 'assets/images/tuiles/Historique examens.png',
+    icon: Icons.history_rounded,
+    accentColor: _amberAccent,
   ),
   CategoryDefinition(
     category: HomeCategory.challenge,
@@ -177,7 +242,8 @@ const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
     title: 'Défis & classement',
     description: 'Classements et compétitions chronométrées.',
     itemIndexes: [5, 6],
-    asset: 'assets/images/tuiles/Classement.png',
+    icon: Icons.emoji_events_rounded,
+    accentColor: _amberAccent,
   ),
   CategoryDefinition(
     category: HomeCategory.help,
@@ -186,5 +252,6 @@ const List<CategoryDefinition> kHomeCategories = <CategoryDefinition>[
     description: 'Guides d’utilisation et futures thématiques.',
     itemIndexes: [4],
     icon: Icons.help_outline_rounded,
+    accentColor: _pinkAccent,
   ),
 ];

--- a/lib/screens/categories/widgets/category_menu_list.dart
+++ b/lib/screens/categories/widgets/category_menu_list.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import '../../../utils/palette_utils.dart';
 import '../category_definitions.dart';
 
 class CategoryMenuList extends StatelessWidget {
@@ -44,14 +43,9 @@ class _CategoryMenuCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = playIconColors(item.palette);
     final theme = Theme.of(context);
-    final Color accent = colors.isNotEmpty
-        ? colors.last
-        : theme.colorScheme.primary;
-    final Color background = colors.isNotEmpty
-        ? colors.first.withOpacity(0.15)
-        : theme.colorScheme.primary.withOpacity(0.08);
+    final Color accent = item.accentColor;
+    final Color background = accent.withOpacity(0.12);
     final textStyle = theme.textTheme.titleMedium?.copyWith(
       fontWeight: FontWeight.w700,
       color: theme.colorScheme.onSurface,
@@ -104,25 +98,20 @@ class _VisualIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const double size = 64;
-    if (item.asset != null) {
-      return ClipRRect(
-        borderRadius: BorderRadius.circular(16),
-        child: Image.asset(
-          item.asset!,
-          height: size,
-          width: size,
-          fit: BoxFit.cover,
-          filterQuality: FilterQuality.high,
-        ),
-      );
-    }
-
     return Container(
       height: size,
       width: size,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: accent.withOpacity(0.15),
+        color: Colors.white.withOpacity(0.92),
+        boxShadow: [
+          BoxShadow(
+            color: accent.withOpacity(0.18),
+            blurRadius: 12,
+            offset: const Offset(0, 6),
+          ),
+        ],
+        border: Border.all(color: accent.withOpacity(0.18), width: 1.2),
       ),
       alignment: Alignment.center,
       child: Icon(item.icon, size: 32, color: accent),

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -32,52 +32,17 @@ import 'categories/aide_themes_screen.dart';
 /// ============================================================================
 
 class SectionStyle {
-  final double itemWidthFraction;
   final double? itemHeight;
-  final Color borderColor;
-  final double borderWidth;
-  final double borderRadius;
-
-  /// Couleur de fond… si `tileGradient` est null.
-  final Color tileBackgroundColor;
-
-  /// Dégradé vibrant (prioritaire si défini)
-  final Gradient? tileGradient;
-
-  final TextStyle sectionTitleStyle;
-
-  /// Couleur du texte sur la tuile (par défaut: blanc sur dégradé sombre)
-  final TextStyle? tileTitleTextStyle;
-
-  /// Couleur de l’icône (par défaut: blanc)
-  final Color? tileIconColor;
-
-  final double tileSpacing;
+  final TextStyle titleTextStyle;
 
   const SectionStyle({
-    required this.itemWidthFraction,
-    required this.itemHeight,
-    required this.borderColor,
-    this.borderWidth = 1.25,
-    this.borderRadius = 18,
-    required this.tileBackgroundColor,
-    this.tileGradient,
-    required this.sectionTitleStyle,
-    this.tileTitleTextStyle,
-    this.tileIconColor,
-    this.tileSpacing = 12,
+    this.itemHeight,
+    required this.titleTextStyle,
   });
 }
 
 class PlayUIConfig {
   final double panelHeightFactor;
-  final String quickPrepTitle;
-  final String coursesTitle;
-  final String bankTitle;
-  final String resourcesTitle;
-  final String historyTitle;
-  final String challengeTitle;
-  final String helpTitle;
   final Map<String, SectionStyle> sectionStyles;
 
   /// Espace sous le message de bienvenue (déjà existant)
@@ -88,13 +53,6 @@ class PlayUIConfig {
 
   const PlayUIConfig({
     required this.panelHeightFactor,
-    required this.quickPrepTitle,
-    required this.coursesTitle,
-    required this.bankTitle,
-    required this.resourcesTitle,
-    required this.historyTitle,
-    required this.challengeTitle,
-    required this.helpTitle,
     required this.sectionStyles,
     this.spacingUnderWelcome = 16.0,
     this.spacingBetweenLogoAndWelcome = 1.0,
@@ -142,182 +100,68 @@ const double baseCardHeight = 180;
 /// ========= CONFIG GLOBALE =========
 final PlayUIConfig UI = PlayUIConfig(
   panelHeightFactor: 0.72,
-  quickPrepTitle: 'Prépa rapide',
-  coursesTitle: 'Cours ENA (Côte d’Ivoire)',
-  bankTitle: 'Sujets & corrigés',
-  resourcesTitle: 'Ressources officielles (CI)',
-  historyTitle: 'Historique & suivi',
-  challengeTitle: 'Défis & classement',
-  helpTitle: 'Aide & thèmes',
   sectionStyles: {
-    'quick': SectionStyle(
-      itemWidthFraction: 0.50,
+    'quick': const SectionStyle(
       itemHeight: 200,
-      borderColor: const Color(0x887C4DFF),
-      borderWidth: 1.0,
-      borderRadius: 10,
-      tileBackgroundColor: const Color(0xFF7C4DFF),
-      tileGradient: const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [Color(0xFF4DBBFF), Color(0xFF3182EA)],
+      titleTextStyle: TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.w800,
+        color: _titleColor,
       ),
-      sectionTitleStyle: const TextStyle(
-        fontSize: 24, fontWeight: FontWeight.w800, color: _titleColor,
-      ),
-      tileTitleTextStyle: const TextStyle(
-        fontSize: 19, fontWeight: FontWeight.w800, color: Colors.white,
-      ),
-      tileIconColor: Colors.white,
-      tileSpacing: 12.0,
     ),
-
-    'courses': SectionStyle(
-      itemWidthFraction: 0.46,
-      itemHeight: 200.0,
-      borderColor: const Color(0xFF21295C),
-      borderWidth: 1.0,
-      borderRadius: 10,
-      tileBackgroundColor: const Color(0xFF00E5FF),
-      tileGradient: const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [Color(0xFF4DBBFF), Color(0xFF3182EA)], ),
-      sectionTitleStyle: const TextStyle(
-        fontSize: 22, fontWeight: FontWeight.w800, color: _titleColor,
+    'courses': const SectionStyle(
+      itemHeight: 200,
+      titleTextStyle: TextStyle(
+        fontSize: 22,
+        fontWeight: FontWeight.w800,
+        color: _titleColor,
       ),
-      tileTitleTextStyle: const TextStyle(
-        fontSize: 20, fontWeight: FontWeight.w800, color: Colors.white,
-      ),
-      tileIconColor: Colors.white,
-      tileSpacing: 10.0,
     ),
-
-    'bank': SectionStyle(
-      itemWidthFraction: 0.55,
-      itemHeight: 160.0,
-      borderColor: const Color(0x88FFC400),
-      borderWidth: 1.0,
-      borderRadius: 10,
-      tileBackgroundColor: const Color(0xFFFFC400),
-      tileGradient: const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [Color(0xFFFFA200), Color(0xFFFF8800)],
+    'bank': const SectionStyle(
+      itemHeight: 170,
+      titleTextStyle: TextStyle(
+        fontSize: 22,
+        fontWeight: FontWeight.w800,
+        color: _titleColor,
       ),
-      sectionTitleStyle: const TextStyle(
-        fontSize: 22, fontWeight: FontWeight.w800, color: _titleColor,
-      ),
-      tileTitleTextStyle: const TextStyle(
-        fontSize: 18, fontWeight: FontWeight.w800, color: Colors.white,
-      ),
-      tileIconColor: Colors.white,
-      tileSpacing: 12.0,
     ),
-
-    'resources': SectionStyle(
-      itemWidthFraction: 0.55,
-      itemHeight: 160.0,
-      borderColor: const Color(0x8800C853),
-      borderWidth: 1.0,
-      borderRadius: 0,
-      tileBackgroundColor: const Color(0xFF00C853),
-      tileGradient: const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [Color(0xFFFF5A00), Color(0xFFFF4C00)],
+    'resources': const SectionStyle(
+      itemHeight: 170,
+      titleTextStyle: TextStyle(
+        fontSize: 22,
+        fontWeight: FontWeight.w800,
+        color: _titleColor,
       ),
-      sectionTitleStyle: const TextStyle(
-        fontSize: 22, fontWeight: FontWeight.w800, color: _titleColor,
-      ),
-      tileTitleTextStyle: const TextStyle(
-        fontSize: 18, fontWeight: FontWeight.w800, color: Colors.white,
-      ),
-      tileIconColor: Colors.white,
-      tileSpacing: 12.0,
     ),
-
-    'history': SectionStyle(
-      itemWidthFraction: 0.55,
+    'history': const SectionStyle(
       itemHeight: 190,
-      borderColor: const Color(0x88FF6D00),
-      borderWidth: 1.0,
-      borderRadius: 2,
-      tileBackgroundColor: const Color(0xFFFF6D00),
-      tileGradient: const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [Color(0xFF006507), Color(0xFF2F5C00)],
+      titleTextStyle: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w800,
+        color: _titleColor,
       ),
-      sectionTitleStyle: const TextStyle(
-        fontSize: 20, fontWeight: FontWeight.w800, color: _titleColor,
-      ),
-      tileTitleTextStyle: const TextStyle(
-        fontSize: 22, fontWeight: FontWeight.w800, color: Colors.white,
-      ),
-      tileIconColor: Colors.white,
-      tileSpacing: 12.0,
     ),
-
-    'challenge': SectionStyle(
-      itemWidthFraction: 0.55,
+    'challenge': const SectionStyle(
       itemHeight: 205,
-      borderColor: const Color(0x882962FF),
-      borderWidth: 1.0,
-      borderRadius: 2,
-      tileBackgroundColor: const Color(0xFF2962FF),
-      tileGradient: const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [Color(0xFF264653), Color(0xFF264653)],
+      titleTextStyle: TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.w800,
+        color: _titleColor,
       ),
-      sectionTitleStyle: const TextStyle(
-        fontSize: 20, fontWeight: FontWeight.w800, color: _titleColor,
-      ),
-      tileTitleTextStyle: const TextStyle(
-        fontSize: 20, fontWeight: FontWeight.w800, color: Colors.white,
-      ),
-      tileIconColor: Colors.white,
-      tileSpacing: 12.0,
     ),
-
-    'help': SectionStyle(
-      itemWidthFraction: 1,
-      itemHeight: null,
-      borderColor: const Color(0x88AA00FF),
-      borderWidth: 1.0,
-      borderRadius: 2,
-      tileBackgroundColor: const Color(0xFFAA00FF),
-      tileGradient: const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [Color(0xFF4DBBFF), Color(0xFF3182EA)],
+    'help': const SectionStyle(
+      titleTextStyle: TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.w800,
+        color: _titleColor,
       ),
-      sectionTitleStyle: const TextStyle(
-        fontSize: 18, fontWeight: FontWeight.w800, color: _titleColor,
-      ),
-      tileTitleTextStyle: const TextStyle(
-        fontSize: 20, fontWeight: FontWeight.w800, color: Colors.white,
-      ),
-      tileIconColor: Colors.white,
-      tileSpacing: 12.0,
     ),
   },
-
   spacingUnderWelcome: 16.0,
   spacingBetweenLogoAndWelcome: 1.0,
 );
 
 const CalendarOverlayConfig CAL = CalendarOverlayConfig();
-
-/// === Helper: couleur principale de la tuile (dernier stop du gradient sinon fond) ===
-Color _pickTileMainColor(SectionStyle style) {
-  final g = style.tileGradient;
-  if (g is LinearGradient && g.colors.isNotEmpty) return g.colors.last;
-  if (g is RadialGradient && g.colors.isNotEmpty) return g.colors.last;
-  if (g is SweepGradient && g.colors.isNotEmpty) return g.colors.last;
-  return style.tileBackgroundColor;
-}
 
 /// ============================================================================
 /// === ÉCRAN ==================================================================
@@ -446,12 +290,6 @@ class _PlayScreenState extends State<PlayScreen> {
     precacheImage(_panelBg, context);
     for (final p in _promoImages) {
       precacheImage(AssetImage(p), context);
-    }
-    // Précharger les PNG des tuiles disponibles
-    for (final it in kCategoryMenuItems) {
-      if (it.asset != null) {
-        precacheImage(AssetImage(it.asset!), context);
-      }
     }
   }
 
@@ -847,87 +685,17 @@ class _PlayScreenState extends State<PlayScreen> {
                           (context, index) {
                             final section = sections[index];
                             final style = UI.sectionStyles[section.keyName]!;
-                            final double cardHeight =
-                                style.itemHeight ?? baseCardHeight;
-                            final Color accentColor = _pickTileMainColor(style);
-                            final Color iconColor =
-                                style.tileIconColor ?? Colors.white;
-                            final Color descriptionColor =
-                                style.tileTitleTextStyle?.color ??
-                                    Colors.white.withOpacity(0.85);
                             final modulesCount = section.itemIndexes.length;
-                            final modulesLabel =
-                                '$modulesCount module${modulesCount > 1 ? 's' : ''}';
 
                             return Padding(
                               padding: const EdgeInsets.fromLTRB(16, 6, 16, 0),
-                              child: SizedBox(
-                                height: cardHeight,
-                                child: _TileCard(
-                                  borderColor: style.borderColor,
-                                  borderWidth: style.borderWidth,
-                                  borderRadius: style.borderRadius,
-                                  backgroundColor: style.tileBackgroundColor,
-                                  gradient: style.tileGradient,
-                                  onTap: () => _navigate(context, section.category),
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(20.0),
-                                    child: Row(
-                                      crossAxisAlignment: CrossAxisAlignment.center,
-                                      children: [
-                                        Expanded(
-                                          child: Column(
-                                            crossAxisAlignment:
-                                                CrossAxisAlignment.start,
-                                            mainAxisAlignment:
-                                                MainAxisAlignment.center,
-                                            children: [
-                                              Text(
-                                                section.title,
-                                                style: style.sectionTitleStyle,
-                                              ),
-                                              const SizedBox(height: 8),
-                                              Text(
-                                                section.description,
-                                                style: TextStyle(
-                                                  color: descriptionColor,
-                                                  fontSize: 15 * scale,
-                                                  fontWeight: FontWeight.w500,
-                                                ),
-                                                maxLines: 2,
-                                                overflow: TextOverflow.ellipsis,
-                                              ),
-                                              const SizedBox(height: 12),
-                                              Container(
-                                                padding: const EdgeInsets.symmetric(
-                                                    horizontal: 12, vertical: 6),
-                                                decoration: BoxDecoration(
-                                                  color:
-                                                      accentColor.withOpacity(0.15),
-                                                  borderRadius:
-                                                      BorderRadius.circular(30),
-                                                ),
-                                                child: Text(
-                                                  modulesLabel,
-                                                  style: TextStyle(
-                                                    color: accentColor,
-                                                    fontWeight: FontWeight.w700,
-                                                  ),
-                                                ),
-                                              ),
-                                            ],
-                                          ),
-                                        ),
-                                        const SizedBox(width: 16),
-                                        _buildCategoryVisual(
-                                          section,
-                                          iconColor,
-                                          scale,
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
+                              child: HomeCategoryTile(
+                                definition: section,
+                                style: style,
+                                modulesCount: modulesCount,
+                                scale: scale,
+                                height: style.itemHeight ?? baseCardHeight,
+                                onTap: () => _navigate(context, section.category),
                               ),
                             );
                           },
@@ -941,36 +709,6 @@ class _PlayScreenState extends State<PlayScreen> {
             ],
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildCategoryVisual(
-    CategoryDefinition section,
-    Color iconColor,
-    double scale,
-  ) {
-    final double size = (120 * scale).clamp(80.0, 140.0);
-    if (section.asset != null) {
-      return SizedBox(
-        height: size,
-        width: size,
-        child: Image.asset(
-          section.asset!,
-          fit: BoxFit.contain,
-          filterQuality: FilterQuality.high,
-        ),
-      );
-    }
-
-    return Container(
-      height: size,
-      width: size,
-      alignment: Alignment.center,
-      child: Icon(
-        section.icon ?? Icons.apps_rounded,
-        size: size * 0.7,
-        color: iconColor,
       ),
     );
   }
@@ -1295,6 +1033,138 @@ class _LiveQuizList extends StatelessWidget {
   }
 }
 
+class HomeCategoryTile extends StatelessWidget {
+  const HomeCategoryTile({
+    super.key,
+    required this.definition,
+    required this.style,
+    required this.modulesCount,
+    required this.scale,
+    required this.height,
+    required this.onTap,
+  });
+
+  final CategoryDefinition definition;
+  final SectionStyle style;
+  final int modulesCount;
+  final double scale;
+  final double height;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Color accent = definition.accentColor;
+    final double iconContainerSize = (72 * scale).clamp(56.0, 86.0);
+    final double iconSize = (48 * scale).clamp(36.0, 56.0);
+    final String modulesLabel =
+        '$modulesCount module${modulesCount > 1 ? 's' : ''}';
+    final TextStyle descriptionStyle =
+        theme.textTheme.bodyMedium?.copyWith(
+              color: const Color(0xFF5F5A78),
+              fontWeight: FontWeight.w500,
+            ) ??
+            const TextStyle(
+              color: Color(0xFF5F5A78),
+              fontWeight: FontWeight.w500,
+              fontSize: 15,
+            );
+    final TextStyle badgeStyle =
+        theme.textTheme.labelLarge?.copyWith(
+              color: accent,
+              fontWeight: FontWeight.w700,
+            ) ??
+            TextStyle(
+              color: accent,
+              fontWeight: FontWeight.w700,
+              fontSize: 13,
+            );
+
+    return SizedBox(
+      height: height,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(26),
+          onTap: onTap,
+          child: Ink(
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(26),
+              border: Border.all(color: accent.withOpacity(0.16), width: 1.2),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x14000000),
+                  blurRadius: 20,
+                  offset: Offset(0, 10),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Container(
+                    height: iconContainerSize,
+                    width: iconContainerSize,
+                    decoration: BoxDecoration(
+                      color: accent.withOpacity(0.12),
+                      borderRadius: BorderRadius.circular(22),
+                    ),
+                    child: Icon(
+                      definition.icon,
+                      color: accent,
+                      size: iconSize,
+                    ),
+                  ),
+                  const SizedBox(width: 20),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          definition.title,
+                          style: style.titleTextStyle,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          definition.description,
+                          style: descriptionStyle,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 12),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 14,
+                            vertical: 6,
+                          ),
+                          decoration: BoxDecoration(
+                            color: accent.withOpacity(0.12),
+                            borderRadius: BorderRadius.circular(30),
+                          ),
+                          child: Text(modulesLabel, style: badgeStyle),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    color: accent.withOpacity(0.8),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _LiveQuizItem {
   const _LiveQuizItem({
     required this.icon,
@@ -1309,63 +1179,7 @@ class _LiveQuizItem {
   final String subtitle;
 }
 
-/// Tuile card commune
-class _TileCard extends StatelessWidget {
-  final Widget child;
-  final Color borderColor;
-  final double borderWidth;
-  final double borderRadius;
-  final Color backgroundColor;
-  final Gradient? gradient;
-  final VoidCallback? onTap;
-
-  const _TileCard({
-    super.key,
-    required this.child,
-    required this.borderColor,
-    required this.borderWidth,
-    required this.borderRadius,
-    required this.backgroundColor,
-    this.gradient,
-    this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: Ink(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(borderRadius),
-          border: Border.all(color: borderColor, width: borderWidth),
-          gradient: gradient,
-          color: gradient == null ? backgroundColor : null,
-          boxShadow: const [
-            BoxShadow(
-              color: Color(0x1F000000),
-              blurRadius: 12,
-              offset: Offset(0, 6),
-            ),
-            BoxShadow(
-              color: Color(0x14000000),
-              blurRadius: 24,
-              offset: Offset(0, 10),
-            ),
-          ],
-        ),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(borderRadius),
-          splashColor: Colors.white24,
-          highlightColor: Colors.white10,
-          onTap: onTap,
-          child: child,
-        ),
-      ),
-    );
-  }
-}
-
-/// Carrousel (si besoin ailleurs)
+  /// Carrousel (si besoin ailleurs)
 class _PromoCarousel extends StatelessWidget {
   final List<String> images;
   final PageController controller;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,6 @@ flutter:
     - assets/images/background_playscreen.png
     - assets/images/background_playscreen2.png
     - assets/images/
-    - assets/images/tuiles/
     - assets/images/C1.png
     - assets/images/C2.png
     - assets/images/C3.png


### PR DESCRIPTION
## Summary
- replace category menu definitions to use Material icons and accent colors instead of PNG assets
- add the HomeCategoryTile widget on the play screen and align ENA menus with the new icon treatment
- simplify section UI configuration and drop the unused tile asset bundle from pubspec.yaml

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fbb10090832fae14c14f9eab677f