### PR TITLE
Refactor live quiz shortcuts and competition flow

### DIFF
--- a/lib/screens/categories/defis_classement_screen.dart
+++ b/lib/screens/categories/defis_classement_screen.dart
@@ -2,15 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-import '../../models/question.dart';
-import '../../services/question_history_store.dart';
-import '../../services/question_loader.dart';
-import '../../services/question_randomizer.dart';
-import '../competition_screen.dart';
 import '../leaderboard_screen.dart';
 import 'category_definitions.dart';
 import 'category_helpers.dart';
 import 'widgets/category_menu_list.dart';
+import '../../services/competition_quiz_launcher.dart';
 
 class DefisClassementScreen extends StatefulWidget {
   final CategoryDefinition definition;
@@ -34,125 +30,12 @@ class _DefisClassementScreenState extends State<DefisClassementScreen> {
         );
         break;
       case 6:
-        await _startCompetition();
+        await CompetitionQuizLauncher.launch(context);
         break;
       default:
         await showComingSoonDialog(context, 'Défi à venir');
         break;
     }
-  }
-
-  Future<void> _startCompetition() async {
-    bool progressShown = false;
-    try {
-      const int desiredCount = 60;
-      final all = await QuestionLoader.loadENA();
-      if (!mounted) return;
-      showDialog(
-        context: context,
-        barrierDismissible: false,
-        builder: (_) => const Center(child: CircularProgressIndicator()),
-      );
-      progressShown = true;
-      final selected = await pickAndShuffle(
-        all,
-        desiredCount,
-        dedupeByQuestion: true,
-      );
-      if (progressShown && mounted) Navigator.pop(context);
-
-      final proceed = await _handleShortDraw(selected, desiredCount);
-      if (!proceed || !mounted) return;
-
-      final messenger = ScaffoldMessenger.of(context);
-      unawaited(
-        QuestionHistoryStore.addAll(selected.map((q) => q.id)).catchError(
-          (Object error, _) {
-            if (!mounted) return;
-            messenger.showSnackBar(
-              const SnackBar(
-                content: Text(
-                    'Échec de l’enregistrement de l’historique des questions.'),
-              ),
-            );
-          },
-        ),
-      );
-
-      await Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => CompetitionScreen(
-            questions: selected,
-            timePerQuestion: 5,
-            startTime: DateTime.now(),
-          ),
-        ),
-      );
-    } catch (e) {
-      if (progressShown && mounted) Navigator.pop(context);
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Unable to load question bank: $e')),
-      );
-    }
-  }
-
-  Future<bool> _handleShortDraw(List<Question> selected, int requested) async {
-    if (selected.length >= requested) return true;
-    if (!mounted) return false;
-
-    if (selected.isEmpty) {
-      await showDialog<void>(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Historique épuisé'),
-          content: const Text(
-              'Toutes les questions ont déjà été vues. Réinitialiser l\'historique pour recommencer.'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(_, null),
-              child: const Text('Fermer'),
-            ),
-            TextButton(
-              onPressed: () {
-                QuestionHistoryStore.clear();
-                Navigator.pop(_, null);
-              },
-              child: const Text('Réinitialiser'),
-            ),
-          ],
-        ),
-      );
-      return false;
-    }
-
-    final proceed = await showDialog<bool>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('Commencer ?'),
-        content: Text('Vous avez déjà vu la plupart des questions — '
-            '${selected.length}/$requested disponibles.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(_, false),
-            child: const Text('Annuler'),
-          ),
-          TextButton(
-            onPressed: () {
-              QuestionHistoryStore.clear();
-              Navigator.pop(_, false);
-            },
-            child: const Text('Réinitialiser'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(_, true),
-            child: const Text('Continuer'),
-          ),
-        ],
-      ),
-    );
-    return proceed == true;
   }
 
   @override

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -15,6 +15,7 @@ import '../services/question_loader.dart';
 import '../services/scoring.dart';
 import '../services/history_store.dart';
 import '../services/competition_service.dart';
+import '../services/competition_quiz_launcher.dart';
 import '../utils/palette_utils.dart';
 import '../utils/responsive_utils.dart';
 
@@ -342,6 +343,10 @@ class _PlayScreenState extends State<PlayScreen> {
     await Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const OfficialIntroScreen()),
     );
+  }
+
+  Future<void> _handleLaunchCompetition() async {
+    await CompetitionQuizLauncher.launch(context);
   }
 
   Future<void> _openLeaderboard() async {
@@ -756,23 +761,26 @@ class _PlayScreenState extends State<PlayScreen> {
     required double panelHeightFactor,
   }) {
     final liveQuizItems = <_LiveQuizItem>[
-      const _LiveQuizItem(
+      _LiveQuizItem(
         icon: Icons.flash_on_rounded,
-        iconColor: Color(0xFF7C4DFF),
-        title: 'Sprint Express',
-        subtitle: '20 questions en 5 minutes',
+        iconColor: const Color(0xFF7C4DFF),
+        title: 'Quiz rapide',
+        subtitle: 'Démarre un entraînement instantané',
+        onTap: _handleCreateQuickQuiz,
       ),
-      const _LiveQuizItem(
+      _LiveQuizItem(
         icon: Icons.people_alt_rounded,
-        iconColor: Color(0xFF5336C6),
-        title: 'Duel du soir',
-        subtitle: 'Affronte un candidat au hasard',
+        iconColor: const Color(0xFF5336C6),
+        title: 'Défi compétition',
+        subtitle: '60 questions pour grimper au classement',
+        onTap: _handleLaunchCompetition,
       ),
-      const _LiveQuizItem(
+      _LiveQuizItem(
         icon: Icons.workspace_premium_rounded,
-        iconColor: Color(0xFF9C6BFF),
-        title: 'Marathon Officiel',
+        iconColor: const Color(0xFF9C6BFF),
+        title: 'Simulation officielle',
         subtitle: 'Sujet d’entraînement en conditions réelles',
+        onTap: _handleLaunchOfficialQuiz,
       ),
     ];
 
@@ -1428,10 +1436,17 @@ class _LeaderboardEntryRow extends StatelessWidget {
   }
 }
 
-class _LiveQuizList extends StatelessWidget {
+class _LiveQuizList extends StatefulWidget {
   const _LiveQuizList({required this.items});
 
   final List<_LiveQuizItem> items;
+
+  @override
+  State<_LiveQuizList> createState() => _LiveQuizListState();
+}
+
+class _LiveQuizListState extends State<_LiveQuizList> {
+  int? _loadingIndex;
 
   @override
   Widget build(BuildContext context) {
@@ -1451,14 +1466,16 @@ class _LiveQuizList extends StatelessWidget {
       child: ListView.separated(
         physics: const NeverScrollableScrollPhysics(),
         shrinkWrap: true,
-        itemCount: items.length,
+        itemCount: widget.items.length,
         separatorBuilder: (_, __) => const Divider(
           height: 1,
           thickness: 1,
           color: Color(0xFFE8E6F3),
         ),
         itemBuilder: (context, index) {
-          final item = items[index];
+          final item = widget.items[index];
+          final isLoading = _loadingIndex == index;
+          final hasAction = item.onTap != null;
           return ListTile(
             leading: Container(
               height: 48,
@@ -1482,8 +1499,18 @@ class _LiveQuizList extends StatelessWidget {
                     color: const Color(0xFF6F6A89),
                   ),
             ),
-            trailing: const Icon(Icons.chevron_right_rounded,
-                color: Color(0xFF7C4DFF)),
+            trailing: isLoading
+                ? SizedBox.square(
+                    dimension: 24,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 3,
+                      valueColor: AlwaysStoppedAnimation<Color>(item.iconColor),
+                    ),
+                  )
+                : const Icon(
+                    Icons.chevron_right_rounded,
+                    color: Color(0xFF7C4DFF),
+                  ),
             contentPadding: const EdgeInsets.symmetric(
               horizontal: 12,
               vertical: 6,
@@ -1491,7 +1518,20 @@ class _LiveQuizList extends StatelessWidget {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(20),
             ),
-            onTap: () {},
+            enabled: hasAction && !isLoading,
+            onTap: hasAction
+                ? () async {
+                    if (_loadingIndex != null) return;
+                    setState(() => _loadingIndex = index);
+                    try {
+                      await item.onTap?.call();
+                    } finally {
+                      if (mounted) {
+                        setState(() => _loadingIndex = null);
+                      }
+                    }
+                  }
+                : null,
           );
         },
       ),
@@ -1637,12 +1677,14 @@ class _LiveQuizItem {
     required this.iconColor,
     required this.title,
     required this.subtitle,
+    this.onTap,
   });
 
   final IconData icon;
   final Color iconColor;
   final String title;
   final String subtitle;
+  final Future<void> Function()? onTap;
 }
 
 /// Carrousel (si besoin ailleurs)

--- a/lib/services/competition_quiz_launcher.dart
+++ b/lib/services/competition_quiz_launcher.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import '../models/question.dart';
+import 'question_history_store.dart';
+import 'question_loader.dart';
+import 'question_randomizer.dart';
+import '../screens/competition_screen.dart';
+
+class CompetitionQuizLauncher {
+  const CompetitionQuizLauncher._();
+
+  static Future<void> launch(BuildContext context) async {
+    bool progressShown = false;
+    final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.maybeOf(context);
+
+    try {
+      const int desiredCount = 60;
+      final all = await QuestionLoader.loadENA();
+      if (!context.mounted) return;
+
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(child: CircularProgressIndicator()),
+      );
+      progressShown = true;
+
+      final selected = await pickAndShuffle(
+        all,
+        desiredCount,
+        dedupeByQuestion: true,
+      );
+
+      if (progressShown && context.mounted) navigator.pop();
+
+      final proceed = await _handleShortDraw(context, selected, desiredCount);
+      if (!proceed || !context.mounted) return;
+
+      if (messenger != null) {
+        unawaited(
+          QuestionHistoryStore.addAll(selected.map((q) => q.id)).catchError(
+            (Object error, _) {
+              if (!context.mounted) return;
+              messenger.showSnackBar(
+                const SnackBar(
+                  content: Text(
+                    'Échec de l\'enregistrement de l\'historique des questions.',
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+      }
+
+      await navigator.push(
+        MaterialPageRoute(
+          builder: (_) => CompetitionScreen(
+            questions: selected,
+            timePerQuestion: 5,
+            startTime: DateTime.now(),
+          ),
+        ),
+      );
+    } catch (e) {
+      if (progressShown && context.mounted) navigator.pop();
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Unable to load question bank: $e')),
+      );
+    }
+  }
+
+  static Future<bool> _handleShortDraw(
+    BuildContext context,
+    List<Question> selected,
+    int requested,
+  ) async {
+    if (selected.length >= requested) return true;
+    if (!context.mounted) return false;
+
+    if (selected.isEmpty) {
+      await showDialog<void>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('Historique épuisé'),
+          content: const Text(
+            'Toutes les questions ont déjà été vues. Réinitialiser l\'historique pour recommencer.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('Fermer'),
+            ),
+            TextButton(
+              onPressed: () {
+                QuestionHistoryStore.clear();
+                Navigator.of(dialogContext).pop();
+              },
+              child: const Text('Réinitialiser'),
+            ),
+          ],
+        ),
+      );
+      return false;
+    }
+
+    final proceed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Commencer ?'),
+        content: Text(
+          'Vous avez déjà vu la plupart des questions — '
+          '${selected.length}/$requested disponibles.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Annuler'),
+          ),
+          TextButton(
+            onPressed: () {
+              QuestionHistoryStore.clear();
+              Navigator.of(dialogContext).pop(false);
+            },
+            child: const Text('Réinitialiser'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Continuer'),
+          ),
+        ],
+      ),
+    );
+
+    return proceed == true;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable competition quiz launcher to centralize competition start logic
- wire the Play screen live quiz shortcuts to real async actions with progress feedback
- update the classement challenge screen to use the shared competition launcher

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d881231d20832fb5b72216c9444314