### PR TITLE
Update play screen leaderboard avatar

### DIFF
--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
 import '../utils/arcade_level_utils.dart';
+import '../utils/rank_display_helper.dart';
 import '../widgets/arcade_badge_chip.dart';
 import '../widgets/play_themed_scaffold.dart';
 
@@ -134,14 +135,20 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
 }
 
 class _RankAvatar extends StatelessWidget {
-  final int rank; const _RankAvatar({required this.rank});
-  @override Widget build(BuildContext context){
-    final isTop3 = rank<=3; Color bg; IconData icon;
-    switch(rank){case 1: bg=const Color(0xFFFFD700); icon=Icons.emoji_events; break;
-                  case 2: bg=const Color(0xFFC0C0C0); icon=Icons.emoji_events; break;
-                  case 3: bg=const Color(0xFFCD7F32); icon=Icons.emoji_events; break;
-                  default: bg=Colors.blueGrey.shade100; icon=Icons.person;}
-    return CircleAvatar(backgroundColor: bg,
-      child: isTop3? Icon(icon, color: Colors.black87) : Text('$rank', style: const TextStyle(color: Colors.black87)));
+  final int rank;
+  const _RankAvatar({required this.rank});
+  @override
+  Widget build(BuildContext context) {
+    final style = rankDisplayStyleFor(rank);
+    final hasIcon = style.icon != null;
+    return CircleAvatar(
+      backgroundColor: style.backgroundColor,
+      child: hasIcon
+          ? Icon(style.icon, color: style.foregroundColor)
+          : Text(
+              '$rank',
+              style: TextStyle(color: style.foregroundColor),
+            ),
+    );
   }
 }

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -18,6 +18,7 @@ import '../services/competition_service.dart';
 import '../services/competition_quiz_launcher.dart';
 import '../services/arcade_progress_store.dart';
 import '../utils/palette_utils.dart';
+import '../utils/rank_display_helper.dart';
 import '../utils/responsive_utils.dart';
 
 import '../widgets/arcade_badge_chip.dart';
@@ -212,6 +213,8 @@ class _HomeShellState extends State<HomeShell> {
   List<LeaderboardEntry> _topEntries = const [];
   bool _topEntriesLoading = true;
   String? _topEntriesError;
+  LeaderboardEntry? _currentUserEntry;
+  int? _currentUserRank;
 
   final ArcadeProgressStore _arcadeProgressStore = ArcadeProgressStore();
   ArcadeProgressData? _arcadeProgress;
@@ -339,14 +342,32 @@ class _HomeShellState extends State<HomeShell> {
     setState(() {
       _topEntriesLoading = true;
       _topEntriesError = null;
+      _currentUserEntry = null;
+      _currentUserRank = null;
     });
     try {
-      final entries = await _competitionService.topEntries(limit: 3);
+      final entries = await _competitionService.topEntries(limit: 1000);
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      LeaderboardEntry? currentEntry;
+      int? currentRank;
+
+      if (uid != null) {
+        final index = entries.indexWhere((e) => e.userId == uid);
+        if (index >= 0) {
+          currentEntry = entries[index];
+          currentRank = index + 1;
+        } else {
+          currentEntry = await _competitionService.entryForUser(uid);
+        }
+      }
+
       if (!mounted) {
         return;
       }
       setState(() {
-        _topEntries = entries;
+        _topEntries = entries.take(3).toList();
+        _currentUserEntry = currentEntry;
+        _currentUserRank = currentRank;
         _topEntriesLoading = false;
       });
     } catch (e) {
@@ -355,6 +376,8 @@ class _HomeShellState extends State<HomeShell> {
       }
       setState(() {
         _topEntries = const [];
+        _currentUserEntry = null;
+        _currentUserRank = null;
         _topEntriesLoading = false;
         _topEntriesError = "Impossible de récupérer le classement.";
       });
@@ -833,9 +856,13 @@ class _HomeShellState extends State<HomeShell> {
     required ArcadeProgressData? arcadeProgress,
     required bool arcadeProgressLoading,
   }) {
+    final entryName = _currentUserEntry?.name.trim();
+    final fallbackName = entryName != null && entryName.isNotEmpty
+        ? entryName
+        : 'Utilisateur';
     final displayName = hasName && (name?.trim().isNotEmpty ?? false)
         ? name!.trim()
-        : 'Utilisateur';
+        : fallbackName;
     final avatarLabel = displayName.isNotEmpty
         ? displayName.characters.first.toUpperCase()
         : '?';
@@ -848,6 +875,9 @@ class _HomeShellState extends State<HomeShell> {
             ? Icons.wb_sunny_rounded
             : Icons.nights_stay_rounded;
         final formattedDate = _formatDateTime(now);
+        final int? rank = _currentUserRank;
+        final RankDisplayStyle? rankStyle =
+            rank != null ? rankDisplayStyleFor(rank) : null;
 
         return Align(
           alignment: Alignment.topCenter,
@@ -942,15 +972,25 @@ class _HomeShellState extends State<HomeShell> {
                   backgroundColor: Colors.white.withOpacity(0.2),
                   child: CircleAvatar(
                     radius: 24,
-                    backgroundColor: Colors.white,
-                    child: Text(
-                      avatarLabel,
-                      style: const TextStyle(
-                        color: Color(0xFF6C4DFF),
-                        fontWeight: FontWeight.w700,
-                        fontSize: 20,
-                      ),
-                    ),
+                    backgroundColor:
+                        rankStyle?.backgroundColor ?? Colors.white,
+                    child: rank != null && rankStyle != null
+                        ? Text(
+                            '$rank',
+                            style: TextStyle(
+                              color: rankStyle.foregroundColor,
+                              fontWeight: FontWeight.w700,
+                              fontSize: 20,
+                            ),
+                          )
+                        : Text(
+                            avatarLabel,
+                            style: const TextStyle(
+                              color: Color(0xFF6C4DFF),
+                              fontWeight: FontWeight.w700,
+                              fontSize: 20,
+                            ),
+                          ),
                   ),
                 ),
               ],

--- a/lib/utils/rank_display_helper.dart
+++ b/lib/utils/rank_display_helper.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class RankDisplayStyle {
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final IconData? icon;
+
+  const RankDisplayStyle({
+    required this.backgroundColor,
+    required this.foregroundColor,
+    this.icon,
+  });
+}
+
+const Color _kGoldColor = Color(0xFFFFD700);
+const Color _kSilverColor = Color(0xFFC0C0C0);
+const Color _kBronzeColor = Color(0xFFCD7F32);
+const Color _kDefaultBackground = Color(0xFFCFD8DC);
+const Color _kDefaultForeground = Color(0xDD000000);
+
+RankDisplayStyle rankDisplayStyleFor(int rank) {
+  switch (rank) {
+    case 1:
+      return const RankDisplayStyle(
+        backgroundColor: _kGoldColor,
+        foregroundColor: _kDefaultForeground,
+        icon: Icons.emoji_events,
+      );
+    case 2:
+      return const RankDisplayStyle(
+        backgroundColor: _kSilverColor,
+        foregroundColor: _kDefaultForeground,
+        icon: Icons.emoji_events,
+      );
+    case 3:
+      return const RankDisplayStyle(
+        backgroundColor: _kBronzeColor,
+        foregroundColor: _kDefaultForeground,
+        icon: Icons.emoji_events,
+      );
+    default:
+      return const RankDisplayStyle(
+        backgroundColor: _kDefaultBackground,
+        foregroundColor: _kDefaultForeground,
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared helper that maps leaderboard ranks to colors and icons
- load enough competition entries on the play screen to capture the signed-in user and show their rank in the header avatar
- reuse the helper in the leaderboard screen and keep the top-card list trimmed to the leading entries

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da9c197738832f97d6d0afbe2c295d