### PR TITLE
Adjust leaderboard badge layout

### DIFF
--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -72,15 +72,21 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
                 final badgeLabel = normalizeArcadeLevel(e.arcadeLevel);
                 return ListTile(
                   leading: _RankAvatar(rank: rank),
-                  title: Text(e.name, style: Theme.of(context).textTheme.titleMedium),
-                  subtitle: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
+                  title: Row(
                     children: [
-                      Text('Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}'),
-                      const SizedBox(height: 4),
                       ArcadeBadgeChip(label: badgeLabel, compact: true),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          e.name,
+                          style: Theme.of(context).textTheme.titleMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
                     ],
+                  ),
+                  subtitle: Text(
+                    'Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}',
                   ),
                   isThreeLine: true,
                   trailing: Column(


### PR DESCRIPTION
## Summary
- display the arcade badge chip next to the participant name in the leaderboard
- remove the duplicate badge from the subtitle while preserving the existing layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9dc6331c8832f9332674a433d4e53