### PR TITLE
Adopt PlayThemedScaffold styling on account and history screens

### DIFF
--- a/lib/screens/exam_history_screen.dart
+++ b/lib/screens/exam_history_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import '../models/exam_history_entry.dart';
 import '../services/history_store.dart';
 import '../services/local_history_persistence.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 class ExamHistoryScreen extends StatefulWidget {
   const ExamHistoryScreen({super.key});
@@ -157,7 +158,10 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
 
-    return Scaffold(
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      safeAreaTop: true,
+      bodyPadding: const EdgeInsets.fromLTRB(24, kToolbarHeight + 24, 24, 24),
       appBar: AppBar(
         title: const Text('Historique — Examens'),
         actions: [
@@ -188,19 +192,25 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
                 )
               : RefreshIndicator(
                   onRefresh: _load,
-                  child: ListView.builder(
+                  child: ListView.separated(
                     physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.only(bottom: 16),
                     itemCount: _items.length,
+                    separatorBuilder: (_, __) => const SizedBox(height: 16),
                     itemBuilder: (context, index) {
                       final entry = _items[index];
-              final status = _statusFor(entry);
+                      final status = _statusFor(entry);
                       final weakSubjects = entry.weakSubjects();
                       final ratio = entry.overallSuccessRatio();
                       return Card(
-                        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                        elevation: 2,
+                        margin: EdgeInsets.zero,
+                        elevation: 4,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                        clipBehavior: Clip.antiAlias,
                         child: Padding(
-                          padding: const EdgeInsets.all(16),
+                          padding: const EdgeInsets.all(20),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
@@ -245,12 +255,12 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
                                 ],
                               ),
                               if (weakSubjects.isNotEmpty) ...[
-                                const SizedBox(height: 8),
+                                const SizedBox(height: 12),
                                 Text(
                                   'Points à renforcer',
                                   style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700),
                                 ),
-                                const SizedBox(height: 4),
+                                const SizedBox(height: 6),
                                 Wrap(
                                   spacing: 8,
                                   runSpacing: 4,
@@ -263,6 +273,7 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
                                   ],
                                 ),
                               ],
+                              const SizedBox(height: 12),
                               _buildSubjectBreakdown(entry, textTheme),
                             ],
                           ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -7,8 +7,8 @@ import '../models/user_profile.dart';
 import '../services/auth_service.dart';
 import '../services/user_profile_service.dart';
 import '../services/design_bus.dart';
-import '../utils/palette_utils.dart';
 import '../widgets/primary_button.dart';
+import '../widgets/play_themed_scaffold.dart';
 import 'play_screen.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -73,165 +73,187 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return ValueListenableBuilder<DesignConfig>(
       valueListenable: DesignBus.notifier,
-      builder: (context, cfg, _) {
+      builder: (context, _, __) {
         final theme = Theme.of(context);
         final errorStyle = TextStyle(color: theme.colorScheme.error);
         final isBusy = _isLoading || _isGoogleLoading;
         final loginButtonTheme = ElevatedButtonThemeData(
           style: _loginButtonStyle(theme),
         );
-        final textColor =
-            textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
-        return Scaffold(
-          backgroundColor: Colors.transparent,
+        return PlayThemedScaffold(
+          bodyMode: PlayThemedScaffoldBodyMode.panel,
+          safeAreaTop: true,
+          bodyPadding: const EdgeInsets.fromLTRB(24, kToolbarHeight + 24, 24, 24),
           appBar: AppBar(
-            backgroundColor: Colors.transparent,
-            elevation: 0,
-            scrolledUnderElevation: 0,
-            surfaceTintColor: Colors.transparent,
-            foregroundColor: textColor,
             title: Text(_isLogin ? 'Se connecter' : "Créer un compte"),
           ),
           body: Center(
             child: SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: Form(
-                key: _formKey,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                      Image.asset(
-                        'assets/images/logo_splash.png',
-                        height: 180,
-                        fit: BoxFit.contain,
-                      ),
-                      const SizedBox(height: 24),
-                      TextFormField(
-                        controller: _emailController,
-                        keyboardType: TextInputType.emailAddress,
-                        autofillHints: const [AutofillHints.email],
-                        decoration: const InputDecoration(labelText: 'Email'),
-                        validator: (value) {
-                          if (value == null || value.trim().isEmpty) {
-                            return 'Email requis';
-                          }
-                          final email = value.trim();
-                          final emailRegex = RegExp(r'^[^@]+@[^@]+[.][^@]+$');
-                          if (!emailRegex.hasMatch(email)) {
-                            return 'Email invalide';
-                          }
-                          return null;
-                        },
-                      ),
-                      const SizedBox(height: 16),
-                      if (!_isLogin)
-                        ...[
-                          TextFormField(
-                            controller: _nameController,
-                            decoration: const InputDecoration(labelText: 'Nom'),
-                            validator: (value) {
-                              if (!_isLogin &&
-                                  (value == null || value.trim().isEmpty)) {
-                                return 'Nom requis';
-                              }
-                              return null;
-                            },
-                          ),
-                          const SizedBox(height: 16),
-                        ],
-                      TextFormField(
-                        controller: _passwordController,
-                        decoration:
-                            const InputDecoration(labelText: 'Mot de passe'),
-                        keyboardType: TextInputType.visiblePassword,
-                        autocorrect: false,
-                        enableSuggestions: false,
-                        obscureText: true,
-                        validator: (value) {
-                          final pwd = value?.trim() ?? '';
-                          if (pwd.isEmpty) {
-                            return 'Mot de passe requis';
-                          }
-                          if (pwd.length < 6) {
-                            return 'Le mot de passe doit contenir au moins 6 caractères';
-                          }
-                          final hasLetter = RegExp(r'[A-Za-z]').hasMatch(pwd);
-                          final hasDigit = RegExp(r'\d').hasMatch(pwd);
-                          if (!hasLetter || !hasDigit) {
-                            return 'Le mot de passe doit contenir des lettres et des chiffres';
-                          }
-                          return null;
-                        },
-                      ),
-                      const SizedBox(height: 12),
-                      if (_error != null)
-                        Text(_error!, style: errorStyle),
-                      const SizedBox(height: 12),
-                      Theme(
-                        data: theme.copyWith(
-                          elevatedButtonTheme: loginButtonTheme,
-                        ),
-                        child: PrimaryButton(
-                          onPressed: isBusy ? null : _submit,
-                          child: _isLoading
-                              ? const SizedBox(
-                                  width: 24,
-                                  height: 24,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2,
-                                  ),
-                                )
-                              : Text(_isLogin ? 'Connexion' : 'Inscription'),
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      ElevatedButton.icon(
-                        onPressed: isBusy ? null : _signInWithGoogle,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF4285F4),
-                          foregroundColor: Colors.white,
-                          minimumSize: const Size.fromHeight(56),
-                          shape: const RoundedRectangleBorder(
-                            borderRadius: BorderRadius.zero,
-                          ),
-                        ),
-                        icon: _isGoogleLoading
-                            ? const SizedBox(
-                                width: 24,
-                                height: 24,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  valueColor:
-                                      AlwaysStoppedAnimation<Color>(Colors.white),
-                                ),
-                              )
-                            : const Icon(
-                                FontAwesomeIcons.google,
-                                size: 24,
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 520),
+                  child: Card(
+                    margin: EdgeInsets.zero,
+                    elevation: 6,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    clipBehavior: Clip.antiAlias,
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Form(
+                        key: _formKey,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Center(
+                              child: Image.asset(
+                                'assets/images/logo_splash.png',
+                                height: 160,
+                                fit: BoxFit.contain,
                               ),
-                        label: const Text('Se connecter avec Google'),
-                      ),
-                      const SizedBox(height: 12),
-                      if (_unverifiedUser != null)
-                        TextButton(
-                          onPressed: _resendVerificationEmail,
-                          child:
-                              const Text('Renvoyer l\'email de vérification'),
+                            ),
+                            const SizedBox(height: 24),
+                            TextFormField(
+                              controller: _emailController,
+                              keyboardType: TextInputType.emailAddress,
+                              autofillHints: const [AutofillHints.email],
+                              decoration: const InputDecoration(labelText: 'Email'),
+                              validator: (value) {
+                                if (value == null || value.trim().isEmpty) {
+                                  return 'Email requis';
+                                }
+                                final email = value.trim();
+                                final emailRegex = RegExp(r'^[^@]+@[^@]+[.][^@]+$');
+                                if (!emailRegex.hasMatch(email)) {
+                                  return 'Email invalide';
+                                }
+                                return null;
+                              },
+                            ),
+                            const SizedBox(height: 16),
+                            if (!_isLogin) ...[
+                              TextFormField(
+                                controller: _nameController,
+                                decoration: const InputDecoration(labelText: 'Nom'),
+                                validator: (value) {
+                                  if (!_isLogin &&
+                                      (value == null || value.trim().isEmpty)) {
+                                    return 'Nom requis';
+                                  }
+                                  return null;
+                                },
+                              ),
+                              const SizedBox(height: 16),
+                            ],
+                            TextFormField(
+                              controller: _passwordController,
+                              decoration:
+                                  const InputDecoration(labelText: 'Mot de passe'),
+                              keyboardType: TextInputType.visiblePassword,
+                              autocorrect: false,
+                              enableSuggestions: false,
+                              obscureText: true,
+                              validator: (value) {
+                                final pwd = value?.trim() ?? '';
+                                if (pwd.isEmpty) {
+                                  return 'Mot de passe requis';
+                                }
+                                if (pwd.length < 6) {
+                                  return 'Le mot de passe doit contenir au moins 6 caractères';
+                                }
+                                final hasLetter = RegExp(r'[A-Za-z]').hasMatch(pwd);
+                                final hasDigit = RegExp(r'\d').hasMatch(pwd);
+                                if (!hasLetter || !hasDigit) {
+                                  return 'Le mot de passe doit contenir des lettres et des chiffres';
+                                }
+                                return null;
+                              },
+                            ),
+                            const SizedBox(height: 12),
+                            if (_error != null) ...[
+                              Text(_error!, style: errorStyle),
+                              const SizedBox(height: 12),
+                            ],
+                            Theme(
+                              data: theme.copyWith(
+                                elevatedButtonTheme: loginButtonTheme,
+                              ),
+                              child: SizedBox(
+                                width: double.infinity,
+                                child: PrimaryButton(
+                                  onPressed: isBusy ? null : _submit,
+                                  child: _isLoading
+                                      ? const SizedBox(
+                                          width: 24,
+                                          height: 24,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                          ),
+                                        )
+                                      : Text(
+                                          _isLogin ? 'Connexion' : 'Inscription'),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            ElevatedButton.icon(
+                              onPressed: isBusy ? null : _signInWithGoogle,
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: const Color(0xFF4285F4),
+                                foregroundColor: Colors.white,
+                                minimumSize: const Size.fromHeight(56),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16),
+                                ),
+                              ),
+                              icon: _isGoogleLoading
+                                  ? const SizedBox(
+                                      width: 24,
+                                      height: 24,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        valueColor:
+                                            AlwaysStoppedAnimation<Color>(Colors.white),
+                                      ),
+                                    )
+                                  : const Icon(
+                                      FontAwesomeIcons.google,
+                                      size: 24,
+                                    ),
+                              label: const Text('Se connecter avec Google'),
+                            ),
+                            const SizedBox(height: 12),
+                            if (_unverifiedUser != null)
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: TextButton(
+                                  onPressed: _resendVerificationEmail,
+                                  child: const Text(
+                                      'Renvoyer l\'email de vérification'),
+                                ),
+                              ),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: TextButton(
+                                onPressed: () => setState(() {
+                                  _isLogin = !_isLogin;
+                                  _unverifiedUser = null;
+                                }),
+                                child: Text(
+                                    _isLogin ? "Créer un compte" : 'Déjà inscrit ?'),
+                              ),
+                            ),
+                          ],
                         ),
-                      TextButton(
-                        onPressed: () => setState(() {
-                          _isLogin = !_isLogin;
-                          _unverifiedUser = null;
-                        }),
-                        child:
-                            Text(_isLogin ? "Créer un compte" : 'Déjà inscrit ?'),
-                      )
-                    ],
+                      ),
+                    ),
                   ),
                 ),
               ),
             ),
+          ),
         );
       },
     );

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -17,6 +17,7 @@ import '../services/competition_service.dart';
 import '../services/private_scores_store.dart';
 import 'dashboard_screen.dart';
 import '../utils/arcade_level_utils.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 class ProfileEditScreen extends StatefulWidget {
   const ProfileEditScreen({super.key});
@@ -402,30 +403,36 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Modifier le profil',
-                style: Theme.of(context)
-                    .textTheme
-                    .headlineSmall
-                    ?.copyWith(fontWeight: FontWeight.w700),
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      safeAreaTop: true,
+      bodyPadding: const EdgeInsets.fromLTRB(24, kToolbarHeight + 24, 24, 24),
+      appBar: AppBar(
+        title: const Text('Modifier le profil'),
+      ),
+      body: SingleChildScrollView(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Card(
+              margin: EdgeInsets.zero,
+              elevation: 4,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(24),
               ),
-              const SizedBox(height: 16),
-              Expanded(
+              clipBehavior: Clip.antiAlias,
+              child: Padding(
+                padding: const EdgeInsets.all(24),
                 child: Form(
                   key: _formKey,
-                  child: ListView(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Center(
+                      Align(
+                        alignment: Alignment.center,
                         child: InkWell(
                           onTap: _pickImage,
+                          borderRadius: BorderRadius.circular(60),
                           child: _buildAvatarCircle(),
                         ),
                       ),
@@ -434,36 +441,42 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
                         controller: _firstNameController,
                         decoration: const InputDecoration(labelText: 'Prénom'),
                       ),
-                      const SizedBox(height: 12),
+                      const SizedBox(height: 16),
                       TextFormField(
                         controller: _lastNameController,
                         decoration: const InputDecoration(labelText: 'Nom'),
                       ),
-                      const SizedBox(height: 12),
+                      const SizedBox(height: 16),
                       TextFormField(
                         controller: _pseudoController,
                         decoration: const InputDecoration(labelText: 'Pseudonyme'),
                       ),
-                      const SizedBox(height: 12),
+                      const SizedBox(height: 16),
                       TextFormField(
                         controller: _professionController,
                         decoration: const InputDecoration(labelText: 'Profession'),
                       ),
                       const SizedBox(height: 24),
-                      ElevatedButton(
-                        onPressed: _save,
-                        child: const Text('Enregistrer'),
+                      SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          onPressed: _save,
+                          child: const Text('Enregistrer'),
+                        ),
                       ),
                       const SizedBox(height: 12),
-                      TextButton(
-                        onPressed: _showChangePasswordDialog,
-                        child: const Text('Changer le mot de passe'),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: TextButton(
+                          onPressed: _showChangePasswordDialog,
+                          child: const Text('Changer le mot de passe'),
+                        ),
                       ),
                     ],
                   ),
                 ),
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -3,9 +3,10 @@ import 'package:flutter/material.dart';
 
 import 'package:firebase_auth/firebase_auth.dart';
 
+import '../services/question_loader.dart';
+import '../widgets/play_themed_scaffold.dart';
 import 'login_screen.dart';
 import 'play_screen.dart';
-import '../services/question_loader.dart';
 
 /// Initial splash screen showing the app logo before navigating to login.
 class SplashScreen extends StatefulWidget {
@@ -80,7 +81,9 @@ class _SplashScreenState extends State<SplashScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return const PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.plain,
+      bodyPadding: EdgeInsets.all(24),
       body: Center(
         child: Image.asset(
           'assets/images/logo_splash.png',

--- a/lib/screens/training_history_screen.dart
+++ b/lib/screens/training_history_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/training_history_entry.dart';
 import '../services/local_history_persistence.dart';
 import '../services/training_history_store.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 class TrainingHistoryScreen extends StatefulWidget {
   const TrainingHistoryScreen({super.key});
@@ -72,7 +73,10 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      safeAreaTop: true,
+      bodyPadding: const EdgeInsets.fromLTRB(24, kToolbarHeight + 24, 24, 24),
       appBar: AppBar(
         title: const Text('Historique — Entraînement'),
         actions: [
@@ -84,81 +88,93 @@ class _TrainingHistoryScreenState extends State<TrainingHistoryScreen> {
       body: _loading
           ? const Center(child: CircularProgressIndicator())
           : _items.isEmpty
-              ? const Center(child: Text('Aucune tentative enregistrée pour l’instant.'))
-              : ListView.builder(
-              itemCount: _items.length,
-              itemBuilder: (context, i) {
-                final e = _items[i];
-                final theme = Theme.of(context);
-                final textTheme = theme.textTheme;
-
-                String statusText;
-                Color statusColor;
-                if (e.abandoned) {
-                  statusText = 'Abandonné';
-                  statusColor = Colors.orange.shade200;
-                } else if (e.success) {
-                  statusText = 'Validé';
-                  statusColor = Colors.green.shade200;
-                } else {
-                  statusText = 'Échoué';
-                  statusColor = Colors.red.shade200;
-                }
-
-                final chipLabelColor =
-                    ThemeData.estimateBrightnessForColor(statusColor) ==
-                            Brightness.dark
-                        ? Colors.white
-                        : Colors.black87;
-
-                return Card(
-                  margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              ? const Center(
                   child: Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
+                    padding: EdgeInsets.symmetric(horizontal: 24),
+                    child: Text('Aucune tentative enregistrée pour l’instant.'),
+                  ),
+                )
+              : ListView.separated(
+                  itemCount: _items.length,
+                  padding: const EdgeInsets.only(bottom: 16),
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemBuilder: (context, i) {
+                    final e = _items[i];
+                    final theme = Theme.of(context);
+                    final textTheme = theme.textTheme;
+
+                    String statusText;
+                    Color statusColor;
+                    if (e.abandoned) {
+                      statusText = 'Abandonné';
+                      statusColor = Colors.orange.shade200;
+                    } else if (e.success) {
+                      statusText = 'Validé';
+                      statusColor = Colors.green.shade200;
+                    } else {
+                      statusText = 'Échoué';
+                      statusColor = Colors.red.shade200;
+                    }
+
+                    final chipLabelColor =
+                        ThemeData.estimateBrightnessForColor(statusColor) ==
+                                Brightness.dark
+                            ? Colors.white
+                            : Colors.black87;
+
+                    return Card(
+                      margin: EdgeInsets.zero,
+                      elevation: 4,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      clipBehavior: Clip.antiAlias,
+                      child: Padding(
+                        padding: const EdgeInsets.all(20),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Expanded(
-                              child: Text(
-                                '${e.subject} • ${e.chapter}',
-                                style: textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.w700,
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    '${e.subject} • ${e.chapter}',
+                                    style: textTheme.titleMedium?.copyWith(
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                                  ),
                                 ),
-                              ),
+                                Chip(
+                                  label: Text(
+                                    statusText,
+                                    style: textTheme.labelLarge?.copyWith(
+                                      fontWeight: FontWeight.w600,
+                                      color: chipLabelColor,
+                                    ),
+                                  ),
+                                  backgroundColor: statusColor,
+                                  visualDensity: VisualDensity.compact,
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 10, vertical: 3),
+                                ),
+                              ],
                             ),
-                            Chip(
-                              label: Text(
-                                statusText,
-                                style: textTheme.labelLarge?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                  color: chipLabelColor,
-                                ),
-                              ),
-                              backgroundColor: statusColor,
-                              visualDensity: VisualDensity.compact,
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                            const SizedBox(height: 8),
+                            Text(
+                              '${_fmt(e.date)} • durée ${e.durationMinutes} min',
+                              style: textTheme.bodyLarge,
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              'Score : ${e.correct}/${e.total} — brut ${e.rawScore} • pondéré ${e.weightedScore}',
+                              style: textTheme.bodyLarge,
                             ),
                           ],
                         ),
-                        const SizedBox(height: 4),
-                        Text(
-                          '${_fmt(e.date)} • durée ${e.durationMinutes} min',
-                          style: textTheme.bodyLarge,
-                        ),
-                        const SizedBox(height: 6),
-                        Text(
-                          'Score : ${e.correct}/${e.total} — brut ${e.rawScore} • pondéré ${e.weightedScore}',
-                          style: textTheme.bodyLarge,
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              },
-            ),
+                      ),
+                    );
+                  },
+                ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace the login, splash, exam history, training history, and profile edit scaffolds with PlayThemedScaffold to inherit the PlayScreen background
- wrap forms and list content in rounded cards with PlayScreen padding and spacing for consistent layouts
- tweak buttons and text actions to match the new card layouts while preserving existing behaviors

## Testing
- not run (flutter is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68daaec63fa0832fb6a1baa587e35135