### PR TITLE
Persist arcade mode progression and update leaderboard badge

### DIFF
--- a/lib/screens/arcade_mode_screen.dart
+++ b/lib/screens/arcade_mode_screen.dart
@@ -9,6 +9,7 @@ import '../services/question_randomizer.dart';
 import '../services/question_history_store.dart';
 import '../services/scoring.dart';
 import '../services/leaderboard_hooks.dart';
+import '../services/arcade_progress_store.dart';
 import 'exam_full_screen.dart';
 
 class ArcadeModeScreen extends StatefulWidget {
@@ -75,9 +76,27 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
   bool _preparing = false;
   String? _error;
   _ArcadeModeStateSummary? _lastSummary;
+  final ArcadeProgressStore _progressStore = ArcadeProgressStore();
+  ArcadeProgressData? _progressData;
+  bool _loadingProgress = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadProgress());
+  }
+
+  Future<void> _loadProgress() async {
+    final progress = await _progressStore.load();
+    if (!mounted) return;
+    setState(() {
+      _progressData = progress;
+      _loadingProgress = false;
+    });
+  }
 
   Future<void> _startArcade() async {
-    if (_preparing) return;
+    if (_preparing || _loadingProgress) return;
     setState(() {
       _preparing = true;
       _error = null;
@@ -106,7 +125,7 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
       int totalBlank = 0;
       int totalQuestions = 0;
       int levelsCompleted = 0;
-      int levelIndex = 0;
+      int levelIndex = _progressData?.resumeIndex ?? 0;
       bool aborted = false;
       bool shortage = false;
 
@@ -144,6 +163,7 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
           break;
         }
 
+        await _handleLevelValidated(level);
         levelsCompleted += 1;
         levelIndex += 1;
       }
@@ -197,6 +217,7 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
         percent: summary.totalQuestions == 0
             ? 0.0
             : (summary.correct / summary.totalQuestions) * 100.0,
+        arcadeLevel: _progressData?.levelLabel,
       );
 
       if (!mounted) return;
@@ -384,8 +405,11 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final previewLevels =
-        List.generate(_previewLevelCount, (i) => _previewLevelAt(i));
+    final resumeIndex = _progressData?.resumeIndex ?? 0;
+    final previewLevels = List.generate(
+      _previewLevelCount,
+      (i) => _previewLevelAt(resumeIndex + i),
+    );
 
     return Scaffold(
       appBar: AppBar(
@@ -460,8 +484,15 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
                           child: CircularProgressIndicator(strokeWidth: 2),
                         )
                       : const Icon(Icons.play_arrow_rounded),
-                  label: Text(_preparing ? 'Préparation…' : 'Lancer la session'),
-                  onPressed: _preparing ? null : _startArcade,
+                  label: Text(
+                    _preparing
+                        ? 'Préparation…'
+                        : _loadingProgress
+                            ? 'Chargement…'
+                            : 'Lancer la session',
+                  ),
+                  onPressed:
+                      _preparing || _loadingProgress ? null : _startArcade,
                 ),
               ),
             ),
@@ -469,6 +500,18 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
         ),
       ),
     );
+  }
+
+  Future<void> _handleLevelValidated(_ArcadeLevel level) async {
+    final nextLabel = 'Niveau ${level.index + 2}';
+    final updated = await _progressStore.save(
+      levelLabel: nextLabel,
+      baseProfile: _progressData?.profile,
+    );
+    if (!mounted) return;
+    setState(() {
+      _progressData = updated;
+    });
   }
 
   Widget _buildLevelCard(_ArcadeLevel level, ThemeData theme) {

--- a/lib/services/arcade_progress_store.dart
+++ b/lib/services/arcade_progress_store.dart
@@ -1,0 +1,121 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/user_profile.dart';
+import '../utils/arcade_level_utils.dart';
+import 'user_profile_service.dart';
+
+class ArcadeProgressData {
+  final String levelLabel;
+  final UserProfile? profile;
+
+  const ArcadeProgressData({
+    required this.levelLabel,
+    this.profile,
+  });
+
+  int get resumeIndex {
+    final nextLevelNumber = ArcadeProgressStore.levelNumberFromLabel(levelLabel);
+    return nextLevelNumber > 0 ? nextLevelNumber - 1 : 0;
+  }
+
+  ArcadeProgressData copyWith({
+    String? levelLabel,
+    UserProfile? profile,
+  }) {
+    return ArcadeProgressData(
+      levelLabel: levelLabel ?? this.levelLabel,
+      profile: profile ?? this.profile,
+    );
+  }
+}
+
+class ArcadeProgressStore {
+  static const String _prefsLevelLabelKey = 'arcade.progress.levelLabel';
+
+  final UserProfileService _profileService;
+
+  ArcadeProgressStore({UserProfileService? profileService})
+      : _profileService = profileService ?? UserProfileService();
+
+  Future<ArcadeProgressData> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    var storedLabel = prefs.getString(_prefsLevelLabelKey);
+
+    UserProfile? profile;
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid != null) {
+      try {
+        profile = await _profileService.loadProfile(uid);
+      } catch (e, st) {
+        debugPrint('Failed to load profile for $uid: $e\n$st');
+      }
+    }
+
+    if (profile != null) {
+      storedLabel = normalizeArcadeLevel(profile.arcadeLevel);
+      await prefs.setString(_prefsLevelLabelKey, storedLabel);
+    } else {
+      storedLabel = normalizeArcadeLevel(storedLabel);
+      await prefs.setString(_prefsLevelLabelKey, storedLabel);
+    }
+
+    return ArcadeProgressData(levelLabel: storedLabel, profile: profile);
+  }
+
+  Future<ArcadeProgressData> save({
+    required String levelLabel,
+    UserProfile? baseProfile,
+  }) async {
+    final normalizedLabel = normalizeArcadeLevel(levelLabel);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsLevelLabelKey, normalizedLabel);
+
+    UserProfile? resolvedProfile = baseProfile;
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid != null) {
+      resolvedProfile ??= await _safeLoadProfile(uid);
+      final nextProfile = UserProfile(
+        firstName: resolvedProfile?.firstName ?? '',
+        lastName: resolvedProfile?.lastName ?? '',
+        nickname: resolvedProfile?.nickname ?? '',
+        profession: resolvedProfile?.profession ?? '',
+        photoUrl: resolvedProfile?.photoUrl ?? '',
+        arcadeLevel: normalizedLabel,
+      );
+      final savedProfile = await _safeSaveProfile(nextProfile);
+      resolvedProfile = savedProfile ?? resolvedProfile ?? nextProfile;
+    }
+
+    return ArcadeProgressData(levelLabel: normalizedLabel, profile: resolvedProfile);
+  }
+
+  Future<UserProfile?> _safeLoadProfile(String uid) async {
+    try {
+      return await _profileService.loadProfile(uid);
+    } catch (e, st) {
+      debugPrint('Failed to load profile for $uid: $e\n$st');
+      return null;
+    }
+  }
+
+  Future<UserProfile?> _safeSaveProfile(UserProfile profile) async {
+    try {
+      await _profileService.saveProfile(profile);
+      return profile;
+    } catch (e, st) {
+      debugPrint('Failed to save arcade progress: $e\n$st');
+      return null;
+    }
+  }
+
+  static int levelNumberFromLabel(String label) {
+    final match = RegExp(r'(\d+)').firstMatch(label);
+    if (match == null) {
+      return 1;
+    }
+    final value = int.tryParse(match.group(1)!);
+    return value == null || value <= 0 ? 1 : value;
+  }
+}

--- a/lib/services/leaderboard_hooks.dart
+++ b/lib/services/leaderboard_hooks.dart
@@ -1,8 +1,7 @@
 // lib/services/leaderboard_hooks.dart
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
-import '../services/user_profile_service.dart';
+import '../services/arcade_progress_store.dart';
 import '../utils/arcade_level_utils.dart';
 import '../widgets/leaderboard_save_dialog.dart';
 
@@ -97,8 +96,10 @@ class LeaderboardHooks {
     required int blank,
     required int durationSec,
     double? percent,
+    String? arcadeLevel,
   }) async {
-    final arcadeLevel = await _currentArcadeLevel();
+    final resolvedArcadeLevel =
+        arcadeLevel ?? await _currentArcadeLevel();
     await _save(
       context: context,
       mode: 'competition',
@@ -108,7 +109,7 @@ class LeaderboardHooks {
       blank: blank,
       durationSec: durationSec,
       percent: percent,
-      arcadeLevel: arcadeLevel,
+      arcadeLevel: resolvedArcadeLevel,
     );
   }
 
@@ -121,8 +122,10 @@ class LeaderboardHooks {
     required int blank,
     required int durationSec,
     double? percent,
+    String? arcadeLevel,
   }) async {
-    final arcadeLevel = await _currentArcadeLevel();
+    final resolvedArcadeLevel =
+        arcadeLevel ?? await _currentArcadeLevel();
     await _save(
       context: context,
       mode: 'arcade',
@@ -132,23 +135,15 @@ class LeaderboardHooks {
       blank: blank,
       durationSec: durationSec,
       percent: percent,
-      arcadeLevel: arcadeLevel,
+      arcadeLevel: resolvedArcadeLevel,
     );
   }
 
   /// Récupère le niveau d’arcade courant depuis le profil utilisateur,
   /// puis le normalise via `normalizeArcadeLevel`.
   static Future<String?> _currentArcadeLevel() async {
-    final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return null;
-
-    try {
-      final profile = await UserProfileService().loadProfile(uid);
-      if (profile == null) return null;
-      return normalizeArcadeLevel(profile.arcadeLevel);
-    } catch (_) {
-      // On reste tolérant : l’absence de niveau n’empêche pas l’enregistrement.
-      return null;
-    }
+    final progress = await ArcadeProgressStore().load();
+    final label = normalizeArcadeLevel(progress.levelLabel);
+    return label.isEmpty ? null : label;
   }
 }


### PR DESCRIPTION
## Summary
- load the saved arcade progress before building previews and use it to resume at the next level
- persist validated levels locally and in the remote profile through the new `ArcadeProgressStore`
- feed the freshly saved level into leaderboard saves so the badge reflects the latest arcade progress

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9dc5db850832f828069bf0e8d109e