### PR TITLE
Update ArcadeBadgeChip to display level icon and number

### DIFF
--- a/lib/widgets/arcade_badge_chip.dart
+++ b/lib/widgets/arcade_badge_chip.dart
@@ -20,9 +20,22 @@ class ArcadeBadgeChip extends StatelessWidget {
       fontWeight: FontWeight.w600,
       fontSize: compact ? 12 : null,
     );
+    final levelMatch = RegExp(r'\d+').firstMatch(label);
+    final hasLevelNumber = levelMatch != null;
+
+    final labelWidget = hasLevelNumber
+        ? Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.stars, size: iconSize, color: foreground),
+              const SizedBox(width: 4),
+              Text(levelMatch!.group(0)!, style: textStyle),
+            ],
+          )
+        : Text(label, style: textStyle);
+
     return Chip(
-      avatar: Icon(Icons.stars, size: iconSize, color: foreground),
-      label: Text(label, style: textStyle),
+      label: labelWidget,
       backgroundColor: background,
       side: BorderSide(color: colorScheme.primary.withOpacity(0.4)),
       padding: padding,


### PR DESCRIPTION
## Summary
- extract the level number from the badge label using a regular expression
- render the chip label as an icon and number combination, falling back to the original label if no number is found

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da9c1b43f0832f9578126f2b49dcb5