### PR TITLE
Add arcade badge chip to arcade mode level cards

### DIFF
--- a/lib/screens/arcade_mode_screen.dart
+++ b/lib/screens/arcade_mode_screen.dart
@@ -9,6 +9,7 @@ import '../services/question_randomizer.dart';
 import '../services/question_history_store.dart';
 import '../services/scoring.dart';
 import '../services/leaderboard_hooks.dart';
+import '../widgets/arcade_badge_chip.dart';
 import 'exam_full_screen.dart';
 
 class ArcadeModeScreen extends StatefulWidget {
@@ -489,7 +490,15 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(level.title, style: theme.textTheme.titleMedium),
+          Wrap(
+            spacing: 8,
+            runSpacing: 4,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              ArcadeBadgeChip(label: level.title, compact: true),
+              Text(level.title, style: theme.textTheme.titleMedium),
+            ],
+          ),
           const SizedBox(height: 6),
           Text(level.description, style: theme.textTheme.bodyMedium),
           const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- import and use the shared arcade badge chip widget on arcade mode level cards
- adjust the layout to display the badge before the level title while keeping mobile-friendly wrapping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9dc6001b8832fbb0c5c3e4d9e1889