### PR TITLE
Refactor home shell navigation

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -238,85 +238,111 @@ class _DashboardScreenState extends State<DashboardScreen> {
     final rankText = rank != null ? '$rank' : 'Non renseigné';
     final badgeLabel = normalizeArcadeLevel(profile?.arcadeLevel ?? entry?.arcadeLevel);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Mon dashboard'),
-        actions: [
+    final titleStyle = Theme.of(context).textTheme.headlineSmall;
+
+    final header = Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Mon dashboard',
+              style: titleStyle?.copyWith(fontWeight: FontWeight.w700),
+            ),
+          ),
           IconButton(
-              onPressed: _pickPhoto,
-              icon: const Icon(Icons.camera_alt),
-              tooltip: 'Changer la photo'),
+            onPressed: _pickPhoto,
+            icon: const Icon(Icons.camera_alt),
+            tooltip: 'Changer la photo',
+          ),
           IconButton(
-              onPressed: _openProfileEdit,
-              icon: const Icon(Icons.edit),
-              tooltip: 'Modifier le profil'),
+            onPressed: _openProfileEdit,
+            icon: const Icon(Icons.edit),
+            tooltip: 'Modifier le profil',
+          ),
         ],
       ),
-      body: _loading
-          ? const Center(child: CircularProgressIndicator())
-          : ListView(
-              padding: const EdgeInsets.all(16),
-              children: [
-                Image.asset('assets/images/logo_splash.png', height: 150),
-                const SizedBox(height: 24),
-                Row(
-                  children: [
-                    _buildAvatar(),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: Text(
-                        'Pseudo : ${profile?.nickname ?? ''}',
-                        style: Theme.of(context).textTheme.titleLarge,
-                      ),
+    );
+
+    final content = _loading
+        ? const Center(child: CircularProgressIndicator())
+        : ListView(
+            padding: const EdgeInsets.only(bottom: 24),
+            children: [
+              Align(
+                child: Image.asset('assets/images/logo_splash.png', height: 150),
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  _buildAvatar(),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Text(
+                      'Pseudo : ${profile?.nickname ?? ''}',
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
-                  ],
-                ),
-                const SizedBox(height: 24),
-                Card(
-                  child: ListTile(
-                    leading: const Icon(Icons.person),
-                    title: const Text('Prénom'),
-                    subtitle: Text(profile?.firstName ?? ''),
                   ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.person),
+                  title: const Text('Prénom'),
+                  subtitle: Text(profile?.firstName ?? ''),
                 ),
-                Card(
-                  child: ListTile(
-                    leading: const Icon(Icons.person_outline),
-                    title: const Text('Nom'),
-                    subtitle: Text(profile?.lastName ?? ''),
-                  ),
+              ),
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.person_outline),
+                  title: const Text('Nom'),
+                  subtitle: Text(profile?.lastName ?? ''),
                 ),
-                Card(
-                  child: ListTile(
-                    leading: const Icon(Icons.work),
-                    title: const Text('Profession'),
-                    subtitle: Text(profile?.profession ?? ''),
-                  ),
+              ),
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.work),
+                  title: const Text('Profession'),
+                  subtitle: Text(profile?.profession ?? ''),
                 ),
-                Card(
-                  child: ListTile(
-                    leading: const Icon(Icons.emoji_events),
-                    title: const Text('Score'),
-                    subtitle: Text(scoreText),
-                  ),
+              ),
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.emoji_events),
+                  title: const Text('Score'),
+                  subtitle: Text(scoreText),
                 ),
-                Card(
-                  child: ListTile(
-                    leading: const Icon(Icons.military_tech),
-                    title: const Text('Badge arcade'),
-                    subtitle: Text(badgeLabel),
-                    trailing: ArcadeBadgeChip(label: badgeLabel),
-                  ),
+              ),
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.military_tech),
+                  title: const Text('Badge arcade'),
+                  subtitle: Text(badgeLabel),
+                  trailing: ArcadeBadgeChip(label: badgeLabel),
                 ),
-                Card(
-                  child: ListTile(
-                    leading: const Icon(Icons.leaderboard),
-                    title: const Text('Classement global'),
-                    subtitle: Text(rankText),
-                  ),
+              ),
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.leaderboard),
+                  title: const Text('Classement global'),
+                  subtitle: Text(rankText),
                 ),
-              ],
-            ),
+              ),
+            ],
+          );
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            header,
+            Expanded(child: content),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -88,137 +88,146 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
       max: 22,
     );
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Personnalisation')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          // Aperçu dynamique du thème actuel
-          Container(
-            height: 120,
-            decoration: BoxDecoration(
-              gradient: LinearGradient(colors: previewColors),
+    final titleStyle = Theme.of(context)
+        .textTheme
+        .headlineSmall
+        ?.copyWith(fontWeight: FontWeight.w700);
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Personnalisation', style: titleStyle),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.only(bottom: 32),
+                children: [
+                  Container(
+                    height: 120,
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(colors: previewColors),
+                    ),
+                    alignment: Alignment.center,
+                    child: Text(
+                      'Aperçu',
+                      style: TextStyle(
+                        color: previewTextColor,
+                        fontSize: previewFontSize,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  _sectionTitle('Thème', sectionTitleSize),
+                  SwitchListTile(
+                    title: const Text('Mode sombre'),
+                    value: _cfg.darkMode,
+                    onChanged: (v) => _apply(_cfg.copyWith(darkMode: v)),
+                  ),
+                  SwitchListTile(
+                    title: const Text('Fond dégradé'),
+                    value: _cfg.bgGradient,
+                    onChanged: (v) => _apply(_cfg.copyWith(bgGradient: v)),
+                  ),
+                  const Divider(height: 32),
+                  _sectionTitle('Palette de couleurs', sectionTitleSize),
+                  SizedBox(
+                    height: 200,
+                    child: GridView.count(
+                      crossAxisCount: 4,
+                      mainAxisSpacing: 12,
+                      crossAxisSpacing: 12,
+                      physics: const NeverScrollableScrollPhysics(),
+                      children: [
+                        for (final p in _palettes) _colorChoice(p),
+                      ],
+                    ),
+                  ),
+                  const Divider(height: 32),
+                  _sectionTitle('Options', sectionTitleSize),
+                  SwitchListTile(
+                    title: const Text('Effet "wave" (halo)'),
+                    value: _cfg.waveEnabled,
+                    onChanged: (v) => _apply(_cfg.copyWith(waveEnabled: v)),
+                  ),
+                  SwitchListTile(
+                    title: const Text('Icônes monochromes'),
+                    value: _cfg.useMono,
+                    onChanged: (v) => _apply(
+                      _cfg.copyWith(
+                        useMono: v,
+                        monoColor: v
+                            ? complementaryColor(_cfg.bgPaletteName)
+                            : _cfg.monoColor,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  ExpansionTile(
+                    title: const Text('Verre (glassmorphism)'),
+                    children: [
+                      _sliderTile(
+                        label: 'Blur',
+                        value: _cfg.glassBlur,
+                        min: 8,
+                        max: 28,
+                        divisions: 20,
+                        onChanged: (v) => _apply(_cfg.copyWith(glassBlur: v)),
+                      ),
+                      _sliderTile(
+                        label: 'Opacité fond',
+                        value: _cfg.glassBgOpacity,
+                        min: 0.08,
+                        max: 0.30,
+                        divisions: 22,
+                        onChanged: (v) =>
+                            _apply(_cfg.copyWith(glassBgOpacity: v)),
+                      ),
+                      _sliderTile(
+                        label: 'Opacité bordure',
+                        value: _cfg.glassBorderOpacity,
+                        min: 0.0,
+                        max: 0.5,
+                        divisions: 25,
+                        onChanged: (v) =>
+                            _apply(_cfg.copyWith(glassBorderOpacity: v)),
+                      ),
+                    ],
+                  ),
+                  ExpansionTile(
+                    title: const Text('Tuiles'),
+                    children: [
+                      _sliderTile(
+                        label: 'Taille icône (px)',
+                        value: _cfg.tileIconSize,
+                        min: 36,
+                        max: 100,
+                        divisions: 64,
+                        onChanged: (v) =>
+                            _apply(_cfg.copyWith(tileIconSize: v)),
+                      ),
+                      SwitchListTile(
+                        title: const Text('Centrer icône + texte'),
+                        value: _cfg.tileCenter,
+                        onChanged: (v) =>
+                            _apply(_cfg.copyWith(tileCenter: v)),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  FilledButton.icon(
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.save),
+                    label: const Text('Enregistrer et revenir'),
+                  ),
+                ],
+              ),
             ),
-            alignment: Alignment.center,
-            child: Text(
-              'Aperçu',
-              style: TextStyle(
-                color: previewTextColor,
-                fontSize: previewFontSize,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
-          const SizedBox(height: 24),
-
-          _sectionTitle('Thème', sectionTitleSize),
-          SwitchListTile(
-            title: const Text('Mode sombre'),
-            value: _cfg.darkMode,
-            onChanged: (v) => _apply(_cfg.copyWith(darkMode: v)),
-          ),
-          SwitchListTile(
-            title: const Text('Fond dégradé'),
-            value: _cfg.bgGradient,
-            onChanged: (v) => _apply(_cfg.copyWith(bgGradient: v)),
-          ),
-          const Divider(height: 32),
-
-          _sectionTitle('Palette de couleurs', sectionTitleSize),
-          SizedBox(
-            height: 200,
-            child: GridView.count(
-              crossAxisCount: 4,
-              mainAxisSpacing: 12,
-              crossAxisSpacing: 12,
-              physics: const NeverScrollableScrollPhysics(),
-              children: [
-                for (final p in _palettes) _colorChoice(p),
-              ],
-            ),
-          ),
-          const Divider(height: 32),
-
-          _sectionTitle('Options', sectionTitleSize),
-          SwitchListTile(
-            title: const Text('Effet "wave" (halo)'),
-            value: _cfg.waveEnabled,
-            onChanged: (v) => _apply(_cfg.copyWith(waveEnabled: v)),
-          ),
-          SwitchListTile(
-            title: const Text('Icônes monochromes'),
-            value: _cfg.useMono,
-            onChanged: (v) => _apply(
-              _cfg.copyWith(
-                useMono: v,
-                monoColor: v
-                    ? complementaryColor(_cfg.bgPaletteName)
-                    : _cfg.monoColor,
-              ),
-            ),
-          ),
-
-          // Sections avancées repliables
-          const SizedBox(height: 8),
-          ExpansionTile(
-            title: const Text('Verre (glassmorphism)'),
-            children: [
-              _sliderTile(
-                label: 'Blur',
-                value: _cfg.glassBlur,
-                min: 8,
-                max: 28,
-                divisions: 20,
-                onChanged: (v) => _apply(_cfg.copyWith(glassBlur: v)),
-              ),
-              _sliderTile(
-                label: 'Opacité fond',
-                value: _cfg.glassBgOpacity,
-                min: 0.08,
-                max: 0.30,
-                divisions: 22,
-                onChanged: (v) => _apply(_cfg.copyWith(glassBgOpacity: v)),
-              ),
-              _sliderTile(
-                label: 'Opacité bordure',
-                value: _cfg.glassBorderOpacity,
-                min: 0.0,
-                max: 0.5,
-                divisions: 25,
-                onChanged: (v) =>
-                    _apply(_cfg.copyWith(glassBorderOpacity: v)),
-              ),
-            ],
-          ),
-
-          ExpansionTile(
-            title: const Text('Tuiles'),
-            children: [
-              _sliderTile(
-                label: 'Taille icône (px)',
-                value: _cfg.tileIconSize,
-                min: 36,
-                max: 100,
-                divisions: 64,
-                onChanged: (v) =>
-                    _apply(_cfg.copyWith(tileIconSize: v)),
-              ),
-              SwitchListTile(
-                title: const Text('Centrer icône + texte'),
-                value: _cfg.tileCenter,
-                onChanged: (v) =>
-                    _apply(_cfg.copyWith(tileCenter: v)),
-              ),
-            ],
-          ),
-
-          const SizedBox(height: 24),
-          ElevatedButton.icon(
-            onPressed: () => Navigator.pop(context),
-            icon: const Icon(Icons.check),
-            label: const Text('Terminer'),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/exam_history_screen.dart
+++ b/lib/screens/exam_history_screen.dart
@@ -78,134 +78,154 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
         final theme = Theme.of(context);
         final cs = theme.colorScheme;
         final textTheme = theme.textTheme;
-        return Scaffold(
-          backgroundColor: Colors.transparent,
-          appBar: AppBar(
-            title: const Text('Historique des examens'),
-            actions: [
-              if (_items.isNotEmpty)
-                IconButton(
-                  onPressed: _clearAll,
-                  icon: const Icon(Icons.delete_forever),
-                  tooltip: 'Effacer l’historique',
-                )
-            ],
-          ),
-          body: _loading
-              ? const Center(child: CircularProgressIndicator())
-              : _items.isEmpty
-                  ? const Center(
-                      child: Text('Aucun examen enregistré pour le moment.'))
-                  : ListView.builder(
-                  itemCount: _items.length,
-                  itemBuilder: (context, i) {
-                    final e = _items[i];
-                    final weak = e.weakSubjects();
-                    Color chipBg;
-                    Color chipFg;
-                    String chipText;
-                    if (e.abandoned) {
-                      chipBg = cs.tertiaryContainer;
-                      chipFg = cs.onTertiaryContainer;
-                      chipText = 'Abandonné';
-                    } else if (e.success) {
-                      chipBg = cs.primaryContainer;
-                      chipFg = cs.onPrimaryContainer;
-                      chipText = 'Réussi';
-                    } else {
-                      chipBg = cs.errorContainer;
-                      chipFg = cs.onErrorContainer;
-                      chipText = 'Échoué';
-                    }
 
-                    return Card(
-                      margin: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 6),
-                      child: Padding(
-                        padding: const EdgeInsets.all(12),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    'Examen du ${_fmt(e.date)}',
-                                    style: textTheme.titleLarge?.copyWith(
-                                      fontWeight: FontWeight.w700,
-                                    ),
-                                  ),
-                                ),
-                                Chip(
-                                  label: Text(
-                                    chipText,
-                                    style: textTheme.labelLarge?.copyWith(
-                                      fontWeight: FontWeight.w600,
-                                      color: chipFg,
-                                    ),
-                                  ),
-                                  backgroundColor: chipBg,
-                                  visualDensity: VisualDensity.compact,
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 8, vertical: 2),
-                                ),
-                              ],
+        Widget buildList() {
+          if (_loading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (_items.isEmpty) {
+            return const Center(
+              child: Text('Aucun examen enregistré pour le moment.'),
+            );
+          }
+          return ListView.builder(
+            itemCount: _items.length,
+            itemBuilder: (context, i) {
+              final e = _items[i];
+              final weak = e.weakSubjects();
+              Color chipBg;
+              Color chipFg;
+              String chipText;
+              if (e.abandoned) {
+                chipBg = cs.tertiaryContainer;
+                chipFg = cs.onTertiaryContainer;
+                chipText = 'Abandonné';
+              } else if (e.success) {
+                chipBg = cs.primaryContainer;
+                chipFg = cs.onPrimaryContainer;
+                chipText = 'Réussi';
+              } else {
+                chipBg = cs.errorContainer;
+                chipFg = cs.onErrorContainer;
+                chipText = 'Échoué';
+              }
+
+              return Card(
+                margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              'Examen du ${_fmt(e.date)}',
+                              style: textTheme.titleLarge?.copyWith(
+                                fontWeight: FontWeight.w700,
+                              ),
                             ),
-                            const SizedBox(height: 6),
-                            Text(
-                              'Total pondéré : ${e.totalPondere}',
-                              style: textTheme.bodyLarge?.copyWith(
+                          ),
+                          Chip(
+                            label: Text(
+                              chipText,
+                              style: textTheme.labelLarge?.copyWith(
                                 fontWeight: FontWeight.w600,
+                                color: chipFg,
                               ),
                             ),
-                            const Divider(height: 16),
-                            Text(
-                              'Détails par matière :',
-                              style: textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            for (final s in e.scoresBruts.keys) ...[
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceBetween,
-                                children: [
-                                  Expanded(
-                                    child: Text(
-                                      s,
-                                      style: textTheme.bodyLarge,
-                                    ),
-                                  ),
-                                  Text(
-                                    'Brut ${e.scoresBruts[s]} • Pondéré ${e.scoresPonderes[s]}',
-                                    style: textTheme.bodyLarge,
-                                  ),
-                                  const SizedBox(width: 8),
-                                  Text(
-                                    '(${e.correctBySubject[s]}/${e.totalBySubject[s]})',
-                                    style: textTheme.bodyLarge,
-                                  ),
-                                ],
-                              ),
-                              const SizedBox(height: 4),
-                            ],
-                            if (weak.isNotEmpty) ...[
-                              const Divider(height: 16),
-                              Text(
-                                'À renforcer : ${weak.join(', ')}',
-                                style: textTheme.bodyLarge?.copyWith(
-                                  color: cs.tertiary,
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                            ],
-                          ],
+                            backgroundColor: chipBg,
+                            visualDensity: VisualDensity.compact,
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 2),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        'Total pondéré : ${e.totalPondere}',
+                        style: textTheme.bodyLarge?.copyWith(
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
-                    );
-                  },
+                      const Divider(height: 16),
+                      Text(
+                        'Détails par matière :',
+                        style: textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      for (final s in e.scoresBruts.keys) ...[
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Expanded(
+                              child: Text(
+                                s,
+                                style: textTheme.bodyLarge,
+                              ),
+                            ),
+                            Text(
+                              'Brut ${e.scoresBruts[s]} • Pondéré ${e.scoresPonderes[s]}',
+                              style: textTheme.bodyLarge,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              '(${e.correctBySubject[s]}/${e.totalBySubject[s]})',
+                              style: textTheme.bodyLarge,
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 4),
+                      ],
+                      if (weak.isNotEmpty) ...[
+                        const Divider(height: 16),
+                        Text(
+                          'À renforcer : ${weak.join(', ')}',
+                          style: textTheme.bodyLarge?.copyWith(
+                            color: cs.tertiary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
                 ),
+              );
+            },
+          );
+        }
+
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'Historique des examens',
+                        style: theme.textTheme.headlineSmall
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                    if (_items.isNotEmpty)
+                      IconButton(
+                        onPressed: _clearAll,
+                        icon: const Icon(Icons.delete_forever),
+                        tooltip: 'Effacer l’historique',
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Expanded(child: buildList()),
+              ],
+            ),
+          ),
         );
       },
     );

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -184,13 +184,23 @@ const CalendarOverlayConfig CAL = CalendarOverlayConfig();
 /// ============================================================================
 /// === ÉCRAN ==================================================================
 /// ============================================================================
-class PlayScreen extends StatefulWidget {
+class PlayScreen extends StatelessWidget {
   const PlayScreen({super.key});
+
   @override
-  State<PlayScreen> createState() => _PlayScreenState();
+  Widget build(BuildContext context) {
+    return const HomeShell();
+  }
 }
 
-class _PlayScreenState extends State<PlayScreen> {
+class HomeShell extends StatefulWidget {
+  const HomeShell({super.key});
+
+  @override
+  State<HomeShell> createState() => _HomeShellState();
+}
+
+class _HomeShellState extends State<HomeShell> {
   static const Color _bottomBarColor = Color(0xFF6C4DFF);
   static const Color _bottomBarHighlight = Color(0x29FFFFFF);
   static const Color _fabForeground = Color(0xFF6C4DFF);
@@ -240,31 +250,30 @@ class _PlayScreenState extends State<PlayScreen> {
     super.initState();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
-    _navItems = [
+    _navItems = const [
+      _NavDestination(
+        icon: Icons.home_outlined,
+        label: 'Accueil',
+      ),
       _NavDestination(
         icon: Icons.dashboard_outlined,
         label: 'Dashboard',
-        builder: (_) => const DashboardScreen(),
       ),
       _NavDestination(
         icon: Icons.quiz_outlined,
         label: 'Quiz',
-        builder: (_) => const SubjectListScreen(),
       ),
       _NavDestination(
         icon: Icons.history,
         label: 'Historique',
-        builder: (_) => const ExamHistoryScreen(),
       ),
       _NavDestination(
         icon: Icons.person_outline,
         label: 'Profil',
-        builder: (_) => const ProfileEditScreen(),
       ),
       _NavDestination(
         icon: Icons.settings_outlined,
         label: 'Paramètres',
-        builder: (_) => const DesignSettingsScreen(),
       ),
     ];
 
@@ -352,19 +361,11 @@ class _PlayScreenState extends State<PlayScreen> {
     }
   }
 
-  Future<void> _onNavItemSelected(int index) async {
-    setState(() => _selectedNavIndex = index);
-    final builder = _navItems[index].builder;
-
-    if (builder != null) {
-      await Navigator.of(context).push(
-        MaterialPageRoute(builder: builder),
-      );
+  void _onNavItemSelected(int index) {
+    if (_selectedNavIndex == index) {
+      return;
     }
-
-    if (!mounted) return;
-
-    setState(() => _selectedNavIndex = 0);
+    setState(() => _selectedNavIndex = index);
   }
 
   Future<void> _handleCreateQuickQuiz() async {
@@ -595,35 +596,22 @@ class _PlayScreenState extends State<PlayScreen> {
               foregroundColor: textColor,
               toolbarHeight: 0,
             ),
-            floatingActionButton: _buildMainFab(),
+            floatingActionButton:
+                _selectedNavIndex == 0 ? _buildMainFab() : null,
             floatingActionButtonLocation:
                 FloatingActionButtonLocation.centerDocked,
             bottomNavigationBar: _buildBottomAppBar(),
-            body: Stack(
-              fit: StackFit.expand,
-              children: [
-                // Background écran
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    color: bgColor,
-                    image: DecorationImage(image: _screenBg, fit: BoxFit.cover),
-                  ),
-                ),
-                _buildHeader(
-                  topInset: topInset,
-                  hasName: hasName,
-                  name: name,
-                  welcomeFontSize: welcomeFontSize,
-                  nameFontSize: nameFontSize,
-                  arcadeProgress: _arcadeProgress,
-                  arcadeProgressLoading: _arcadeProgressLoading,
-                ),
-                _buildSections(
-                  sections: sections,
-                  scale: scale,
-                  panelHeightFactor: UI.panelHeightFactor,
-                ),
-              ],
+            body: _buildShellBody(
+              backgroundColor: bgColor,
+              surfaceColor: Theme.of(context).scaffoldBackgroundColor,
+              topInset: topInset,
+              hasName: hasName,
+              name: name,
+              welcomeFontSize: welcomeFontSize,
+              nameFontSize: nameFontSize,
+              sections: sections,
+              scale: scale,
+              panelHeightFactor: UI.panelHeightFactor,
             ),
           ),
         );
@@ -631,12 +619,135 @@ class _PlayScreenState extends State<PlayScreen> {
     );
   }
 
+  Widget _buildShellBody({
+    required Color backgroundColor,
+    required Color surfaceColor,
+    required double topInset,
+    required bool hasName,
+    required String? name,
+    required double welcomeFontSize,
+    required double nameFontSize,
+    required List<CategoryDefinition> sections,
+    required double scale,
+    required double panelHeightFactor,
+  }) {
+    final tabChildren = <Widget>[
+      KeyedSubtree(
+        key: const ValueKey('home_tab'),
+        child: _buildHomeTab(
+          backgroundColor: backgroundColor,
+          topInset: topInset,
+          hasName: hasName,
+          name: name,
+          welcomeFontSize: welcomeFontSize,
+          nameFontSize: nameFontSize,
+          sections: sections,
+          scale: scale,
+          panelHeightFactor: panelHeightFactor,
+        ),
+      ),
+      _buildSurfaceTab(
+        key: const ValueKey('dashboard_tab'),
+        backgroundColor: surfaceColor,
+        child: const DashboardScreen(
+          key: PageStorageKey<String>('dashboard_tab'),
+        ),
+      ),
+      _buildSurfaceTab(
+        key: const ValueKey('subjects_tab'),
+        backgroundColor: surfaceColor,
+        child: const SubjectListScreen(
+          key: PageStorageKey<String>('subject_list_tab'),
+        ),
+      ),
+      _buildSurfaceTab(
+        key: const ValueKey('history_tab'),
+        backgroundColor: surfaceColor,
+        child: const ExamHistoryScreen(
+          key: PageStorageKey<String>('history_tab'),
+        ),
+      ),
+      _buildSurfaceTab(
+        key: const ValueKey('profile_tab'),
+        backgroundColor: surfaceColor,
+        child: const ProfileEditScreen(
+          key: PageStorageKey<String>('profile_tab'),
+        ),
+      ),
+      _buildSurfaceTab(
+        key: const ValueKey('design_tab'),
+        backgroundColor: surfaceColor,
+        child: const DesignSettingsScreen(
+          key: PageStorageKey<String>('design_tab'),
+        ),
+      ),
+    ];
+
+    return IndexedStack(
+      index: _selectedNavIndex,
+      children: tabChildren,
+    );
+  }
+
+  Widget _buildHomeTab({
+    required Color backgroundColor,
+    required double topInset,
+    required bool hasName,
+    required String? name,
+    required double welcomeFontSize,
+    required double nameFontSize,
+    required List<CategoryDefinition> sections,
+    required double scale,
+    required double panelHeightFactor,
+  }) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            image: DecorationImage(image: _screenBg, fit: BoxFit.cover),
+          ),
+        ),
+        _buildHeader(
+          topInset: topInset,
+          hasName: hasName,
+          name: name,
+          welcomeFontSize: welcomeFontSize,
+          nameFontSize: nameFontSize,
+          arcadeProgress: _arcadeProgress,
+          arcadeProgressLoading: _arcadeProgressLoading,
+        ),
+        _buildSections(
+          sections: sections,
+          scale: scale,
+          panelHeightFactor: panelHeightFactor,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSurfaceTab({
+    required Key key,
+    required Color backgroundColor,
+    required Widget child,
+  }) {
+    return KeyedSubtree(
+      key: key,
+      child: ColoredBox(
+        color: backgroundColor,
+        child: child,
+      ),
+    );
+  }
+
   /// NAV BAR
   Widget _buildBottomAppBar() {
     final buttons = <Widget>[];
 
+    final notchIndex = (_navItems.length / 2).floor();
     for (var i = 0; i < _navItems.length; i++) {
-      if (i == 2) {
+      if (i == notchIndex) {
         buttons.add(const SizedBox(width: 68));
       }
       buttons.add(
@@ -672,19 +783,28 @@ class _PlayScreenState extends State<PlayScreen> {
         isSelected ? Colors.white : Colors.white.withOpacity(0.72);
 
     return Center(
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: () => _onNavItemSelected(index),
-          borderRadius: BorderRadius.circular(18),
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: isSelected ? _bottomBarHighlight : Colors.transparent,
+      child: Semantics(
+        label: item.label,
+        selected: isSelected,
+        button: true,
+        child: Material(
+          color: Colors.transparent,
+          child: Tooltip(
+            message: item.label,
+            child: InkWell(
+              onTap: () => _onNavItemSelected(index),
               borderRadius: BorderRadius.circular(18),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color:
+                      isSelected ? _bottomBarHighlight : Colors.transparent,
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: Icon(item.icon, color: foreground, size: 24),
+              ),
             ),
-            child: Icon(item.icon, color: foreground, size: 24),
           ),
         ),
       ),
@@ -1826,11 +1946,9 @@ class _PromoCarousel extends StatelessWidget {
 class _NavDestination {
   final IconData icon;
   final String label;
-  final WidgetBuilder? builder;
 
   const _NavDestination({
     required this.icon,
     required this.label,
-    this.builder,
   });
 }

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -402,52 +402,66 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Modifier le profil')),
-      body: Padding(
+    return SafeArea(
+      child: Padding(
         padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: ListView(
-            children: [
-              Center(
-                child: InkWell(
-                  onTap: _pickImage,
-                  child: _buildAvatarCircle(),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Modifier le profil',
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: Form(
+                key: _formKey,
+                child: ListView(
+                  children: [
+                    Center(
+                      child: InkWell(
+                        onTap: _pickImage,
+                        child: _buildAvatarCircle(),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    TextFormField(
+                      controller: _firstNameController,
+                      decoration: const InputDecoration(labelText: 'Prénom'),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _lastNameController,
+                      decoration: const InputDecoration(labelText: 'Nom'),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _pseudoController,
+                      decoration: const InputDecoration(labelText: 'Pseudonyme'),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _professionController,
+                      decoration: const InputDecoration(labelText: 'Profession'),
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: _save,
+                      child: const Text('Enregistrer'),
+                    ),
+                    const SizedBox(height: 12),
+                    TextButton(
+                      onPressed: _showChangePasswordDialog,
+                      child: const Text('Changer le mot de passe'),
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(height: 24),
-              TextFormField(
-                controller: _firstNameController,
-                decoration: const InputDecoration(labelText: 'Prénom'),
-              ),
-              const SizedBox(height: 12),
-              TextFormField(
-                controller: _lastNameController,
-                decoration: const InputDecoration(labelText: 'Nom'),
-              ),
-              const SizedBox(height: 12),
-              TextFormField(
-                controller: _pseudoController,
-                decoration: const InputDecoration(labelText: 'Pseudonyme'),
-              ),
-              const SizedBox(height: 12),
-              TextFormField(
-                controller: _professionController,
-                decoration: const InputDecoration(labelText: 'Profession'),
-              ),
-              const SizedBox(height: 24),
-              ElevatedButton(
-                onPressed: _save,
-                child: const Text('Enregistrer'),
-              ),
-              const SizedBox(height: 12),
-              TextButton(
-                onPressed: _showChangePasswordDialog,
-                child: const Text('Changer le mot de passe'),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -24,59 +24,65 @@ class SubjectListScreen extends StatelessWidget {
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
         final mediaQuery = MediaQuery.of(context);
         final scale = computeScaleFactor(mediaQuery);
-        return Scaffold(
-          extendBody: true,
-          extendBodyBehindAppBar: true,
-          backgroundColor: Colors.transparent,
-          appBar: AppBar(
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            foregroundColor: textColor,
-            title: const Text('Modules ENA'),
-          ),
-          body: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: GridView.builder(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 2,
-                  crossAxisSpacing: 14,
-                  mainAxisSpacing: 14,
-                  childAspectRatio: 1.05,
+
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Modules ENA',
+                  style: Theme.of(context)
+                      .textTheme
+                      .headlineSmall
+                      ?.copyWith(color: textColor, fontWeight: FontWeight.w700),
                 ),
-                itemCount: subjectsENA.length,
-                itemBuilder: (context, index) {
-                  final subject = subjectsENA[index];
-                  final item = _subjectItems[index];
-                  return GlassTile(
-                    title: subject.name,
-                    icon: item.icon,
-                    gradientColors: item.gradientColors,
-                    blur: cfg.glassBlur,
-                    bgOpacity: cfg.glassBgOpacity,
-                    borderOpacity: cfg.glassBorderOpacity,
-                    iconSize: cfg.tileIconSize,
-                    scaleFactor: scale,
-                    centerContent: cfg.tileCenter,
-                    useMono: cfg.useMono,
-                    monoColor: cfg.monoColor,
-                    textColor: textColor,
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => ChapterListScreen(
-                            subjectName: subject.name,
-                            chapterName: subject.chapters.isNotEmpty
-                                ? subject.chapters.first.name
-                                : '',
-                          ),
-                        ),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: GridView.builder(
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      crossAxisSpacing: 14,
+                      mainAxisSpacing: 14,
+                      childAspectRatio: 1.05,
+                    ),
+                    itemCount: subjectsENA.length,
+                    itemBuilder: (context, index) {
+                      final subject = subjectsENA[index];
+                      final item = _subjectItems[index];
+                      return GlassTile(
+                        title: subject.name,
+                        icon: item.icon,
+                        gradientColors: item.gradientColors,
+                        blur: cfg.glassBlur,
+                        bgOpacity: cfg.glassBgOpacity,
+                        borderOpacity: cfg.glassBorderOpacity,
+                        iconSize: cfg.tileIconSize,
+                        scaleFactor: scale,
+                        centerContent: cfg.tileCenter,
+                        useMono: cfg.useMono,
+                        monoColor: cfg.monoColor,
+                        textColor: textColor,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => ChapterListScreen(
+                                subjectName: subject.name,
+                                chapterName: subject.chapters.isNotEmpty
+                                    ? subject.chapters.first.name
+                                    : '',
+                              ),
+                            ),
+                          );
+                        },
                       );
                     },
-                  );
-                },
-              ),
+                  ),
+                ),
+              ],
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- replace the `PlayScreen` state with a new `HomeShell` that keeps the bottom bar scaffold and swaps tab contents with an `IndexedStack`
- embed the dashboard, subjects, history, profile and design settings pages directly inside the shell and add a dedicated home tab
- rewrite each embedded screen to render without its own Scaffold so it can live inside the shell panel

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9eee1fa24832f8dba1e746aaf715d