### PR TITLE
Add quick quiz last-result persistence and display

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -1,5 +1,6 @@
 // lib/screens/play_screen.dart
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -198,6 +199,10 @@ class _PlayScreenState extends State<PlayScreen> {
   int _promoIndex = 0;
 
   bool _resumingQuickQuiz = false;
+  late final Listenable _quickQuizListenable = Listenable.merge([
+    OngoingQuickQuizStore.notifier,
+    OngoingQuickQuizStore.lastResultNotifier,
+  ]);
 
   // Fonds
   late final AssetImage _screenBg =
@@ -376,6 +381,19 @@ class _PlayScreenState extends State<PlayScreen> {
           ),
         ),
       );
+      final completedAt = DateTime.now();
+      if (result != null) {
+        await OngoingQuickQuizStore.saveLastResult(
+          QuickQuizSummary(
+            title: state.title,
+            completedAt: completedAt,
+            correctAnswers: result.correctCount,
+            totalQuestions: result.total,
+          ),
+        );
+      } else {
+        await OngoingQuickQuizStore.clearLastResult();
+      }
       await OngoingQuickQuizStore.clear();
 
       if (!mounted) {
@@ -801,26 +819,21 @@ class _PlayScreenState extends State<PlayScreen> {
                       SliverPadding(
                         padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
                         sliver: SliverToBoxAdapter(
-                          child: ValueListenableBuilder<OngoingQuickQuizState?>(
-                            valueListenable: OngoingQuickQuizStore.notifier,
-                            builder: (_, state, __) {
-                              final hasQuiz =
-                                  state != null && state.questionIds.isNotEmpty;
-                              final progress = hasQuiz
-                                  ? state!.completionRatio.clamp(0.0, 1.0)
-                                  : 0.0;
-                              final percentLabel = hasQuiz
-                                  ? '${(progress * 100).round()} % complété'
-                                  : 'Aucun quiz en cours';
-                              final subtitle = hasQuiz
-                                  ? state!.title
-                                  : 'Lancez un entraînement rapide pour continuer.';
+                          child: AnimatedBuilder(
+                            animation: _quickQuizListenable,
+                            builder: (_, __) {
+                              final state = OngoingQuickQuizStore.notifier.value;
+                              final summary =
+                                  OngoingQuickQuizStore.lastResultNotifier.value;
+                              final ongoing = (state != null &&
+                                      state.questionIds.isNotEmpty)
+                                  ? state
+                                  : null;
                               return _RecentQuizCard(
-                                subtitle: subtitle,
-                                progress: progress,
-                                progressLabel: percentLabel,
-                                onContinue: hasQuiz
-                                    ? () => _handleResumeQuickQuiz(state!)
+                                ongoingState: ongoing,
+                                lastSummary: summary,
+                                onContinue: ongoing != null
+                                    ? () => _handleResumeQuickQuiz(ongoing)
                                     : null,
                                 isBusy: _resumingQuickQuiz,
                               );
@@ -969,23 +982,42 @@ class _PlayScreenState extends State<PlayScreen> {
 
 class _RecentQuizCard extends StatelessWidget {
   const _RecentQuizCard({
-    required this.subtitle,
-    required this.progress,
-    required this.progressLabel,
+    required this.ongoingState,
+    required this.lastSummary,
     required this.onContinue,
     required this.isBusy,
   });
 
-  final String subtitle;
-  final double progress;
-  final String progressLabel;
+  final OngoingQuickQuizState? ongoingState;
+  final QuickQuizSummary? lastSummary;
   final VoidCallback? onContinue;
   final bool isBusy;
 
   @override
   Widget build(BuildContext context) {
-    final clampedProgress = progress.clamp(0.0, 1.0);
-    final bool enabled = onContinue != null && !isBusy;
+    final hasQuiz = ongoingState != null && ongoingState!.questionIds.isNotEmpty;
+    final summary = lastSummary;
+    final double rawProgress = hasQuiz
+        ? ongoingState!.completionRatio
+        : (summary?.completionRatio ?? 0.0);
+    final double clampedProgress = rawProgress.clamp(0.0, 1.0);
+    final int percentValue = (clampedProgress * 100).round();
+    final String subtitle = hasQuiz
+        ? ongoingState!.title
+        : summary?.title ?? 'Lancez un entraînement rapide pour continuer.';
+    final String progressLabel;
+    if (hasQuiz) {
+      progressLabel = '$percentValue % complété';
+    } else if (summary != null) {
+      progressLabel =
+          'Dernier score : $percentValue % – ${summary.correctAnswers}/${summary.totalQuestions}';
+    } else {
+      progressLabel = 'Aucun quiz en cours';
+    }
+    final bool showButton = hasQuiz && onContinue != null;
+    final bool enabled = showButton && !isBusy;
+    final mainAxisAlignment =
+        showButton ? MainAxisAlignment.spaceBetween : MainAxisAlignment.start;
     return Container(
       decoration: BoxDecoration(
         gradient: const LinearGradient(
@@ -1033,7 +1065,7 @@ class _RecentQuizCard extends StatelessWidget {
           ),
           const SizedBox(height: 12),
           Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            mainAxisAlignment: mainAxisAlignment,
             children: [
               Text(
                 progressLabel,
@@ -1042,28 +1074,29 @@ class _RecentQuizCard extends StatelessWidget {
                       fontWeight: FontWeight.w700,
                     ),
               ),
-              TextButton(
-                style: TextButton.styleFrom(
-                  foregroundColor: const Color(0xFF4315C5),
-                  backgroundColor: Colors.white,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(18),
+              if (showButton)
+                TextButton(
+                  style: TextButton.styleFrom(
+                    foregroundColor: const Color(0xFF4315C5),
+                    backgroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 18, vertical: 10),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(18),
+                    ),
                   ),
+                  onPressed: enabled ? onContinue : null,
+                  child: isBusy
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text(
+                          'Continuer',
+                          style: TextStyle(fontWeight: FontWeight.w700),
+                        ),
                 ),
-                onPressed: enabled ? onContinue : null,
-                child: isBusy
-                    ? const SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Text(
-                        'Continuer',
-                        style: TextStyle(fontWeight: FontWeight.w700),
-                      ),
-              ),
             ],
           ),
         ],

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -100,8 +100,21 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
           },
         ),
       ));
+      final completedAt = DateTime.now();
+      if (res != null) {
+        await OngoingQuickQuizStore.saveLastResult(
+          QuickQuizSummary(
+            title: title,
+            completedAt: completedAt,
+            correctAnswers: res.correctCount,
+            totalQuestions: res.total,
+          ),
+        );
+      } else {
+        await OngoingQuickQuizStore.clearLastResult();
+      }
       await OngoingQuickQuizStore.clear();
-      final elapsedSeconds = DateTime.now().difference(startTime).inSeconds;
+      final elapsedSeconds = completedAt.difference(startTime).inSeconds;
 
       if (res != null) {
         final bool success = res.total > 0 && (res.correctCount / res.total) >= 0.5; // ≥50% de bonnes réponses
@@ -157,6 +170,7 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
     } catch (e) {
       if (mounted) Navigator.pop(context);
       unawaited(OngoingQuickQuizStore.clear());
+      unawaited(OngoingQuickQuizStore.clearLastResult());
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Échec du lancement de l\'entraînement : $e')),

--- a/lib/services/ongoing_quiz_store.dart
+++ b/lib/services/ongoing_quiz_store.dart
@@ -6,6 +6,60 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'local_history_persistence.dart';
 
+class QuickQuizSummary {
+  final String title;
+  final DateTime completedAt;
+  final int correctAnswers;
+  final int totalQuestions;
+
+  const QuickQuizSummary({
+    required this.title,
+    required this.completedAt,
+    required this.correctAnswers,
+    required this.totalQuestions,
+  });
+
+  double get percent {
+    if (totalQuestions <= 0) {
+      return 0.0;
+    }
+    return (correctAnswers / totalQuestions) * 100.0;
+  }
+
+  double get completionRatio => percent / 100.0;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'title': title,
+      'completedAt': completedAt.toIso8601String(),
+      'correctAnswers': correctAnswers,
+      'totalQuestions': totalQuestions,
+    };
+  }
+
+  factory QuickQuizSummary.fromJson(Map<String, dynamic> json) {
+    final rawDate = json['completedAt'];
+    DateTime completedAt;
+    if (rawDate is String) {
+      completedAt = DateTime.tryParse(rawDate) ?? DateTime.now();
+    } else if (rawDate is int) {
+      completedAt = DateTime.fromMillisecondsSinceEpoch(rawDate);
+    } else {
+      completedAt = DateTime.now();
+    }
+    return QuickQuizSummary(
+      title: json['title']?.toString() ?? 'Entraînement rapide',
+      completedAt: completedAt,
+      correctAnswers: json['correctAnswers'] is num
+          ? (json['correctAnswers'] as num).toInt()
+          : int.tryParse(json['correctAnswers']?.toString() ?? '') ?? 0,
+      totalQuestions: json['totalQuestions'] is num
+          ? (json['totalQuestions'] as num).toInt()
+          : int.tryParse(json['totalQuestions']?.toString() ?? '') ?? 0,
+    );
+  }
+}
+
 class OngoingQuickQuizState {
   final String title;
   final List<String> questionIds;
@@ -101,11 +155,15 @@ class OngoingQuickQuizStore {
   OngoingQuickQuizStore._();
 
   static const String _prefsKeyBase = 'ongoing_quick_quiz_state';
+  static const String _prefsKeyLastBase = 'ongoing_quick_quiz_state_last';
 
   static final ValueNotifier<OngoingQuickQuizState?> notifier =
       ValueNotifier<OngoingQuickQuizState?>(null);
+  static final ValueNotifier<QuickQuizSummary?> lastResultNotifier =
+      ValueNotifier<QuickQuizSummary?>(null);
 
   static OngoingQuickQuizState? _cache;
+  static QuickQuizSummary? _lastResultCache;
   static bool _loaded = false;
   static Future<void>? _loadingFuture;
   static bool _listenerRegistered = false;
@@ -125,7 +183,7 @@ class OngoingQuickQuizStore {
         return;
       }
       _cache = state;
-      _notify();
+      _notifyState();
     } catch (err, st) {
       if (kDebugMode) {
         debugPrint('OngoingQuickQuizStore.save failed: $err\n$st');
@@ -146,12 +204,50 @@ class OngoingQuickQuizStore {
     }
     if (_activeUserKey == targetKey) {
       _cache = null;
-      _notify();
+      _notifyState();
     }
   }
 
-  static void _notify() {
+  static Future<void> saveLastResult(QuickQuizSummary summary) async {
+    await _ensureLoaded();
+    final targetKey = _activeUserKey;
+    try {
+      await _persistSummaryFor(targetKey, summary);
+      if (_activeUserKey != targetKey) {
+        return;
+      }
+      _lastResultCache = summary;
+      _notifyLastResult();
+    } catch (err, st) {
+      if (kDebugMode) {
+        debugPrint('OngoingQuickQuizStore.saveLastResult failed: $err\n$st');
+      }
+    }
+  }
+
+  static Future<void> clearLastResult() async {
+    await _ensureLoaded();
+    final targetKey = _activeUserKey;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_scopedLastKey(targetKey));
+    } catch (err, st) {
+      if (kDebugMode) {
+        debugPrint('OngoingQuickQuizStore.clearLastResult failed: $err\n$st');
+      }
+    }
+    if (_activeUserKey == targetKey) {
+      _lastResultCache = null;
+      _notifyLastResult();
+    }
+  }
+
+  static void _notifyState() {
     notifier.value = _cache;
+  }
+
+  static void _notifyLastResult() {
+    lastResultNotifier.value = _lastResultCache;
   }
 
   static Future<void> _ensureLoaded() async {
@@ -176,9 +272,11 @@ class OngoingQuickQuizStore {
   static void _handleUserChanged(String newKey) {
     _activeUserKey = newKey;
     _cache = null;
+    _lastResultCache = null;
     _loaded = false;
     _loadingFuture = null;
-    _notify();
+    _notifyState();
+    _notifyLastResult();
   }
 
   static Future<void> _loadFromPrefs() async {
@@ -186,6 +284,7 @@ class OngoingQuickQuizStore {
     try {
       final prefs = await SharedPreferences.getInstance();
       final raw = prefs.getString(_scopedKey(targetKey));
+      final rawLast = prefs.getString(_scopedLastKey(targetKey));
       if (_activeUserKey != targetKey) {
         return;
       }
@@ -203,16 +302,33 @@ class OngoingQuickQuizStore {
           _cache = null;
         }
       }
+      if (rawLast == null || rawLast.isEmpty) {
+        _lastResultCache = null;
+      } else {
+        final decoded = jsonDecode(rawLast);
+        if (decoded is Map<String, dynamic>) {
+          _lastResultCache = QuickQuizSummary.fromJson(decoded);
+        } else if (decoded is Map) {
+          _lastResultCache = QuickQuizSummary.fromJson(
+            Map<String, dynamic>.from(decoded as Map<dynamic, dynamic>),
+          );
+        } else {
+          _lastResultCache = null;
+        }
+      }
       _loaded = true;
-      _notify();
+      _notifyState();
+      _notifyLastResult();
     } catch (err, st) {
       if (kDebugMode) {
         debugPrint('OngoingQuickQuizStore._loadFromPrefs failed: $err\n$st');
       }
       if (_activeUserKey == targetKey) {
         _cache = null;
+        _lastResultCache = null;
         _loaded = true;
-        _notify();
+        _notifyState();
+        _notifyLastResult();
       }
     } finally {
       if (_activeUserKey == targetKey) {
@@ -232,7 +348,22 @@ class OngoingQuickQuizStore {
     );
   }
 
+  static Future<void> _persistSummaryFor(
+    String userKey,
+    QuickQuizSummary summary,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _scopedLastKey(userKey),
+      jsonEncode(summary.toJson()),
+    );
+  }
+
   static String _scopedKey(String userKey) {
     return '${_prefsKeyBase}_$userKey';
+  }
+
+  static String _scopedLastKey(String userKey) {
+    return '${_prefsKeyLastBase}_$userKey';
   }
 }


### PR DESCRIPTION
## Summary
- add a persisted `QuickQuizSummary` per user with a notifier for the last quick quiz result
- record the last quick quiz result when training sessions end and clear it on abandon
- update the Play screen card to combine quiz state with the latest score summary

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d808c48d38832fa467dd684a246951