### PR TITLE
Persist quick quiz state for resuming

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -45,6 +45,10 @@ class ExamFullScreen extends StatefulWidget {
   /// We hard-limit it to 5..10s now.
   final int? overridePerQuestionSeconds;
   final bool competitionMode;
+  final List<int?>? initialAnswers;
+  final int? initialRemainingSeconds;
+  final void Function(int remainingSeconds, List<int?> answers)? onStateChanged;
+  final VoidCallback? onStateCleared;
 
   const ExamFullScreen({
     super.key,
@@ -55,6 +59,10 @@ class ExamFullScreen extends StatefulWidget {
     this.showLocalSummary = true,
     this.overridePerQuestionSeconds,
     this.competitionMode = false,
+    this.initialAnswers,
+    this.initialRemainingSeconds,
+    this.onStateChanged,
+    this.onStateCleared,
   });
 
   @override
@@ -92,6 +100,11 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
       _pageController = PageController();
     }
     answers = List<int?>.filled(widget.questions.length, null);
+    if (widget.initialAnswers != null) {
+      for (int i = 0; i < answers.length && i < widget.initialAnswers!.length; i++) {
+        answers[i] = widget.initialAnswers![i];
+      }
+    }
 
     // Base: provided duration
     remaining = widget.duration.inSeconds;
@@ -102,7 +115,12 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
       remaining = perQ * widget.questions.length;
     }
 
+    if (widget.initialRemainingSeconds != null && widget.initialRemainingSeconds! > 0) {
+      remaining = widget.initialRemainingSeconds!;
+    }
+
     _startTimer();
+    Future.microtask(_notifyStateChanged);
   }
 
   @override
@@ -164,6 +182,19 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     debugPrintStack(stackTrace: stackTrace);
   }
 
+  void _notifyStateChanged() {
+    final callback = widget.onStateChanged;
+    if (callback == null) {
+      return;
+    }
+    callback(remaining, List<int?>.from(answers));
+  }
+
+  void _leaveExam(ExamResult? result) {
+    widget.onStateCleared?.call();
+    Navigator.of(context).pop(result);
+  }
+
   void _startTimer() {
     timer?.cancel();
     timer = Timer.periodic(const Duration(seconds: 1), (t) {
@@ -176,6 +207,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
         _submit(auto: true);
       } else {
         setState(() => remaining--);
+        _notifyStateChanged();
         if (widget.competitionMode && remaining <= 10) {
           if (remaining <= 3) {
             HapticFeedback.heavyImpact();
@@ -204,6 +236,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
 
   void _onAnswer(int index, int choice) {
     setState(() => answers[index] = choice);
+    _notifyStateChanged();
     if (widget.competitionMode) {
       if (index < widget.questions.length - 1) {
         _currentIndex = index + 1;
@@ -291,11 +324,12 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
         remaining -= 30;
         if (remaining < 0) remaining = 0;
       });
+      _notifyStateChanged();
       await _showAlert('Pénalité', '30 secondes retirées du temps restant.');
     } else if (_exitCount >= 3) {
       await _showAlert('Exclusion', 'Vous avez quitté l’application trop souvent.');
       if (mounted) {
-        Navigator.of(context).pop(null);
+        _leaveExam(null);
       }
     }
   }
@@ -390,14 +424,14 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     setState(() => _submitted = true);
 
     if (!widget.showLocalSummary) {
-      Navigator.of(context).pop(_lastResult);
+      _leaveExam(_lastResult);
       return;
     }
 
     await showDialog(
       context: context,
       barrierDismissible: false,
-      builder: (_) => AlertDialog(
+      builder: (dialogContext) => AlertDialog(
         title: Text(auto ? 'Temps écoulé' : 'Résultats'),
         content: Column(
           mainAxisSize: MainAxisSize.min,
@@ -415,8 +449,8 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
         actions: [
           TextButton(
             onPressed: () {
-              Navigator.of(context).pop();
-              Navigator.of(context).pop(_lastResult);
+              Navigator.of(dialogContext).pop();
+              _leaveExam(_lastResult);
             },
             child: const Text('Terminer'),
           ),
@@ -563,7 +597,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                     child: OutlinedButton.icon(
                       onPressed: () async {
                         if (_submitted) {
-                          Navigator.of(context).pop(_lastResult);
+                          _leaveExam(_lastResult);
                           return;
                         }
                         final confirm = await showDialog<bool>(
@@ -583,7 +617,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                           ),
                         );
                         if (confirm == true) {
-                          Navigator.of(context).pop(null);
+                          _leaveExam(null);
                         }
                       },
                       icon: Icon(_submitted ? Icons.check : Icons.close),
@@ -611,7 +645,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
       onWillPop: () async {
         if (widget.competitionMode) return false;
         if (_submitted) {
-          Navigator.of(context).pop(_lastResult);
+          _leaveExam(_lastResult);
           return false;
         }
         final ok = await showDialog<bool>(
@@ -630,7 +664,10 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
             ],
           ),
         );
-        return ok == true;
+        if (ok == true) {
+          _leaveExam(null);
+        }
+        return false;
       },
       child: content,
     );

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -7,8 +7,13 @@ import 'package:characters/characters.dart';
 
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../services/ongoing_quiz_store.dart';
+import '../services/question_loader.dart';
+import '../services/scoring.dart';
 import '../utils/palette_utils.dart';
 import '../utils/responsive_utils.dart';
+
+import '../models/question.dart';
 
 import 'dashboard_screen.dart';
 import 'design_settings_screen.dart';
@@ -16,6 +21,7 @@ import 'subject_list_screen.dart';
 import 'exam_history_screen.dart';
 import 'profile_edit_screen.dart';
 import 'training_quick_start.dart';
+import 'exam_full_screen.dart';
 
 // --- Catégories refactorisées (ENA CI) ---
 import 'categories/category_definitions.dart';
@@ -191,6 +197,8 @@ class _PlayScreenState extends State<PlayScreen> {
   Timer? _promoTimer;
   int _promoIndex = 0;
 
+  bool _resumingQuickQuiz = false;
+
   // Fonds
   late final AssetImage _screenBg =
       const AssetImage('assets/images/background_playscreen.png');
@@ -237,6 +245,7 @@ class _PlayScreenState extends State<PlayScreen> {
     _promoController = PageController(viewportFraction: 1.0);
     _startAutoPlay();
     _startClock();
+    unawaited(OngoingQuickQuizStore.load());
   }
 
   void _startAutoPlay() {
@@ -281,6 +290,113 @@ class _PlayScreenState extends State<PlayScreen> {
     await Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const TrainingQuickStartScreen()),
     );
+  }
+
+  Future<void> _handleResumeQuickQuiz(OngoingQuickQuizState state) async {
+    if (_resumingQuickQuiz) {
+      return;
+    }
+    setState(() => _resumingQuickQuiz = true);
+    bool dialogShown = false;
+    void closeDialog() {
+      if (!dialogShown) {
+        return;
+      }
+      if (mounted) {
+        Navigator.of(context, rootNavigator: true).pop();
+      }
+      dialogShown = false;
+    }
+
+    try {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(child: CircularProgressIndicator()),
+      );
+      dialogShown = true;
+
+      final all = await QuestionLoader.loadENA();
+      if (!mounted) {
+        closeDialog();
+        return;
+      }
+      final byId = <String, Question>{for (final q in all) q.id: q};
+      final questions = <Question>[];
+      for (final id in state.questionIds) {
+        final question = byId[id];
+        if (question != null) {
+          questions.add(question);
+        }
+      }
+
+      closeDialog();
+
+      if (questions.isEmpty || questions.length != state.questionIds.length) {
+        await OngoingQuickQuizStore.clear();
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Impossible de reprendre le quiz en cours.')),
+        );
+        return;
+      }
+
+      final initialAnswers = List<int?>.filled(questions.length, null, growable: false);
+      for (int i = 0; i < initialAnswers.length && i < state.answers.length; i++) {
+        initialAnswers[i] = state.answers[i];
+      }
+      final remaining = state.remainingSeconds > 0 ? state.remainingSeconds : 1;
+      final scoring = const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 1);
+
+      final result = await Navigator.push<ExamResult?>(
+        context,
+        MaterialPageRoute(
+          builder: (_) => ExamFullScreen(
+            questions: questions,
+            duration: Duration(seconds: remaining),
+            scoring: scoring,
+            title: state.title,
+            showLocalSummary: true,
+            initialAnswers: initialAnswers,
+            initialRemainingSeconds: remaining,
+            onStateChanged: (newRemaining, answers) {
+              unawaited(
+                OngoingQuickQuizStore.save(
+                  state.copyWith(
+                    remainingSeconds: newRemaining,
+                    answers: answers,
+                  ),
+                ),
+              );
+            },
+            onStateCleared: () {
+              unawaited(OngoingQuickQuizStore.clear());
+            },
+          ),
+        ),
+      );
+      await OngoingQuickQuizStore.clear();
+
+      if (!mounted) {
+        return;
+      }
+      if (result == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Quiz interrompu.')),
+        );
+      }
+    } catch (err) {
+      closeDialog();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Impossible de reprendre le quiz : $err')),
+      );
+    } finally {
+      closeDialog();
+      if (mounted) {
+        setState(() => _resumingQuickQuiz = false);
+      }
+    }
   }
 
   @override
@@ -659,7 +775,31 @@ class _PlayScreenState extends State<PlayScreen> {
                       SliverPadding(
                         padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
                         sliver: SliverToBoxAdapter(
-                          child: _RecentQuizCard(),
+                          child: ValueListenableBuilder<OngoingQuickQuizState?>(
+                            valueListenable: OngoingQuickQuizStore.notifier,
+                            builder: (_, state, __) {
+                              final hasQuiz =
+                                  state != null && state.questionIds.isNotEmpty;
+                              final progress = hasQuiz
+                                  ? state!.completionRatio.clamp(0.0, 1.0)
+                                  : 0.0;
+                              final percentLabel = hasQuiz
+                                  ? '${(progress * 100).round()} % complété'
+                                  : 'Aucun quiz en cours';
+                              final subtitle = hasQuiz
+                                  ? state!.title
+                                  : 'Lancez un entraînement rapide pour continuer.';
+                              return _RecentQuizCard(
+                                subtitle: subtitle,
+                                progress: progress,
+                                progressLabel: percentLabel,
+                                onContinue: hasQuiz
+                                    ? () => _handleResumeQuickQuiz(state!)
+                                    : null,
+                                isBusy: _resumingQuickQuiz,
+                              );
+                            },
+                          ),
                         ),
                       ),
 
@@ -802,10 +942,24 @@ class _PlayScreenState extends State<PlayScreen> {
 }
 
 class _RecentQuizCard extends StatelessWidget {
-  const _RecentQuizCard();
+  const _RecentQuizCard({
+    required this.subtitle,
+    required this.progress,
+    required this.progressLabel,
+    required this.onContinue,
+    required this.isBusy,
+  });
+
+  final String subtitle;
+  final double progress;
+  final String progressLabel;
+  final VoidCallback? onContinue;
+  final bool isBusy;
 
   @override
   Widget build(BuildContext context) {
+    final clampedProgress = progress.clamp(0.0, 1.0);
+    final bool enabled = onContinue != null && !isBusy;
     return Container(
       decoration: BoxDecoration(
         gradient: const LinearGradient(
@@ -835,7 +989,7 @@ class _RecentQuizCard extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           Text(
-            'Préparation concours ENA',
+            subtitle,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                   color: Colors.white70,
                   fontWeight: FontWeight.w600,
@@ -845,7 +999,7 @@ class _RecentQuizCard extends StatelessWidget {
           ClipRRect(
             borderRadius: BorderRadius.circular(18),
             child: LinearProgressIndicator(
-              value: 0.65,
+              value: clampedProgress,
               minHeight: 14,
               backgroundColor: Colors.white.withOpacity(0.2),
               valueColor: const AlwaysStoppedAnimation(Color(0xFFFFD740)),
@@ -856,7 +1010,7 @@ class _RecentQuizCard extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                '65 % complété',
+                progressLabel,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Colors.white,
                       fontWeight: FontWeight.w700,
@@ -872,11 +1026,17 @@ class _RecentQuizCard extends StatelessWidget {
                     borderRadius: BorderRadius.circular(18),
                   ),
                 ),
-                onPressed: () {},
-                child: const Text(
-                  'Continuer',
-                  style: TextStyle(fontWeight: FontWeight.w700),
-                ),
+                onPressed: enabled ? onContinue : null,
+                child: isBusy
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text(
+                        'Continuer',
+                        style: TextStyle(fontWeight: FontWeight.w700),
+                      ),
               ),
             ],
           ),

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -10,6 +10,7 @@ import '../models/training_history_entry.dart';
 import '../services/training_history_store.dart';
 import 'exam_full_screen.dart';
 import '../services/leaderboard_hooks.dart';
+import '../services/ongoing_quiz_store.dart';
 import '../widgets/chip_selector.dart';
 
 class TrainingQuickStartScreen extends StatefulWidget {
@@ -65,6 +66,14 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
 
       final totalSeconds = _perQuestionSeconds * selected.length;
       final scoring = const ExamScoring(correct: 1, wrong: -1, blank: 0, coefficient: 1);
+      final title = 'Entraînement (${_perQuestionSeconds}s/question)';
+      final quickState = OngoingQuickQuizState(
+        title: title,
+        questionIds: selected.map((q) => q.id).toList(growable: false),
+        answers: List<int?>.filled(selected.length, null, growable: false),
+        remainingSeconds: totalSeconds,
+      );
+      await OngoingQuickQuizStore.save(quickState);
 
       final startTime = DateTime.now();
       final res = await Navigator.push<ExamResult?>(context, MaterialPageRoute(
@@ -72,10 +81,26 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
           questions: selected,
           duration: Duration(seconds: totalSeconds),
           scoring: scoring,
-          title: 'Entraînement (${_perQuestionSeconds}s/question)',
+          title: title,
           showLocalSummary: true,
+          initialAnswers: quickState.answers,
+          initialRemainingSeconds: quickState.remainingSeconds,
+          onStateChanged: (remaining, answers) {
+            unawaited(
+              OngoingQuickQuizStore.save(
+                quickState.copyWith(
+                  remainingSeconds: remaining,
+                  answers: answers,
+                ),
+              ),
+            );
+          },
+          onStateCleared: () {
+            unawaited(OngoingQuickQuizStore.clear());
+          },
         ),
       ));
+      await OngoingQuickQuizStore.clear();
       final elapsedSeconds = DateTime.now().difference(startTime).inSeconds;
 
       if (res != null) {
@@ -131,6 +156,7 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
       }
     } catch (e) {
       if (mounted) Navigator.pop(context);
+      unawaited(OngoingQuickQuizStore.clear());
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Échec du lancement de l\'entraînement : $e')),

--- a/lib/services/ongoing_quiz_store.dart
+++ b/lib/services/ongoing_quiz_store.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'local_history_persistence.dart';
+
+class OngoingQuickQuizState {
+  final String title;
+  final List<String> questionIds;
+  final List<int?> answers;
+  final int remainingSeconds;
+
+  OngoingQuickQuizState({
+    required this.title,
+    required List<String> questionIds,
+    required List<int?> answers,
+    required this.remainingSeconds,
+  })  : questionIds = List<String>.unmodifiable(questionIds),
+        answers = List<int?>.unmodifiable(_normalizeAnswers(questionIds, answers)),
+        remainingSeconds = remainingSeconds < 0 ? 0 : remainingSeconds;
+
+  static List<int?> _normalizeAnswers(
+    List<String> questionIds,
+    List<int?> source,
+  ) {
+    final normalized = List<int?>.filled(questionIds.length, null, growable: false);
+    for (int i = 0; i < normalized.length && i < source.length; i++) {
+      final value = source[i];
+      normalized[i] = value;
+    }
+    return normalized;
+  }
+
+  double get completionRatio {
+    if (questionIds.isEmpty) {
+      return 0.0;
+    }
+    final answered = answers.where((a) => a != null).length;
+    return answered / questionIds.length;
+  }
+
+  OngoingQuickQuizState copyWith({
+    String? title,
+    List<String>? questionIds,
+    List<int?>? answers,
+    int? remainingSeconds,
+  }) {
+    final newQuestionIds = questionIds ?? this.questionIds;
+    final newAnswers = answers ?? this.answers;
+    return OngoingQuickQuizState(
+      title: title ?? this.title,
+      questionIds: newQuestionIds,
+      answers: newAnswers,
+      remainingSeconds: remainingSeconds ?? this.remainingSeconds,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'title': title,
+      'questionIds': questionIds,
+      'answers': answers,
+      'remainingSeconds': remainingSeconds,
+    };
+  }
+
+  factory OngoingQuickQuizState.fromJson(Map<String, dynamic> json) {
+    final rawIds = json['questionIds'];
+    final ids = rawIds is List
+        ? rawIds.map((e) => e?.toString() ?? '').where((e) => e.isNotEmpty).toList(growable: false)
+        : const <String>[];
+    final rawAnswers = json['answers'];
+    final parsedAnswers = <int?>[];
+    if (rawAnswers is List) {
+      for (final item in rawAnswers) {
+        if (item == null) {
+          parsedAnswers.add(null);
+        } else if (item is num) {
+          parsedAnswers.add(item.toInt());
+        } else {
+          final parsed = int.tryParse(item.toString());
+          parsedAnswers.add(parsed);
+        }
+      }
+    }
+    final remaining = json['remainingSeconds'];
+    final remainingSeconds = remaining is num ? remaining.toInt() : 0;
+    final title = json['title']?.toString() ?? 'Entraînement rapide';
+    return OngoingQuickQuizState(
+      title: title,
+      questionIds: ids,
+      answers: parsedAnswers,
+      remainingSeconds: remainingSeconds,
+    );
+  }
+}
+
+class OngoingQuickQuizStore {
+  OngoingQuickQuizStore._();
+
+  static const String _prefsKeyBase = 'ongoing_quick_quiz_state';
+
+  static final ValueNotifier<OngoingQuickQuizState?> notifier =
+      ValueNotifier<OngoingQuickQuizState?>(null);
+
+  static OngoingQuickQuizState? _cache;
+  static bool _loaded = false;
+  static Future<void>? _loadingFuture;
+  static bool _listenerRegistered = false;
+  static String _activeUserKey = LocalHistoryPersistence.activeUserKey;
+
+  static Future<OngoingQuickQuizState?> load() async {
+    await _ensureLoaded();
+    return _cache;
+  }
+
+  static Future<void> save(OngoingQuickQuizState state) async {
+    await _ensureLoaded();
+    final targetKey = _activeUserKey;
+    try {
+      await _persistFor(targetKey, state);
+      if (_activeUserKey != targetKey) {
+        return;
+      }
+      _cache = state;
+      _notify();
+    } catch (err, st) {
+      if (kDebugMode) {
+        debugPrint('OngoingQuickQuizStore.save failed: $err\n$st');
+      }
+    }
+  }
+
+  static Future<void> clear() async {
+    await _ensureLoaded();
+    final targetKey = _activeUserKey;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_scopedKey(targetKey));
+    } catch (err, st) {
+      if (kDebugMode) {
+        debugPrint('OngoingQuickQuizStore.clear failed: $err\n$st');
+      }
+    }
+    if (_activeUserKey == targetKey) {
+      _cache = null;
+      _notify();
+    }
+  }
+
+  static void _notify() {
+    notifier.value = _cache;
+  }
+
+  static Future<void> _ensureLoaded() async {
+    _ensureUserListener();
+    if (_loaded) {
+      return;
+    }
+    _loadingFuture ??= _loadFromPrefs();
+    await _loadingFuture;
+  }
+
+  static void _ensureUserListener() {
+    if (_listenerRegistered) {
+      return;
+    }
+    _listenerRegistered = true;
+    LocalHistoryPersistence.ensureInitialized();
+    _activeUserKey = LocalHistoryPersistence.activeUserKey;
+    LocalHistoryPersistence.addUserChangeListener(_handleUserChanged);
+  }
+
+  static void _handleUserChanged(String newKey) {
+    _activeUserKey = newKey;
+    _cache = null;
+    _loaded = false;
+    _loadingFuture = null;
+    _notify();
+  }
+
+  static Future<void> _loadFromPrefs() async {
+    final targetKey = _activeUserKey;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_scopedKey(targetKey));
+      if (_activeUserKey != targetKey) {
+        return;
+      }
+      if (raw == null || raw.isEmpty) {
+        _cache = null;
+      } else {
+        final decoded = jsonDecode(raw);
+        if (decoded is Map<String, dynamic>) {
+          _cache = OngoingQuickQuizState.fromJson(decoded);
+        } else if (decoded is Map) {
+          _cache = OngoingQuickQuizState.fromJson(
+            Map<String, dynamic>.from(decoded as Map<dynamic, dynamic>),
+          );
+        } else {
+          _cache = null;
+        }
+      }
+      _loaded = true;
+      _notify();
+    } catch (err, st) {
+      if (kDebugMode) {
+        debugPrint('OngoingQuickQuizStore._loadFromPrefs failed: $err\n$st');
+      }
+      if (_activeUserKey == targetKey) {
+        _cache = null;
+        _loaded = true;
+        _notify();
+      }
+    } finally {
+      if (_activeUserKey == targetKey) {
+        _loadingFuture = null;
+      }
+    }
+  }
+
+  static Future<void> _persistFor(
+    String userKey,
+    OngoingQuickQuizState state,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _scopedKey(userKey),
+      jsonEncode(state.toJson()),
+    );
+  }
+
+  static String _scopedKey(String userKey) {
+    return '${_prefsKeyBase}_$userKey';
+  }
+}


### PR DESCRIPTION
## Summary
- add an `OngoingQuickQuizStore` backed by `SharedPreferences` to persist quick training sessions
- wire the training quick start flow and Play screen to update the stored state and resume ongoing quizzes
- extend `ExamFullScreen` to restore initial answers/time and report progress updates for persistence

## Testing
- Not run (Flutter SDK unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d7ff7612d0832f9b89c48cf20eaddc