### PR TITLE
Add promo carousel sliver with autoplay guard

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -252,6 +252,7 @@ class _PlayScreenState extends State<PlayScreen> {
     _promoTimer?.cancel();
     _promoTimer = Timer.periodic(const Duration(seconds: 4), (_) {
       if (!mounted || _promoImages.isEmpty) return;
+      if (!_promoController.hasClients) return;
       final next = (_promoIndex + 1) % _promoImages.length;
       _promoController.animateToPage(
         next,
@@ -767,6 +768,31 @@ class _PlayScreenState extends State<PlayScreen> {
                                 },
                               ),
                             ],
+                          ),
+                        ),
+                      ),
+
+                      SliverPadding(
+                        padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
+                        sliver: SliverToBoxAdapter(
+                          child: _PromoCarousel(
+                            images: _promoImages,
+                            controller: _promoController,
+                            currentIndex: _promoIndex,
+                            onIndexTapped: (index) {
+                              if (index == _promoIndex) {
+                                return;
+                              }
+                              setState(() => _promoIndex = index);
+                              if (_promoController.hasClients) {
+                                _promoController.animateToPage(
+                                  index,
+                                  duration:
+                                      const Duration(milliseconds: 450),
+                                  curve: Curves.easeOut,
+                                );
+                              }
+                            },
                           ),
                         ),
                       ),


### PR DESCRIPTION
## Summary
- insert the promo carousel into the play screen scroll view with tap handling
- guard the autoplay timer against running before the controller is attached

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d806050fe4832f953cfeb507c57d21