### PR TITLE
Normalize remainingSeconds parameter initialization

### DIFF
--- a/lib/services/ongoing_quiz_store.dart
+++ b/lib/services/ongoing_quiz_store.dart
@@ -16,7 +16,7 @@ class OngoingQuickQuizState {
     required this.title,
     required List<String> questionIds,
     required List<int?> answers,
-    required this.remainingSeconds,
+    required int remainingSeconds,
   })  : questionIds = List<String>.unmodifiable(questionIds),
         answers = List<int?>.unmodifiable(_normalizeAnswers(questionIds, answers)),
         remainingSeconds = remainingSeconds < 0 ? 0 : remainingSeconds;


### PR DESCRIPTION
## Summary
- update OngoingQuickQuizState constructor to accept a plain remainingSeconds parameter and normalize it in the initializer

## Testing
- dart analyze *(fails: dart is not installed in the container)*
- flutter analyze *(fails: flutter is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d80602e0dc832f89de129a355a648f