### PR TITLE
Create Play-themed scaffold for dashboard sections

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -16,6 +16,7 @@ import '../models/user_profile.dart';
 import 'profile_edit_screen.dart';
 import '../utils/arcade_level_utils.dart';
 import '../widgets/arcade_badge_chip.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -238,7 +239,10 @@ class _DashboardScreenState extends State<DashboardScreen> {
     final rankText = rank != null ? '$rank' : 'Non renseigné';
     final badgeLabel = normalizeArcadeLevel(profile?.arcadeLevel ?? entry?.arcadeLevel);
 
-    return Scaffold(
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      safeAreaTop: true,
+      bodyPadding: const EdgeInsets.fromLTRB(16, kToolbarHeight + 16, 16, 24),
       appBar: AppBar(
         title: const Text('Mon dashboard'),
         actions: [
@@ -255,7 +259,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : ListView(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.only(bottom: 16),
               children: [
                 Image.asset('assets/images/logo_splash.png', height: 150),
                 const SizedBox(height: 24),

--- a/lib/screens/exam_history_screen.dart
+++ b/lib/screens/exam_history_screen.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import '../models/exam_history_entry.dart';
-import '../models/design_config.dart';
-import '../services/design_bus.dart';
 import '../services/history_store.dart';
 import '../services/local_history_persistence.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 class ExamHistoryScreen extends StatefulWidget {
   const ExamHistoryScreen({super.key});
@@ -72,31 +71,32 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<DesignConfig>(
-      valueListenable: DesignBus.notifier,
-      builder: (context, cfg, _) {
-        final theme = Theme.of(context);
-        final cs = theme.colorScheme;
-        final textTheme = theme.textTheme;
-        return Scaffold(
-          backgroundColor: Colors.transparent,
-          appBar: AppBar(
-            title: const Text('Historique des examens'),
-            actions: [
-              if (_items.isNotEmpty)
-                IconButton(
-                  onPressed: _clearAll,
-                  icon: const Icon(Icons.delete_forever),
-                  tooltip: 'Effacer l’historique',
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final textTheme = theme.textTheme;
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      safeAreaTop: true,
+      bodyPadding: const EdgeInsets.fromLTRB(16, kToolbarHeight + 16, 16, 24),
+      appBar: AppBar(
+        title: const Text('Historique des examens'),
+        actions: [
+          if (_items.isNotEmpty)
+            IconButton(
+              onPressed: _clearAll,
+              icon: const Icon(Icons.delete_forever),
+              tooltip: 'Effacer l’historique',
+            )
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _items.isEmpty
+              ? const Center(
+                  child: Text('Aucun examen enregistré pour le moment.'),
                 )
-            ],
-          ),
-          body: _loading
-              ? const Center(child: CircularProgressIndicator())
-              : _items.isEmpty
-                  ? const Center(
-                      child: Text('Aucun examen enregistré pour le moment.'))
-                  : ListView.builder(
+              : ListView.builder(
+                  padding: const EdgeInsets.only(bottom: 16),
                   itemCount: _items.length,
                   itemBuilder: (context, i) {
                     final e = _items[i];
@@ -120,7 +120,9 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
 
                     return Card(
                       margin: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 6),
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
                       child: Padding(
                         padding: const EdgeInsets.all(12),
                         child: Column(
@@ -206,8 +208,6 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
                     );
                   },
                 ),
-        );
-      },
     );
   }
 }

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -4,6 +4,7 @@ import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
 import '../utils/arcade_level_utils.dart';
 import '../widgets/arcade_badge_chip.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 class LeaderboardScreen extends StatefulWidget {
   const LeaderboardScreen({super.key});
@@ -41,68 +42,86 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   @override
   Widget build(BuildContext context) {
     final filtered = _filtered;
-    return Scaffold(
-      appBar: AppBar(title: const Text('Classement'), actions:[
-        IconButton(icon: const Icon(Icons.refresh), onPressed: _load),
-      ]),
-      body: Column(children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(12,12,12,6),
-          child: Row(children: [
-            Expanded(child: TextField(
-              decoration: const InputDecoration(
-                isDense: true,
-                prefixIcon: Icon(Icons.search),
-                hintText: 'Nom / matière',
-                border: OutlineInputBorder(borderRadius: BorderRadius.zero),
-              ),
-              onChanged: (v)=>setState(()=>_query=v),
-            )),
-            const SizedBox(width:12),
-          ]),
-        ),
-        const Divider(height:1),
-        Expanded(child: filtered.isEmpty
-          ? const Center(child: Text('Aucune entrée pour l’instant'))
-          : ListView.separated(
-              itemCount: filtered.length,
-              separatorBuilder: (_, __) => const Divider(height: 1),
-              itemBuilder: (context, i) {
-                final e = filtered[i]; final rank = i+1;
-                final badgeLabel = normalizeArcadeLevel(e.arcadeLevel);
-                return ListTile(
-                  leading: _RankAvatar(rank: rank),
-                  title: Row(
-                    children: [
-                      ArcadeBadgeChip(label: badgeLabel, compact: true),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          e.name,
-                          style: Theme.of(context).textTheme.titleMedium,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ],
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      safeAreaTop: true,
+      bodyPadding: const EdgeInsets.fromLTRB(16, kToolbarHeight + 16, 16, 24),
+      appBar: AppBar(
+        title: const Text('Classement'),
+        actions: [
+          IconButton(icon: const Icon(Icons.refresh), onPressed: _load),
+        ],
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    decoration: const InputDecoration(
+                      isDense: true,
+                      prefixIcon: Icon(Icons.search),
+                      hintText: 'Nom / matière',
+                      border: OutlineInputBorder(borderRadius: BorderRadius.zero),
+                    ),
+                    onChanged: (v) => setState(() => _query = v),
                   ),
-                  subtitle: Text(
-                    'Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}',
-                  ),
-                  isThreeLine: true,
-                  trailing: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Text('${e.percent.toStringAsFixed(1)} %', style: const TextStyle(fontWeight: FontWeight.w800)),
-                      const SizedBox(height: 2),
-                      Text('${e.correct}/${e.total} • ${_fmtDuration(e.durationSec)}'),
-                    ],
-                  ),
-                );
-              },
+                ),
+                const SizedBox(width: 12),
+              ],
             ),
-        ),
-      ]),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: filtered.isEmpty
+                ? const Center(child: Text('Aucune entrée pour l’instant'))
+                : ListView.separated(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    itemCount: filtered.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, i) {
+                      final e = filtered[i];
+                      final rank = i + 1;
+                      final badgeLabel = normalizeArcadeLevel(e.arcadeLevel);
+                      return ListTile(
+                        leading: _RankAvatar(rank: rank),
+                        title: Row(
+                          children: [
+                            ArcadeBadgeChip(label: badgeLabel, compact: true),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                e.name,
+                                style: Theme.of(context).textTheme.titleMedium,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                        subtitle: Text(
+                          'Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}',
+                        ),
+                        isThreeLine: true,
+                        trailing: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Text(
+                              '${e.percent.toStringAsFixed(1)} %',
+                              style: const TextStyle(fontWeight: FontWeight.w800),
+                            ),
+                            const SizedBox(height: 2),
+                            Text('${e.correct}/${e.total} • ${_fmtDuration(e.durationSec)}'),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -5,6 +5,7 @@ import '../services/design_bus.dart';
 import '../utils/palette_utils.dart';
 import '../widgets/glass_tile.dart';
 import '../utils/responsive_utils.dart';
+import '../widgets/play_themed_scaffold.dart';
 import 'chapter_list_screen.dart';
 
 /// Liste des matières ENA
@@ -17,70 +18,63 @@ class SubjectListScreen extends StatelessWidget {
       subjectsENA.length == _subjectItems.length,
       'subjectsENA and _subjectItems should have the same length',
     );
-    return ValueListenableBuilder<DesignConfig>(
-      valueListenable: DesignBus.notifier,
-      builder: (context, cfg, _) {
-        final textColor =
-            textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
-        final mediaQuery = MediaQuery.of(context);
-        final scale = computeScaleFactor(mediaQuery);
-        return Scaffold(
-          extendBody: true,
-          extendBodyBehindAppBar: true,
-          backgroundColor: Colors.transparent,
-          appBar: AppBar(
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            foregroundColor: textColor,
-            title: const Text('Modules ENA'),
-          ),
-          body: SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: GridView.builder(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 2,
-                  crossAxisSpacing: 14,
-                  mainAxisSpacing: 14,
-                  childAspectRatio: 1.05,
-                ),
-                itemCount: subjectsENA.length,
-                itemBuilder: (context, index) {
-                  final subject = subjectsENA[index];
-                  final item = _subjectItems[index];
-                  return GlassTile(
-                    title: subject.name,
-                    icon: item.icon,
-                    gradientColors: item.gradientColors,
-                    blur: cfg.glassBlur,
-                    bgOpacity: cfg.glassBgOpacity,
-                    borderOpacity: cfg.glassBorderOpacity,
-                    iconSize: cfg.tileIconSize,
-                    scaleFactor: scale,
-                    centerContent: cfg.tileCenter,
-                    useMono: cfg.useMono,
-                    monoColor: cfg.monoColor,
-                    textColor: textColor,
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => ChapterListScreen(
-                            subjectName: subject.name,
-                            chapterName: subject.chapters.isNotEmpty
-                                ? subject.chapters.first.name
-                                : '',
-                          ),
-                        ),
-                      );
-                    },
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      safeAreaTop: true,
+      bodyPadding: const EdgeInsets.fromLTRB(16, kToolbarHeight + 16, 16, 24),
+      appBar: AppBar(
+        title: const Text('Modules ENA'),
+      ),
+      body: ValueListenableBuilder<DesignConfig>(
+        valueListenable: DesignBus.notifier,
+        builder: (context, cfg, _) {
+          final textColor =
+              textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
+          final mediaQuery = MediaQuery.of(context);
+          final scale = computeScaleFactor(mediaQuery);
+          return GridView.builder(
+            padding: EdgeInsets.zero,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 14,
+              mainAxisSpacing: 14,
+              childAspectRatio: 1.05,
+            ),
+            itemCount: subjectsENA.length,
+            itemBuilder: (context, index) {
+              final subject = subjectsENA[index];
+              final item = _subjectItems[index];
+              return GlassTile(
+                title: subject.name,
+                icon: item.icon,
+                gradientColors: item.gradientColors,
+                blur: cfg.glassBlur,
+                bgOpacity: cfg.glassBgOpacity,
+                borderOpacity: cfg.glassBorderOpacity,
+                iconSize: cfg.tileIconSize,
+                scaleFactor: scale,
+                centerContent: cfg.tileCenter,
+                useMono: cfg.useMono,
+                monoColor: cfg.monoColor,
+                textColor: textColor,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ChapterListScreen(
+                        subjectName: subject.name,
+                        chapterName: subject.chapters.isNotEmpty
+                            ? subject.chapters.first.name
+                            : '',
+                      ),
+                    ),
                   );
                 },
-              ),
-            ),
-          ),
-        );
-      },
+              );
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/widgets/play_themed_scaffold.dart
+++ b/lib/widgets/play_themed_scaffold.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
+
+enum PlayThemedScaffoldBodyMode {
+  plain,
+  panel,
+}
+
+class PlayThemedScaffold extends StatelessWidget {
+  const PlayThemedScaffold({
+    super.key,
+    this.appBar,
+    required this.body,
+    this.floatingActionButton,
+    this.floatingActionButtonLocation,
+    this.bottomNavigationBar,
+    this.bodyMode = PlayThemedScaffoldBodyMode.plain,
+    this.bodyPadding,
+    this.safeAreaTop,
+    this.safeAreaBottom = true,
+    this.panelHeightFactor = 1.0,
+    this.panelBorderRadius =
+        const BorderRadius.only(topLeft: Radius.circular(22), topRight: Radius.circular(22)),
+    this.panelOverlayColor,
+    this.extendBodyBehindAppBar = true,
+  }) : assert(panelHeightFactor > 0 && panelHeightFactor <= 1.0,
+            'panelHeightFactor must be between 0 (exclusive) and 1 (inclusive).');
+
+  final PreferredSizeWidget? appBar;
+  final Widget body;
+  final Widget? floatingActionButton;
+  final FloatingActionButtonLocation? floatingActionButtonLocation;
+  final Widget? bottomNavigationBar;
+  final PlayThemedScaffoldBodyMode bodyMode;
+  final EdgeInsetsGeometry? bodyPadding;
+  final bool? safeAreaTop;
+  final bool safeAreaBottom;
+  final double panelHeightFactor;
+  final BorderRadius panelBorderRadius;
+  final Color? panelOverlayColor;
+  final bool extendBodyBehindAppBar;
+
+  static const AssetImage _screenBg = AssetImage('assets/images/background_playscreen.png');
+  static const AssetImage _panelBg = AssetImage('assets/images/background_playscreen2.png');
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final textColor =
+            textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
+        final bgColor =
+            pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode).first;
+        final overlayStyle = cfg.darkMode
+            ? SystemUiOverlayStyle.light.copyWith(
+                statusBarColor: Colors.transparent,
+                systemNavigationBarColor: Colors.transparent,
+              )
+            : SystemUiOverlayStyle.dark.copyWith(
+                statusBarColor: Colors.transparent,
+                systemNavigationBarColor: Colors.transparent,
+              );
+
+        final theme = Theme.of(context);
+        final themedData = theme.copyWith(
+          scaffoldBackgroundColor: Colors.transparent,
+          appBarTheme: theme.appBarTheme.copyWith(
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            foregroundColor: textColor,
+          ),
+        );
+
+        final resolvedSafeAreaTop = safeAreaTop ??
+            (bodyMode == PlayThemedScaffoldBodyMode.plain);
+
+        Widget bodyContent = body;
+        if (bodyPadding != null) {
+          bodyContent = Padding(padding: bodyPadding!, child: bodyContent);
+        }
+
+        switch (bodyMode) {
+          case PlayThemedScaffoldBodyMode.plain:
+            if (resolvedSafeAreaTop || safeAreaBottom) {
+              bodyContent = SafeArea(
+                top: resolvedSafeAreaTop,
+                bottom: safeAreaBottom,
+                left: true,
+                right: true,
+                child: bodyContent,
+              );
+            }
+            break;
+          case PlayThemedScaffoldBodyMode.panel:
+            bodyContent = SafeArea(
+              top: resolvedSafeAreaTop,
+              bottom: safeAreaBottom,
+              left: true,
+              right: true,
+              child: bodyContent,
+            );
+            final double heightFactor = panelHeightFactor.clamp(0.0, 1.0) as double;
+            bodyContent = Align(
+              alignment: Alignment.bottomCenter,
+              child: FractionallySizedBox(
+                heightFactor: heightFactor,
+                widthFactor: 1,
+                child: ClipRRect(
+                  borderRadius: panelBorderRadius,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      const DecoratedBox(
+                        decoration: BoxDecoration(
+                          image: DecorationImage(
+                            image: _panelBg,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      ),
+                      Container(
+                        color: panelOverlayColor ?? Colors.white.withOpacity(0.04),
+                      ),
+                      bodyContent,
+                    ],
+                  ),
+                ),
+              ),
+            );
+            break;
+        }
+
+        return AnnotatedRegion<SystemUiOverlayStyle>(
+          value: overlayStyle,
+          child: Theme(
+            data: themedData,
+            child: Scaffold(
+              extendBody: true,
+              extendBodyBehindAppBar: extendBodyBehindAppBar,
+              backgroundColor: Colors.transparent,
+              appBar: appBar,
+              body: Stack(
+                fit: StackFit.expand,
+                children: [
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: bgColor,
+                      image: const DecorationImage(
+                        image: _screenBg,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                  bodyContent,
+                ],
+              ),
+              floatingActionButton: floatingActionButton,
+              floatingActionButtonLocation: floatingActionButtonLocation,
+              bottomNavigationBar: bottomNavigationBar,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `PlayThemedScaffold` widget that reproduces the play screen background and optional panel layout
- migrate dashboard, subject list, exam history, and leaderboard screens to the new shell with adjusted padding and safe areas

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d9eee00a98832f8f63a1c264875897