### PR TITLE
Expose latest exam history and surface it on PlayScreen

### DIFF
--- a/lib/models/exam_history_entry.dart
+++ b/lib/models/exam_history_entry.dart
@@ -87,6 +87,35 @@ class ExamHistoryEntry {
     return <ExamHistoryEntry>[];
   }
 
+  double? overallSuccessRatio() {
+    if (correctBySubject.isEmpty && totalBySubject.isEmpty) {
+      return null;
+    }
+    var totalCorrect = 0;
+    var totalQuestions = 0;
+    final subjects = <String>{
+      ...correctBySubject.keys,
+      ...totalBySubject.keys,
+    };
+    for (final subject in subjects) {
+      final total = totalBySubject[subject] ?? 0;
+      final correct = correctBySubject[subject] ?? 0;
+      if (total <= 0) {
+        continue;
+      }
+      totalQuestions += total;
+      final adjustedCorrect = correct < 0
+          ? 0
+          : (correct > total ? total : correct);
+      totalCorrect += adjustedCorrect;
+    }
+    if (totalQuestions <= 0) {
+      return null;
+    }
+    final ratio = totalCorrect / totalQuestions;
+    return ratio.clamp(0.0, 1.0).toDouble();
+  }
+
   static DateTime _parseDate(dynamic raw) {
     if (raw is Timestamp) {
       final value = raw.toDate();

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -7,10 +7,12 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:characters/characters.dart';
 
 import '../models/design_config.dart';
+import '../models/exam_history_entry.dart';
 import '../services/design_bus.dart';
 import '../services/ongoing_quiz_store.dart';
 import '../services/question_loader.dart';
 import '../services/scoring.dart';
+import '../services/history_store.dart';
 import '../utils/palette_utils.dart';
 import '../utils/responsive_utils.dart';
 
@@ -203,6 +205,7 @@ class _PlayScreenState extends State<PlayScreen> {
   late final Listenable _quickQuizListenable = Listenable.merge([
     OngoingQuickQuizStore.notifier,
     OngoingQuickQuizStore.lastResultNotifier,
+    HistoryStore.latestEntryNotifier(),
   ]);
 
   // Fonds
@@ -252,6 +255,7 @@ class _PlayScreenState extends State<PlayScreen> {
     _startAutoPlay();
     _startClock();
     unawaited(OngoingQuickQuizStore.load());
+    unawaited(HistoryStore.load());
   }
 
   void _startAutoPlay() {
@@ -832,6 +836,8 @@ class _PlayScreenState extends State<PlayScreen> {
                               final state = OngoingQuickQuizStore.notifier.value;
                               final summary =
                                   OngoingQuickQuizStore.lastResultNotifier.value;
+                              final lastExam =
+                                  HistoryStore.latestEntryNotifier().value;
                               final ongoing = (state != null &&
                                       state.questionIds.isNotEmpty)
                                   ? state
@@ -839,6 +845,7 @@ class _PlayScreenState extends State<PlayScreen> {
                               return _RecentQuizCard(
                                 ongoingState: ongoing,
                                 lastSummary: summary,
+                                lastExamEntry: lastExam,
                                 onContinue: ongoing != null
                                     ? () => _handleResumeQuickQuiz(ongoing)
                                     : null,
@@ -993,6 +1000,7 @@ class _RecentQuizCard extends StatelessWidget {
   const _RecentQuizCard({
     required this.ongoingState,
     required this.lastSummary,
+    required this.lastExamEntry,
     required this.onContinue,
     required this.onLaunchQuiz,
     required this.isBusy,
@@ -1000,6 +1008,7 @@ class _RecentQuizCard extends StatelessWidget {
 
   final OngoingQuickQuizState? ongoingState;
   final QuickQuizSummary? lastSummary;
+  final ExamHistoryEntry? lastExamEntry;
   final VoidCallback? onContinue;
   final VoidCallback? onLaunchQuiz;
   final bool isBusy;
@@ -1010,20 +1019,37 @@ class _RecentQuizCard extends StatelessWidget {
     final bool showResume = hasQuiz && onContinue != null;
     final bool showLaunch = !hasQuiz && onLaunchQuiz != null;
     final summary = lastSummary;
+    final examEntry = lastExamEntry;
+    final double? examRatio = examEntry?.overallSuccessRatio();
+    final bool showExamResult = !hasQuiz && summary == null && examEntry != null;
     final double rawProgress = hasQuiz
         ? ongoingState!.completionRatio
-        : (summary?.completionRatio ?? 0.0);
+        : summary != null
+            ? summary.completionRatio
+            : (examRatio ?? 0.0);
     final double clampedProgress = rawProgress.clamp(0.0, 1.0);
     final int percentValue = (clampedProgress * 100).round();
-    final String subtitle = hasQuiz
-        ? ongoingState!.title
-        : summary?.title ?? 'Lancez un entraînement rapide pour continuer.';
+    final String subtitle;
+    if (hasQuiz) {
+      subtitle = ongoingState!.title;
+    } else if (summary != null) {
+      subtitle = summary.title ??
+          'Lancez un entraînement rapide pour continuer.';
+    } else if (showExamResult) {
+      subtitle = 'Résultat de votre dernière simulation complète.';
+    } else {
+      subtitle = 'Lancez un entraînement rapide pour continuer.';
+    }
     final String progressLabel;
     if (hasQuiz) {
       progressLabel = '$percentValue % complété';
     } else if (summary != null) {
       progressLabel =
           'Dernier score : $percentValue % – ${summary.correctAnswers}/${summary.totalQuestions}';
+    } else if (showExamResult) {
+      progressLabel = examRatio != null
+          ? 'Dernière simulation : $percentValue % de réussite'
+          : 'Dernière simulation : données indisponibles';
     } else {
       progressLabel = 'Aucun quiz en cours';
     }

--- a/lib/services/history_store.dart
+++ b/lib/services/history_store.dart
@@ -10,11 +10,16 @@ class HistoryStore {
   static Future<void>? _loadingFuture;
   static bool _listenerRegistered = false;
   static String _activeUserKey = LocalHistoryPersistence.activeUserKey;
+  static final ValueNotifier<ExamHistoryEntry?> _latestEntryNotifier =
+      ValueNotifier<ExamHistoryEntry?>(null);
 
   static Future<List<ExamHistoryEntry>> load() async {
     await _ensureLoaded();
     return List<ExamHistoryEntry>.from(_cache);
   }
+
+  static ValueNotifier<ExamHistoryEntry?> latestEntryNotifier() =>
+      _latestEntryNotifier;
 
   static Future<void> add(ExamHistoryEntry entry) async {
     var attempts = 0;
@@ -30,6 +35,7 @@ class HistoryStore {
         continue;
       }
       _cache = updated;
+      _updateLatestEntry(entry);
       await _persistFor(targetKey, updated);
       return;
     }
@@ -39,6 +45,7 @@ class HistoryStore {
     await _ensureLoaded();
     final targetKey = _activeUserKey;
     _cache = <ExamHistoryEntry>[];
+    _updateLatestEntry(null);
     try {
       await LocalHistoryPersistence.clearExamRaw(targetKey);
     } catch (err, st) {
@@ -72,6 +79,7 @@ class HistoryStore {
     _cache = <ExamHistoryEntry>[];
     _loaded = false;
     _loadingFuture = null;
+    _updateLatestEntry(null);
   }
 
   static Future<void> _loadFromLocal() async {
@@ -101,6 +109,7 @@ class HistoryStore {
         return;
       }
       _cache = entries;
+      _updateLatestEntry(entries.isNotEmpty ? entries.first : null);
       _loaded = true;
     } catch (err, st) {
       if (kDebugMode) {
@@ -108,6 +117,7 @@ class HistoryStore {
       }
       if (_activeUserKey == targetKey) {
         _cache = <ExamHistoryEntry>[];
+        _updateLatestEntry(null);
         _loaded = true;
       }
     } finally {
@@ -141,4 +151,11 @@ class HistoryStore {
         'success': entry.success,
         'abandoned': entry.abandoned,
       };
+
+  static void _updateLatestEntry(ExamHistoryEntry? entry) {
+    if (_latestEntryNotifier.value == entry) {
+      return;
+    }
+    _latestEntryNotifier.value = entry;
+  }
 }


### PR DESCRIPTION
## Summary
- expose a ValueNotifier for the latest exam entry in HistoryStore and keep it synced with loads, adds, and user changes
- add an overall success ratio helper on ExamHistoryEntry to compute a global percentage from subject stats
- surface the latest simulation result on the PlayScreen quick card and trigger HistoryStore.load during init

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d84092a780832fb5863894365fc769