### PR TITLE
Update quick quiz summary on multi exam flow

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -11,6 +11,7 @@ import '../services/question_history_store.dart';
 import '../services/exam_blueprint.dart';
 import '../data/ena_taxonomy.dart';
 import '../utils/palette_utils.dart';
+import '../services/ongoing_quiz_store.dart';
 import 'exam_full_screen.dart';
 import 'exam_history_screen.dart';
 
@@ -311,6 +312,19 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
       abandoned: abandoned, // conservé
     );
     await HistoryStore.add(entry);
+
+    if (!abandoned && totalQuestions > 0) {
+      await OngoingQuickQuizStore.saveLastResult(
+        QuickQuizSummary(
+          title: 'Concours ENA — ${difficultyLabel(_difficulty)}',
+          completedAt: DateTime.now(),
+          correctAnswers: totalCorrect,
+          totalQuestions: totalQuestions,
+        ),
+      );
+    } else {
+      await OngoingQuickQuizStore.clearLastResult();
+    }
 
     await showDialog(
       context: context,


### PR DESCRIPTION
## Summary
- add the ongoing quiz store dependency to the multi exam flow screen
- persist the latest completed multi-exam results for the resume card when a run finishes cleanly
- clear the last stored result when the flow is abandoned or has no questions to avoid partial summaries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d812f29624832f880d889bc970bbf8