### PR TITLE
Wrap multi exam flow in scroll view

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -429,59 +429,66 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
       ),
       body: loading
           ? const Center(child: CircularProgressIndicator())
-          : Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Niveau de difficulté',
-                    style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
-                  ),
-                  const SizedBox(height: 8),
-                  _difficultyPicker(),
-                  const SizedBox(height: 12),
-                  if (perQ == null)
-                    Text(
-                      'Mode Normal : timings officiels des épreuves (réaliste).',
-                      style: textTheme.bodyLarge,
-                    )
-                  else
-                    Text(
-                      'Mode ${difficultyLabel(_difficulty)} : ~${perQ}s par question (temps total ajusté automatiquement).',
-                      style: textTheme.bodyLarge,
-                    ),
-                  const SizedBox(height: 16),
-                  Card(
+          : LayoutBuilder(
+              builder: (context, constraints) {
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.all(16),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(minHeight: constraints.maxHeight),
                     child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        for (final s in sections)
-                          ListTile(
-                            leading: Icon(_iconForSection(s.title)),
-                            title: Text(
-                              s.title,
-                              style: textTheme.titleMedium,
-                            ),
-                            subtitle: Text(
-                              'Barème: ${s.scoring} • Questions visées: ${s.targetCount}',
-                              style: textTheme.bodyLarge,
-                            ),
-                            trailing: const Icon(Icons.chevron_right),
+                        Text(
+                          'Niveau de difficulté',
+                          style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 8),
+                        _difficultyPicker(),
+                        const SizedBox(height: 12),
+                        if (perQ == null)
+                          Text(
+                            'Mode Normal : timings officiels des épreuves (réaliste).',
+                            style: textTheme.bodyLarge,
+                          )
+                        else
+                          Text(
+                            'Mode ${difficultyLabel(_difficulty)} : ~${perQ}s par question (temps total ajusté automatiquement).',
+                            style: textTheme.bodyLarge,
                           ),
+                        const SizedBox(height: 16),
+                        Card(
+                          child: Column(
+                            children: [
+                              for (final s in sections)
+                                ListTile(
+                                  leading: Icon(_iconForSection(s.title)),
+                                  title: Text(
+                                    s.title,
+                                    style: textTheme.titleMedium,
+                                  ),
+                                  subtitle: Text(
+                                    'Barème: ${s.scoring} • Questions visées: ${s.targetCount}',
+                                    style: textTheme.bodyLarge,
+                                  ),
+                                  trailing: const Icon(Icons.chevron_right),
+                                ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 24),
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton.icon(
+                            onPressed: _startFlow,
+                            icon: const Icon(Icons.play_arrow),
+                            label: const Text('Démarrer le parcours'),
+                          ),
+                        ),
                       ],
                     ),
                   ),
-                  const Spacer(),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed: _startFlow,
-                      icon: const Icon(Icons.play_arrow),
-                      label: const Text('Démarrer le parcours'),
-                    ),
-                  ),
-                ],
-              ),
+                );
+              },
             ),
     );
   }


### PR DESCRIPTION
## Summary
- replace the static padding layout with a LayoutBuilder-driven scroll view to keep the content scrollable
- add a constrained box to preserve the original vertical layout while enabling scrolling
- swap the spacer before the launch button for fixed spacing to avoid overflow on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d810d718e4832f80c44c8e66b5b201