### PR TITLE
Add arcade badge support to profiles and leaderboard

### DIFF
--- a/docs/arcade_level_migration.md
+++ b/docs/arcade_level_migration.md
@@ -1,0 +1,57 @@
+# Migration arcadeLevel / badge
+
+Ce dépôt stocke désormais le niveau arcade de l’utilisateur dans les champs `arcadeLevel` et `badge` des documents Firestore (`users` et `competition_scores`). Pour rétro-initialiser les données existantes, vous pouvez utiliser le script Node.js ci-dessous avec le SDK `firebase-admin`.
+
+```bash
+npm install firebase-admin
+```
+
+Créez ensuite un fichier `migrate-arcade-level.js` :
+
+```js
+const admin = require('firebase-admin');
+admin.initializeApp({
+  credential: admin.credential.applicationDefault(),
+});
+
+const DEFAULT_LEVEL = 'Niveau 1';
+
+async function run() {
+  const db = admin.firestore();
+
+  // 1) Mise à jour des profils utilisateurs.
+  const usersSnap = await db.collection('users').get();
+  for (const doc of usersSnap.docs) {
+    const data = doc.data();
+    const current = (data.arcadeLevel || data.badge || '').toString().trim();
+    if (!current) {
+      await doc.ref.set({ arcadeLevel: DEFAULT_LEVEL, badge: DEFAULT_LEVEL }, { merge: true });
+    }
+  }
+
+  // 2) Mise à jour des entrées du classement.
+  const scoresSnap = await db.collection('competition_scores').get();
+  for (const doc of scoresSnap.docs) {
+    const data = doc.data();
+    const current = (data.arcadeLevel || data.badge || '').toString().trim();
+    if (!current) {
+      await doc.ref.set({ arcadeLevel: DEFAULT_LEVEL, badge: DEFAULT_LEVEL }, { merge: true });
+    }
+  }
+
+  console.log('Migration terminée.');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+Exécutez enfin :
+
+```bash
+node migrate-arcade-level.js
+```
+
+> Astuce : si vous préférez utiliser la console Firebase, vous pouvez également créer une règle Cloud Firestore temporaire qui définit `arcadeLevel` via un déclencheur Cloud Functions lors de la première écriture, mais le script ci-dessus permet de migrer l’historique en une seule fois.

--- a/lib/models/leaderboard_entry.dart
+++ b/lib/models/leaderboard_entry.dart
@@ -1,6 +1,8 @@
 // lib/models/leaderboard_entry.dart
+import 'user_profile.dart';
+
 class LeaderboardEntry {
-  final String userId, name, mode, subject, chapter, dateIso;
+  final String userId, name, mode, subject, chapter, dateIso, arcadeLevel;
   final int total, correct, wrong, blank, durationSec;
   final double percent;
   const LeaderboardEntry({
@@ -16,6 +18,7 @@ class LeaderboardEntry {
     required this.durationSec,
     required this.percent,
     required this.dateIso,
+    this.arcadeLevel = UserProfile.defaultArcadeLevel,
   });
   Map<String, dynamic> toJson() => {
     'userId': userId,
@@ -30,6 +33,8 @@ class LeaderboardEntry {
     'durationSec': durationSec,
     'percent': percent,
     'dateIso': dateIso,
+    'arcadeLevel': arcadeLevel,
+    'badge': arcadeLevel,
   };
   factory LeaderboardEntry.fromJson(Map<String, dynamic> m) => LeaderboardEntry(
     userId: (m['userId'] ?? '') as String,
@@ -44,5 +49,17 @@ class LeaderboardEntry {
     durationSec: (m['durationSec'] as num?)?.toInt() ?? 0,
     percent: (m['percent'] as num?)?.toDouble() ?? 0.0,
     dateIso: (m['dateIso'] ?? '') as String,
+    arcadeLevel: _readLevel(m),
   );
+
+  static String _readLevel(Map<String, dynamic> m) {
+    final value = m['arcadeLevel'] ?? m['badge'] ?? '';
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isEmpty ? UserProfile.defaultArcadeLevel : trimmed;
+    }
+    if (value == null) return UserProfile.defaultArcadeLevel;
+    final stringValue = value.toString().trim();
+    return stringValue.isEmpty ? UserProfile.defaultArcadeLevel : stringValue;
+  }
 }

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,12 +1,19 @@
 // lib/models/user_profile.dart
 class UserProfile {
-  final String firstName, lastName, nickname, profession, photoUrl;
+  static const String defaultArcadeLevel = 'Niveau 1';
+  final String firstName,
+      lastName,
+      nickname,
+      profession,
+      photoUrl,
+      arcadeLevel;
   const UserProfile({
     required this.firstName,
     required this.lastName,
     required this.nickname,
     required this.profession,
     required this.photoUrl,
+    this.arcadeLevel = defaultArcadeLevel,
   });
   Map<String, dynamic> toJson() => {
         'firstName': firstName,
@@ -14,6 +21,8 @@ class UserProfile {
         'nickname': nickname,
         'profession': profession,
         'photoUrl': photoUrl,
+        'arcadeLevel': arcadeLevel,
+        'badge': arcadeLevel,
       };
   factory UserProfile.fromJson(Map<String, dynamic> m) => UserProfile(
         firstName: (m['firstName'] ?? '') as String,
@@ -21,5 +30,17 @@ class UserProfile {
         nickname: (m['nickname'] ?? '') as String,
         profession: (m['profession'] ?? '') as String,
         photoUrl: (m['photoUrl'] ?? '') as String,
+        arcadeLevel: _readLevel(m),
       );
+
+  static String _readLevel(Map<String, dynamic> m) {
+    final value = m['arcadeLevel'] ?? m['badge'] ?? '';
+    if (value is String) {
+      final trimmed = value.trim();
+      return trimmed.isEmpty ? defaultArcadeLevel : trimmed;
+    }
+    if (value == null) return defaultArcadeLevel;
+    final stringValue = value.toString().trim();
+    return stringValue.isEmpty ? defaultArcadeLevel : stringValue;
+  }
 }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -14,6 +14,8 @@ import '../services/competition_service.dart';
 import '../services/user_profile_service.dart';
 import '../models/user_profile.dart';
 import 'profile_edit_screen.dart';
+import '../utils/arcade_level_utils.dart';
+import '../widgets/arcade_badge_chip.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -60,11 +62,13 @@ class _DashboardScreenState extends State<DashboardScreen> {
       profile = null;
     }
     profile ??= UserProfile(
-        firstName: '',
-        lastName: '',
-        nickname: entry?.name ?? '',
-        profession: '',
-        photoUrl: '');
+      firstName: '',
+      lastName: '',
+      nickname: entry?.name ?? '',
+      profession: '',
+      photoUrl: '',
+      arcadeLevel: normalizeArcadeLevel(entry?.arcadeLevel),
+    );
     if (!mounted) return;
     setState(() {
       _entry = entry;
@@ -163,7 +167,8 @@ class _DashboardScreenState extends State<DashboardScreen> {
         lastName: _profile?.lastName ?? '',
         nickname: _profile?.nickname ?? '',
         profession: _profile?.profession ?? '',
-        photoUrl: url);
+        photoUrl: url,
+        arcadeLevel: normalizeArcadeLevel(_profile?.arcadeLevel));
     await _profileService.saveProfile(profile);
     if (!mounted) return;
     await _load();
@@ -231,6 +236,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
         ? '${entry.percent.toStringAsFixed(1)}% (${entry.correct}/${entry.total})'
         : 'Non renseigné';
     final rankText = rank != null ? '$rank' : 'Non renseigné';
+    final badgeLabel = normalizeArcadeLevel(profile?.arcadeLevel ?? entry?.arcadeLevel);
 
     return Scaffold(
       appBar: AppBar(
@@ -296,6 +302,14 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 ),
                 Card(
                   child: ListTile(
+                    leading: const Icon(Icons.military_tech),
+                    title: const Text('Badge arcade'),
+                    subtitle: Text(badgeLabel),
+                    trailing: ArcadeBadgeChip(label: badgeLabel),
+                  ),
+                ),
+                Card(
+                  child: ListTile(
                     leading: const Icon(Icons.leaderboard),
                     title: const Text('Classement global'),
                     subtitle: Text(rankText),
@@ -306,3 +320,4 @@ class _DashboardScreenState extends State<DashboardScreen> {
     );
   }
 }
+

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/material.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
+import '../utils/arcade_level_utils.dart';
+import '../widgets/arcade_badge_chip.dart';
 
 class LeaderboardScreen extends StatefulWidget {
   const LeaderboardScreen({super.key});
@@ -67,15 +69,29 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
               separatorBuilder: (_, __) => const Divider(height: 1),
               itemBuilder: (context, i) {
                 final e = filtered[i]; final rank = i+1;
+                final badgeLabel = normalizeArcadeLevel(e.arcadeLevel);
                 return ListTile(
                   leading: _RankAvatar(rank: rank),
                   title: Text(e.name, style: Theme.of(context).textTheme.titleMedium),
-                  subtitle: Text('Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}'),
-                  trailing: Column(mainAxisAlignment: MainAxisAlignment.center, crossAxisAlignment: CrossAxisAlignment.end, children:[
-                    Text('${e.percent.toStringAsFixed(1)} %', style: const TextStyle(fontWeight: FontWeight.w800)),
-                    const SizedBox(height: 2),
-                    Text('${e.correct}/${e.total} • ${_fmtDuration(e.durationSec)}'),
-                  ]),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text('Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}'),
+                      const SizedBox(height: 4),
+                      ArcadeBadgeChip(label: badgeLabel, compact: true),
+                    ],
+                  ),
+                  isThreeLine: true,
+                  trailing: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text('${e.percent.toStringAsFixed(1)} %', style: const TextStyle(fontWeight: FontWeight.w800)),
+                      const SizedBox(height: 2),
+                      Text('${e.correct}/${e.total} • ${_fmtDuration(e.durationSec)}'),
+                    ],
+                  ),
                 );
               },
             ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -372,6 +372,7 @@ class _LoginScreenState extends State<LoginScreen> {
       nickname: nickname,
       profession: '',
       photoUrl: user.photoURL ?? '',
+      arcadeLevel: UserProfile.defaultArcadeLevel,
     );
     await profileService.saveProfile(profile);
   }

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -16,6 +16,7 @@ import '../services/user_profile_service.dart';
 import '../services/competition_service.dart';
 import '../services/private_scores_store.dart';
 import 'dashboard_screen.dart';
+import '../utils/arcade_level_utils.dart';
 
 class ProfileEditScreen extends StatefulWidget {
   const ProfileEditScreen({super.key});
@@ -35,6 +36,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
   Uint8List? _avatarBytes;
   String? _photoUrl;
   String? _initialPseudo;
+  String _arcadeLevel = '';
 
   @override
   void initState() {
@@ -63,6 +65,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     String? storedPhotoUrl;
     String? remoteNickname;
+    String? remoteArcadeLevel;
     if (uid != null) {
       try {
         final profile = await _profileService.loadProfile(uid);
@@ -80,6 +83,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
             remoteNickname = profile.nickname;
           }
           storedPhotoUrl = profile.photoUrl;
+          remoteArcadeLevel = profile.arcadeLevel;
         }
       } catch (e, st) {
         debugPrint('Failed to load profile: $e\n$st');
@@ -96,6 +100,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
         _pseudoController.text = remoteNickname;
       }
       _photoUrl = storedPhotoUrl ?? _photoUrl;
+      _arcadeLevel = normalizeArcadeLevel(remoteArcadeLevel ?? _arcadeLevel);
     });
     _initialPseudo = _pseudoController.text;
   }
@@ -268,6 +273,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
       nickname: _pseudoController.text,
       profession: _professionController.text,
       photoUrl: _buildPhotoUrlForStorage(),
+      arcadeLevel: normalizeArcadeLevel(_arcadeLevel),
     );
     await _profileService.saveProfile(profile);
 
@@ -288,6 +294,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
           durationSec: e.durationSec,
           percent: e.percent,
           dateIso: e.dateIso,
+          arcadeLevel: e.arcadeLevel,
         ));
       }
       final uid = FirebaseAuth.instance.currentUser?.uid;
@@ -308,6 +315,7 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
             durationSec: entry.durationSec,
             percent: entry.percent,
             dateIso: entry.dateIso,
+            arcadeLevel: entry.arcadeLevel,
           );
           await compService.saveEntry(updatedEntry);
         }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -166,6 +166,7 @@ class AuthService {
         nickname: names['nickname'] ?? '',
         profession: '',
         photoUrl: '',
+        arcadeLevel: UserProfile.defaultArcadeLevel,
       );
       await _userProfileService.saveProfile(profile);
     } catch (e) {

--- a/lib/services/leaderboard_hooks.dart
+++ b/lib/services/leaderboard_hooks.dart
@@ -1,5 +1,8 @@
 // lib/services/leaderboard_hooks.dart
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import '../services/user_profile_service.dart';
+import '../utils/arcade_level_utils.dart';
 import '../widgets/leaderboard_save_dialog.dart';
 
 class LeaderboardHooks {
@@ -14,6 +17,7 @@ class LeaderboardHooks {
     required int blank,
     required int durationSec,
     double? percent,
+    String? arcadeLevel,
   }) async {
     final pct = percent ?? (total == 0 ? 0.0 : (correct / total) * 100.0);
     await showSaveScoreDialog(
@@ -27,6 +31,7 @@ class LeaderboardHooks {
       blank: blank,
       durationSec: durationSec,
       percent: pct,
+      arcadeLevel: arcadeLevel,
     );
   }
 
@@ -85,6 +90,7 @@ class LeaderboardHooks {
     required int durationSec,
     double? percent,
   }) async {
+    final arcadeLevel = await _currentArcadeLevel();
     await _save(
       context: context,
       mode: 'competition',
@@ -94,6 +100,23 @@ class LeaderboardHooks {
       blank: blank,
       durationSec: durationSec,
       percent: percent,
+      arcadeLevel: arcadeLevel,
     );
+  }
+
+  static Future<String?> _currentArcadeLevel() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      return null;
+    }
+    try {
+      final profile = await UserProfileService().loadProfile(uid);
+      if (profile == null) {
+        return null;
+      }
+      return normalizeArcadeLevel(profile.arcadeLevel);
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/lib/utils/arcade_level_utils.dart
+++ b/lib/utils/arcade_level_utils.dart
@@ -1,0 +1,9 @@
+import '../models/user_profile.dart';
+
+String normalizeArcadeLevel(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed != null && trimmed.isNotEmpty) {
+    return trimmed;
+  }
+  return UserProfile.defaultArcadeLevel;
+}

--- a/lib/widgets/arcade_badge_chip.dart
+++ b/lib/widgets/arcade_badge_chip.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class ArcadeBadgeChip extends StatelessWidget {
+  final String label;
+  final bool compact;
+
+  const ArcadeBadgeChip({super.key, required this.label, this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final background = colorScheme.primaryContainer;
+    final foreground = colorScheme.onPrimaryContainer;
+    final iconSize = compact ? 16.0 : 18.0;
+    final padding = compact
+        ? const EdgeInsets.symmetric(horizontal: 6, vertical: 2)
+        : const EdgeInsets.symmetric(horizontal: 8, vertical: 4);
+    final textStyle = TextStyle(
+      color: foreground,
+      fontWeight: FontWeight.w600,
+      fontSize: compact ? 12 : null,
+    );
+    return Chip(
+      avatar: Icon(Icons.stars, size: iconSize, color: foreground),
+      label: Text(label, style: textStyle),
+      backgroundColor: background,
+      side: BorderSide(color: colorScheme.primary.withOpacity(0.4)),
+      padding: padding,
+      visualDensity: compact ? VisualDensity.compact : VisualDensity.standard,
+    );
+  }
+}

--- a/lib/widgets/leaderboard_save_dialog.dart
+++ b/lib/widgets/leaderboard_save_dialog.dart
@@ -9,13 +9,20 @@ import '../services/competition_service.dart';
 import '../services/user_profile_service.dart';
 import '../models/user_profile.dart';
 import '../services/private_scores_store.dart';
+import '../utils/arcade_level_utils.dart';
 
 Future<void> showSaveScoreDialog({
   required BuildContext context,
   required String mode, // 'training', 'concours' ou 'competition'
-  String subject = '', String chapter = '',
-  required int total, required int correct, required int wrong, required int blank,
-  required int durationSec, required double percent,
+  String subject = '',
+  String chapter = '',
+  required int total,
+  required int correct,
+  required int wrong,
+  required int blank,
+  required int durationSec,
+  required double percent,
+  String? arcadeLevel,
 }) async {
   // Mode compétition : utilise automatiquement l'utilisateur connecté
   if (mode == 'competition') {
@@ -49,6 +56,9 @@ Future<void> showSaveScoreDialog({
       name = nickname;
     }
 
+    final resolvedArcadeLevel = normalizeArcadeLevel(
+      arcadeLevel ?? profile?.arcadeLevel,
+    );
     final entry = LeaderboardEntry(
       userId: uid,
       name: name,
@@ -62,6 +72,7 @@ Future<void> showSaveScoreDialog({
       durationSec: durationSec,
       percent: percent,
       dateIso: DateTime.now().toIso8601String(),
+      arcadeLevel: resolvedArcadeLevel,
     );
     final service = CompetitionService();
     await service.saveEntry(entry);
@@ -177,6 +188,7 @@ Future<void> showSaveScoreDialog({
       durationSec: durationSec,
       percent: percent,
       dateIso: DateTime.now().toIso8601String(),
+      arcadeLevel: arcadeLevel ?? '',
     );
     await PrivateScoresStore.add(entry);
     if (!context.mounted) return;


### PR DESCRIPTION
## Summary
- add an arcade level field to user profiles and leaderboard entries and persist it through the related services
- surface the arcade badge alongside scores on the dashboard and competition leaderboard using a shared chip widget
- document a Firestore script to backfill arcade levels for existing users and scores

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9d2522f80832fb6665c7ed2cfca31