### PR TITLE
Refine exam flows with PlayThemedScaffold styling

### DIFF
--- a/lib/screens/arcade_mode_screen.dart
+++ b/lib/screens/arcade_mode_screen.dart
@@ -12,6 +12,8 @@ import '../services/scoring.dart';
 import '../services/leaderboard_hooks.dart';
 import '../services/arcade_progress_store.dart';
 import '../widgets/arcade_badge_chip.dart';
+import '../widgets/play_mode_panels.dart';
+import '../widgets/play_themed_scaffold.dart';
 import 'exam_full_screen.dart';
 
 class ArcadeModeScreen extends StatefulWidget {
@@ -421,98 +423,112 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
     final resumeIndex = math.max(0, _progressData?.resumeIndex ?? 0);
     final previewLevels = _buildPreviewLevels(resumeIndex);
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Mode Arcade'),
-      ),
-      body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(
-              child: ListView(
-                padding: const EdgeInsets.all(24),
-                children: [
-                  Text(
-                    'Enchaînez des paliers de difficulté croissante. '
-                    'Chaque niveau adapte automatiquement la cadence et '
-                    'les exigences pour maintenir le défi.',
-                    style: theme.textTheme.bodyLarge,
-                  ),
-                  const SizedBox(height: 24),
-                  Container(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color:
-                            theme.colorScheme.outlineVariant.withOpacity(0.5),
+    final String baseButtonLabel = _preparing
+        ? 'Préparation…'
+        : _loadingProgress
+            ? 'Chargement…'
+            : 'Lancer la session';
+
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      panelHeightFactor: 0.9,
+      safeAreaTop: false,
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(24, 28, 24, 0),
+              children: [
+                PlayPanelHeader(
+                  icon: Icons.videogame_asset_rounded,
+                  title: 'Mode Arcade',
+                  subtitle: 'Paliers successifs à difficulté croissante',
+                  chips: [
+                    PlayInfoChip(
+                      icon: Icons.flag_rounded,
+                      label: 'Niveau ${resumeIndex + 1}',
+                    ),
+                    if (resumeIndex > 0)
+                      PlayInfoChip(
+                        icon: Icons.emoji_events_rounded,
+                        label: '$resumeIndex palier${resumeIndex > 1 ? 's' : ''} validé${resumeIndex > 1 ? 's' : ''}',
                       ),
-                    ),
-                    child: Scrollbar(
-                      child: ListView.builder(
-                        shrinkWrap: true,
-                        physics: const ClampingScrollPhysics(),
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        itemBuilder: (context, index) {
-                          final entry = previewLevels[index];
-                          return _buildLevelCard(
-                            entry.level,
-                            theme,
-                            isCompleted: entry.isCompleted,
-                            isCurrent: entry.isCurrent,
-                          );
-                        },
-                        itemCount: previewLevels.length,
+                    if (_progressData?.profile != null)
+                      PlayInfoChip(
+                        icon: Icons.person_outline,
+                        label: _progressData!.profile!,
                       ),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    'Les niveaux au-delà de ${previewLevels.last.level.title} '
-                    'poursuivent l\'augmentation de la difficulté jusqu\'à '
-                    'épuisement de la banque de questions.',
-                    style: theme.textTheme.bodySmall,
-                  ),
-                  if (_error != null) ...[
-                    const SizedBox(height: 24),
-                    Text(
-                      _error!,
-                      style: theme.textTheme.bodyMedium
-                          ?.copyWith(color: theme.colorScheme.error),
-                    ),
                   ],
-                  if (_lastSummary != null) ...[
-                    const SizedBox(height: 24),
-                    _buildSummaryCard(_lastSummary!, theme),
-                  ],
-                ],
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
-              child: SizedBox(
-                width: double.infinity,
-                child: FilledButton.icon(
-                  icon: _preparing
-                      ? const SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        )
-                      : const Icon(Icons.play_arrow_rounded),
-                  label: Text(
-                    _preparing
-                        ? 'Préparation…'
-                        : _loadingProgress
-                            ? 'Chargement…'
-                            : 'Lancer la session',
-                  ),
-                  onPressed:
-                      _preparing || _loadingProgress ? null : _startArcade,
                 ),
-              ),
+                const SizedBox(height: 24),
+                PlayPanelSurface(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Principe',
+                        style:
+                            theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Enchaînez des paliers de difficulté croissante. Chaque niveau adapte automatiquement la cadence et les exigences pour maintenir le défi.',
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Les niveaux au-delà de ${previewLevels.last.level.title} poursuivent l’augmentation jusqu’à épuisement de la banque de questions.',
+                        style: theme.textTheme.bodySmall,
+                      ),
+                      if (_error != null) ...[
+                        const SizedBox(height: 16),
+                        Text(
+                          _error!,
+                          style: theme.textTheme.bodyMedium
+                              ?.copyWith(color: theme.colorScheme.error),
+                        ),
+                      ],
+                      if (_lastSummary != null) ...[
+                        const SizedBox(height: 16),
+                        _buildSummaryCard(_lastSummary!, theme),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 24),
+                PlayPanelSurface(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Paliers prévus',
+                        style:
+                            theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                      const SizedBox(height: 12),
+                      for (final entry in previewLevels)
+                        _buildLevelCard(
+                          entry.level,
+                          theme,
+                          isCompleted: entry.isCompleted,
+                          isCurrent: entry.isCurrent,
+                        ),
+                    ],
+                  ),
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 28),
+            child: PlayPrimaryButton(
+              label: baseButtonLabel,
+              icon: Icons.play_arrow_rounded,
+              busy: _preparing,
+              onPressed: _preparing || _loadingProgress ? null : _startArcade,
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -557,24 +573,26 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
     bool isCompleted = false,
     bool isCurrent = false,
   }) {
-    final statusColor = isCompleted
-        ? theme.colorScheme.surfaceVariant
-        : theme.colorScheme.surface;
+    final base = theme.colorScheme.primary;
+    final background = base.withOpacity(isCompleted
+        ? (theme.brightness == Brightness.dark ? 0.24 : 0.18)
+        : (theme.brightness == Brightness.dark ? 0.18 : 0.12));
+    final borderColor = base.withOpacity(isCurrent ? 0.45 : 0.2);
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: statusColor,
+        color: background,
         borderRadius: BorderRadius.circular(16),
         border: isCurrent
             ? Border.all(
-                color: theme.colorScheme.primary.withOpacity(0.6),
+                color: borderColor,
                 width: 1.5,
               )
             : null,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.04),
+            color: Colors.black.withOpacity(0.05),
             blurRadius: 12,
             offset: const Offset(0, 4),
           ),

--- a/lib/screens/chapter_list_screen.dart
+++ b/lib/screens/chapter_list_screen.dart
@@ -1,15 +1,18 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+
+import '../models/question.dart';
+import '../models/training_history_entry.dart';
+import '../services/question_history_store.dart';
 import '../services/question_loader.dart';
 import '../services/question_randomizer.dart';
-import '../services/question_history_store.dart';
-import '../models/question.dart';
 import '../services/scoring.dart';
-import '../models/training_history_entry.dart';
 import '../services/training_history_store.dart';
-import 'exam_full_screen.dart';
 import '../widgets/chip_selector.dart';
+import '../widgets/play_mode_panels.dart';
+import '../widgets/play_themed_scaffold.dart';
+import 'exam_full_screen.dart';
 
 class ChapterListScreen extends StatefulWidget {
   final String subjectName;
@@ -193,67 +196,77 @@ class _ChapterListScreenState extends State<ChapterListScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return Scaffold(
-      appBar: AppBar(title: Text('S’entraîner — ${widget.subjectName}')),
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      panelHeightFactor: 0.78,
+      safeAreaTop: false,
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Module : ${widget.chapterName}',
-                    style: textTheme.titleLarge,
-                  ),
-                  const SizedBox(height: 12),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text('Temps par question', style: textTheme.titleMedium),
-                          const SizedBox(height: 8),
-                          ChipSelector<int>(
-                            options: _secondOptions,
-                            selected: _perQuestionSeconds,
-                            onSelected: (s) => setState(() => _perQuestionSeconds = s),
-                            spacing: 8,
-                            runSpacing: 8,
-                            labelBuilder: (s) => '${s}s',
+          : LayoutBuilder(
+              builder: (context, constraints) {
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(24, 28, 24, 36),
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PlayPanelHeader(
+                          icon: Icons.menu_book_rounded,
+                          title: 'S’entraîner — ${widget.subjectName}',
+                          subtitle: widget.chapterName,
+                          chips: [
+                            PlayInfoChip(
+                              icon: Icons.speed_rounded,
+                              label: '${_perQuestionSeconds}s/question',
+                            ),
+                            PlayInfoChip(
+                              icon: Icons.layers_rounded,
+                              label: '${_pool.length} questions disponibles',
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 24),
+                        PlayPanelSurface(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text('Temps par question', style: textTheme.titleMedium),
+                              const SizedBox(height: 12),
+                              ChipSelector<int>(
+                                options: _secondOptions,
+                                selected: _perQuestionSeconds,
+                                onSelected: (s) => setState(() => _perQuestionSeconds = s),
+                                spacing: 8,
+                                runSpacing: 8,
+                                labelBuilder: (s) => '${s}s',
+                              ),
+                              const SizedBox(height: 24),
+                              Text('Nombre de questions', style: textTheme.titleMedium),
+                              const SizedBox(height: 12),
+                              ChipSelector<int>(
+                                options: _countOptions,
+                                selected: _questionCount,
+                                onSelected: (n) => setState(() => _questionCount = n),
+                                spacing: 8,
+                                labelBuilder: (n) => '$n',
+                              ),
+                            ],
                           ),
-                          const SizedBox(height: 16),
-                          Text('Nombre de questions', style: textTheme.titleMedium),
-                          const SizedBox(height: 8),
-                          ChipSelector<int>(
-                            options: _countOptions,
-                            selected: _questionCount,
-                            onSelected: (n) => setState(() => _questionCount = n),
-                            spacing: 8,
-                            labelBuilder: (n) => '$n',
-                          ),
-                          const SizedBox(height: 12),
-                          Text(
-                            'Questions dispo pour ce module : ${_pool.length}',
-                            style: textTheme.bodyLarge,
-                          ),
-                        ],
-                      ),
+                        ),
+                        const Spacer(),
+                        PlayPrimaryButton(
+                          label: 'Commencer l’entraînement',
+                          icon: Icons.play_arrow_rounded,
+                          onPressed: _start,
+                        ),
+                      ],
                     ),
                   ),
-                  const Spacer(),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed: _start,
-                      icon: const Icon(Icons.play_arrow),
-                      label: const Text('Commencer l’entraînement'),
-                    ),
-                  ),
-                ],
-              ),
+                );
+              },
             ),
     );
   }

--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 import '../models/question.dart';
-import '../theme/competition_theme.dart';
 import '../services/leaderboard_hooks.dart';
+import '../theme/competition_theme.dart';
 import '../utils/responsive_utils.dart';
+import '../widgets/play_mode_panels.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 /// Competition quiz screen with a circular countdown and progress tracking.
 class CompetitionScreen extends StatefulWidget {
@@ -118,240 +120,216 @@ class _CompetitionScreenState extends State<CompetitionScreen>
         (resolvedChipTextStyle.fontSize ?? 16) *
                 (resolvedChipTextStyle.height ?? 1.0) +
             16;
-    final double topCardHeight = clampDouble(
-      mediaQuery.size.height * 0.3,
-      240.0,
-      320.0,
-    );
-    return Scaffold(
-      // Global background color comes from the theme.
-      backgroundColor: theme.backgroundColor,
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            children: [
-              // Top card displaying the timer, question text and progress bar.
-              SizedBox(
-                width: double.infinity,
-                height: topCardHeight,
-                child: Container(
-                  padding: const EdgeInsets.all(16),
-                  decoration: BoxDecoration(
-                    color: theme.questionCardColor,
-                    borderRadius:
-                        BorderRadius.circular(theme.questionCardRadius),
-                    boxShadow: theme.questionCardShadow,
-                  ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.max,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Countdown circle.
-                      Center(
-                        child: Container(
-                          padding: const EdgeInsets.all(8),
-                          decoration: BoxDecoration(
-                            color: theme.timerContainerColor,
-                            borderRadius: BorderRadius.circular(
-                                theme.timerContainerRadius),
-                            boxShadow: theme.timerContainerShadow,
-                          ),
-                          child: Stack(
-                            alignment: Alignment.center,
-                            children: [
-                              SizedBox(
-                                width: theme.timerSize,
-                                height: theme.timerSize,
-                                child: CircularProgressIndicator(
-                                  value: _controller.value,
-                                  strokeWidth: theme.timerStrokeWidth,
-                                  color: theme.timerColor,
-                                ),
-                              ),
-                              Text(
-                                '$_remainingSeconds',
-                                style: theme.timerTextStyle,
-                              ),
-                            ],
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.plain,
+      safeAreaTop: true,
+      safeAreaBottom: true,
+      bodyPadding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+      body: Column(
+        children: [
+          PlayPanelSurface(
+            padding: const EdgeInsets.all(18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    PlayCountdownChip(
+                      label: '$_remainingSeconds s restantes',
+                    ),
+                    PlayInfoChip(
+                      icon: Icons.flag_rounded,
+                      label:
+                          'Question ${widget.currentIndex + 1}/${widget.questions.length}',
+                      compact: true,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 18),
+                Center(
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: theme.timerContainerColor,
+                      borderRadius: BorderRadius.circular(
+                        theme.timerContainerRadius,
+                      ),
+                      boxShadow: theme.timerContainerShadow,
+                    ),
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        SizedBox(
+                          width: theme.timerSize,
+                          height: theme.timerSize,
+                          child: CircularProgressIndicator(
+                            value: _controller.value,
+                            strokeWidth: theme.timerStrokeWidth,
+                            color: theme.timerColor,
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 16),
-                      // Question number within the current session.
-                      Text(
-                        'Question ${widget.currentIndex + 1}/${widget.questions.length}',
-                        style: theme.questionIndexTextStyle,
-                      ),
-                      const SizedBox(height: 4),
-                      // Rubric/subject of the current question.
-                      Text(
-                        'Rubrique : ${_currentQuestion.subject}',
-                        style: theme.questionIndexTextStyle,
-                      ),
-                      const SizedBox(height: 8),
-                      // Actual question text.
-                      Expanded(
-                        child: Align(
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            _cleanQuestion(_currentQuestion.question),
-                            style: theme.questionTextStyle,
-                            maxLines: 4,
-                            overflow: TextOverflow.ellipsis,
-                          ),
+                        Text(
+                          '$_remainingSeconds',
+                          style: theme.timerTextStyle,
                         ),
-                      ),
-                      const SizedBox(height: 12),
-                      // Progress bar for overall quiz progression.
-                      LinearProgressIndicator(
-                        value:
-                            (widget.currentIndex + 1) / widget.questions.length,
-                        color: theme.progressBarColor,
-                        backgroundColor:
-                            theme.progressBarColor.withOpacity(0.3),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 24),
-              // Chip displaying the selected answer when user taps an option.
-              SizedBox(
-                height: chipMinHeight,
-                child: AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 250),
-                  switchInCurve: Curves.easeOutBack,
-                  switchOutCurve: Curves.easeInCubic,
-                  transitionBuilder: (child, animation) {
-                    final curved = CurvedAnimation(
-                      parent: animation,
-                      curve: Curves.easeOutCubic,
-                      reverseCurve: Curves.easeInCubic,
-                    );
-                    return FadeTransition(
-                      opacity: animation,
-                      child: SlideTransition(
-                        position: Tween<Offset>(
-                          begin: const Offset(0, 0.1),
-                          end: Offset.zero,
-                        ).animate(curved),
-                        child: ScaleTransition(
-                          scale:
-                              Tween<double>(begin: 0.92, end: 1).animate(curved),
-                          child: child,
-                        ),
-                      ),
-                    );
-                  },
-                  child: _selected >= 0
-                      ? AnimatedAlign(
-                          key: ValueKey<int>(_selected),
-                          alignment: Alignment.center,
-                          duration: const Duration(milliseconds: 250),
-                          curve: Curves.easeOutCubic,
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                                vertical: 8, horizontal: 16),
-                            decoration: BoxDecoration(
-                              color: theme.selectedChipBackgroundColor,
-                              borderRadius: BorderRadius.circular(
-                                theme.selectedChipRadius,
-                              ),
-                            ),
-                            constraints:
-                                BoxConstraints(minHeight: chipMinHeight),
-                            child: Text(
-                              _currentQuestion.choices[_selected],
-                              style: theme.selectedChipTextStyle,
-                            ),
-                          ),
-                        )
-                      : SizedBox(height: chipMinHeight),
+                const SizedBox(height: 16),
+                Text(
+                  'Rubrique : ${_currentQuestion.subject}',
+                  style: theme.questionIndexTextStyle,
                 ),
-              ),
-              const SizedBox(height: 24),
-              // Answer options list.
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: List.generate(_currentQuestion.choices.length, (i) {
-                    final bool isSelected = _selected == i;
-                    final bool isHighlighted = _highlighted == i;
-                    final borderRadius =
-                        BorderRadius.circular(theme.optionCardRadius);
-                    final Color baseColor = theme.optionCardColor;
-                    final Color highlightOverlay =
-                        theme.optionSelectedBorderColor.withOpacity(0.06);
-                    final Color selectedOverlay =
-                        theme.optionSelectedBorderColor.withOpacity(0.12);
-                    final Color resolvedColor = isSelected
-                        ? Color.alphaBlend(selectedOverlay, baseColor)
-                        : isHighlighted
-                            ? Color.alphaBlend(highlightOverlay, baseColor)
-                            : baseColor;
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 8),
-                      child: Container(
-                        width: double.infinity,
-                        constraints: const BoxConstraints(maxWidth: 400),
-                        child: AnimatedScale(
-                          scale: isHighlighted ? 0.97 : 1.0,
-                          duration: const Duration(milliseconds: 140),
-                          curve: Curves.easeOut,
-                          child: Material(
-                            color: Colors.transparent,
-                            borderRadius: borderRadius,
-                            child: InkWell(
-                              borderRadius: borderRadius,
-                              splashColor: theme.optionSelectedBorderColor
-                                  .withOpacity(0.08),
-                              highlightColor: theme.optionSelectedBorderColor
-                                  .withOpacity(0.04),
-                              onHighlightChanged: (value) {
-                                if (_selected >= 0) return;
-                                setState(() {
-                                  _highlighted = value ? i : -1;
-                                });
-                              },
-                              onTap: _selected >= 0
-                                  ? null
-                                  : () => _onOptionTap(i),
-                              child: AnimatedContainer(
-                                duration: const Duration(milliseconds: 200),
-                                curve: Curves.easeOut,
-                                width: double.infinity,
-                                padding:
-                                    const EdgeInsets.symmetric(vertical: 16),
-                                decoration: BoxDecoration(
-                                  color: resolvedColor,
-                                  borderRadius: borderRadius,
-                                  boxShadow: theme.optionCardShadow,
-                                  border: Border.all(
-                                    color: isSelected
-                                        ? theme.optionSelectedBorderColor
-                                        : Colors.transparent,
-                                    width: 2,
-                                  ),
-                                ),
-                                child: Text(
-                                  _currentQuestion.choices[i],
-                                  textAlign: TextAlign.center,
-                                  style: theme.optionTextStyle
-                                      .copyWith(fontSize: optionFontSize),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    );
-                  }),
+                const SizedBox(height: 6),
+                Text(
+                  _cleanQuestion(_currentQuestion.question),
+                  style: theme.questionTextStyle,
+                  maxLines: 4,
+                  overflow: TextOverflow.ellipsis,
                 ),
-              ),
-            ],
+                const SizedBox(height: 16),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: LinearProgressIndicator(
+                    value: (widget.currentIndex + 1) / widget.questions.length,
+                    minHeight: 8,
+                    color: theme.progressBarColor,
+                    backgroundColor: theme.progressBarColor.withOpacity(0.25),
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
+          const SizedBox(height: 20),
+          SizedBox(
+            height: chipMinHeight,
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 250),
+              switchInCurve: Curves.easeOutBack,
+              switchOutCurve: Curves.easeInCubic,
+              transitionBuilder: (child, animation) {
+                final curved = CurvedAnimation(
+                  parent: animation,
+                  curve: Curves.easeOutCubic,
+                  reverseCurve: Curves.easeInCubic,
+                );
+                return FadeTransition(
+                  opacity: animation,
+                  child: SlideTransition(
+                    position: Tween<Offset>(
+                      begin: const Offset(0, 0.1),
+                      end: Offset.zero,
+                    ).animate(curved),
+                    child: ScaleTransition(
+                      scale: Tween<double>(begin: 0.92, end: 1).animate(curved),
+                      child: child,
+                    ),
+                  ),
+                );
+              },
+              child: _selected >= 0
+                  ? AnimatedAlign(
+                      key: ValueKey<int>(_selected),
+                      alignment: Alignment.center,
+                      duration: const Duration(milliseconds: 250),
+                      curve: Curves.easeOutCubic,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 8, horizontal: 16),
+                        decoration: BoxDecoration(
+                          color: theme.selectedChipBackgroundColor,
+                          borderRadius: BorderRadius.circular(
+                            theme.selectedChipRadius,
+                          ),
+                        ),
+                        constraints: BoxConstraints(minHeight: chipMinHeight),
+                        child: Text(
+                          _currentQuestion.choices[_selected],
+                          style: theme.selectedChipTextStyle,
+                        ),
+                      ),
+                    )
+                  : SizedBox(height: chipMinHeight),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: List.generate(_currentQuestion.choices.length, (i) {
+                final bool isSelected = _selected == i;
+                final bool isHighlighted = _highlighted == i;
+                final borderRadius = BorderRadius.circular(theme.optionCardRadius);
+                final Color baseColor = theme.optionCardColor;
+                final Color highlightOverlay =
+                    theme.optionSelectedBorderColor.withOpacity(0.06);
+                final Color selectedOverlay =
+                    theme.optionSelectedBorderColor.withOpacity(0.12);
+                final Color resolvedColor = isSelected
+                    ? Color.alphaBlend(selectedOverlay, baseColor)
+                    : isHighlighted
+                        ? Color.alphaBlend(highlightOverlay, baseColor)
+                        : baseColor;
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Container(
+                    width: double.infinity,
+                    constraints: const BoxConstraints(maxWidth: 400),
+                    child: AnimatedScale(
+                      scale: isHighlighted ? 0.97 : 1.0,
+                      duration: const Duration(milliseconds: 140),
+                      curve: Curves.easeOut,
+                      child: Material(
+                        color: Colors.transparent,
+                        borderRadius: borderRadius,
+                        child: InkWell(
+                          borderRadius: borderRadius,
+                          splashColor:
+                              theme.optionSelectedBorderColor.withOpacity(0.08),
+                          highlightColor:
+                              theme.optionSelectedBorderColor.withOpacity(0.04),
+                          onHighlightChanged: (value) {
+                            if (_selected >= 0) return;
+                            setState(() {
+                              _highlighted = value ? i : -1;
+                            });
+                          },
+                          onTap:
+                              _selected >= 0 ? null : () => _onOptionTap(i),
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 200),
+                            curve: Curves.easeOut,
+                            width: double.infinity,
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                            decoration: BoxDecoration(
+                              color: resolvedColor,
+                              borderRadius: borderRadius,
+                              boxShadow: theme.optionCardShadow,
+                              border: Border.all(
+                                color: isSelected
+                                    ? theme.optionSelectedBorderColor
+                                    : Colors.transparent,
+                                width: 2,
+                              ),
+                            ),
+                            child: Text(
+                              _currentQuestion.choices[i],
+                              textAlign: TextAlign.center,
+                              style: theme.optionTextStyle
+                                  .copyWith(fontSize: optionFontSize),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -12,10 +12,12 @@ import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:flutter_windowmanager/flutter_windowmanager.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 
+import '../app/theme.dart';
 import '../models/question.dart';
 import '../services/scoring.dart';
-import '../app/theme.dart';
 import '../utils/responsive_utils.dart';
+import '../widgets/play_mode_panels.dart';
+import '../widgets/play_themed_scaffold.dart';
 
 class ExamResult {
   final int correctCount;
@@ -260,44 +262,46 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
       min: 16,
       max: 26,
     );
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                CircleAvatar(
-                  backgroundColor: Theme.of(context).colorScheme.primary,
-                  foregroundColor: Colors.white,
-                  child: Text('${i + 1}'),
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                    child: Text(_cleanQuestion(item.question),
-                        style: const TextStyle(fontWeight: FontWeight.w600))),
-              ],
-            ),
-            const SizedBox(height: 8),
-            for (int c = 0; c < item.choices.length; c++)
-              RadioListTile<int>(
-                value: c,
-                groupValue: answers[i],
-                onChanged: _submitted ? null : (v) => _onAnswer(i, v!),
-                contentPadding: EdgeInsets.zero,
-                title: Text(
-                  item.choices[c],
-                  textAlign: TextAlign.start,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        fontSize: optionFontSize,
-                      ) ??
-                      TextStyle(fontSize: optionFontSize),
+    return PlayPanelSurface(
+      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                backgroundColor: Theme.of(context).colorScheme.primary,
+                foregroundColor: Colors.white,
+                child: Text('${i + 1}'),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  _cleanQuestion(item.question),
+                  style: const TextStyle(fontWeight: FontWeight.w600),
                 ),
               ),
-          ],
-        ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          for (int c = 0; c < item.choices.length; c++)
+            RadioListTile<int>(
+              value: c,
+              groupValue: answers[i],
+              onChanged: _submitted ? null : (v) => _onAnswer(i, v!),
+              contentPadding: EdgeInsets.zero,
+              title: Text(
+                item.choices[c],
+                textAlign: TextAlign.start,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontSize: optionFontSize,
+                    ) ??
+                    TextStyle(fontSize: optionFontSize),
+              ),
+            ),
+        ],
       ),
     );
   }
@@ -474,176 +478,24 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     final instructionsBodyStyle =
         textTheme.bodyLarge?.copyWith(height: 1.35);
 
+    final Widget content = widget.competitionMode
+        ? _buildCompetitionContent(title)
+        : _buildStandardContent(
+            q: q,
+            title: title,
+            instructionsTitleStyle: instructionsTitleStyle,
+            instructionsBodyStyle: instructionsBodyStyle,
+          );
+
     if (widget.competitionMode) {
-      Widget content = Scaffold(
-        appBar: AppBar(
-          title: Text(title),
-          actions: [
-            if (!_submitted)
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                child: Chip(
-                  label: Text(_format(remaining),
-                      style: const TextStyle(fontWeight: FontWeight.bold)),
-                  backgroundColor: Colors.redAccent.shade100,
-                ),
-              )
-            else
-              const Padding(
-                padding:
-                    EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                child: Chip(label: Text('Terminé')),
-              ),
-          ],
-        ),
-        body: Column(
-          children: [
-            Expanded(
-              child: PageView.builder(
-                controller: _pageController,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: q.length,
-                itemBuilder: (_, i) => Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: _questionCard(q[i], i),
-                ),
-              ),
-            ),
-            LinearProgressIndicator(
-              value: (_currentIndex + 1) / q.length,
-              minHeight: 6,
-            ),
-          ],
-        ),
+      return WillPopScope(
+        onWillPop: () async => false,
+        child: SelectionContainer.disabled(child: content),
       );
-      content = SelectionContainer.disabled(child: content);
-      return WillPopScope(onWillPop: () async => false, child: content);
     }
 
-    Widget content = Scaffold(
-        appBar: AppBar(
-          title: Text(title),
-          actions: [
-            if (!_submitted)
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                child: Chip(
-                  label: Text(_format(remaining),
-                      style: const TextStyle(fontWeight: FontWeight.bold)),
-                  backgroundColor: Colors.redAccent.shade100,
-                ),
-              )
-            else
-              const Padding(
-                padding:
-                    EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                child: Chip(label: Text('Terminé')),
-              ),
-          ],
-        ),
-        body: Column(
-          children: [
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
-              margin: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.grey.shade100,
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: Colors.grey.shade300),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Instructions',
-                    style: instructionsTitleStyle ??
-                        textTheme.titleMedium
-                            ?.copyWith(fontWeight: FontWeight.bold) ??
-                        const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    'Barème: ${widget.scoring}  •  Temps total: ${_format(remaining)}',
-                    style: instructionsBodyStyle ?? textTheme.bodyLarge,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Répondez à toutes les questions. Le barème négatif s’applique aux mauvaises réponses.',
-                    style: instructionsBodyStyle ?? textTheme.bodyLarge,
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: ListView.separated(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-                itemCount: q.length,
-                separatorBuilder: (_, __) => const SizedBox(height: 8),
-                itemBuilder: (_, i) {
-                  final item = q[i];
-                  return _questionCard(item, i);
-                },
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      onPressed: () async {
-                        if (_submitted) {
-                          _leaveExam(_lastResult);
-                          return;
-                        }
-                        final confirm = await showDialog<bool>(
-                          context: context,
-                          builder: (_) => AlertDialog(
-                            title: const Text('Quitter ?'),
-                            content: const Text(
-                                'Quitter l’épreuve mettra fin à l’examen en cours.'),
-                            actions: [
-                              TextButton(
-                                  onPressed: () => Navigator.pop(context, false),
-                                  child: const Text('Annuler')),
-                              TextButton(
-                                  onPressed: () => Navigator.pop(context, true),
-                                  child: const Text('Quitter')),
-                            ],
-                          ),
-                        );
-                        if (confirm == true) {
-                          _leaveExam(null);
-                        }
-                      },
-                      icon: Icon(_submitted ? Icons.check : Icons.close),
-                      label: Text(_submitted ? 'Terminer' : 'Quitter'),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: ElevatedButton.icon(
-                      onPressed: _submitted ? null : () => _submit(),
-                      icon: const Icon(Icons.flag),
-                      label: const Text('Soumettre'),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
-      );
-    if (widget.competitionMode) {
-      content = SelectionContainer.disabled(child: content);
-    }
     return WillPopScope(
       onWillPop: () async {
-        if (widget.competitionMode) return false;
         if (_submitted) {
           _leaveExam(_lastResult);
           return false;
@@ -670,6 +522,174 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
         return false;
       },
       child: content,
+    );
+  }
+
+  Widget _buildCompetitionContent(String title) {
+    final q = widget.questions;
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.plain,
+      safeAreaTop: true,
+      safeAreaBottom: true,
+      bodyPadding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+      body: Column(
+        children: [
+          PlayPanelHeader(
+            icon: Icons.flash_on_rounded,
+            title: title,
+            subtitle: 'Mode compétition',
+            chips: [
+              PlayCountdownChip(
+                label: _submitted ? 'Terminé' : _format(remaining),
+                icon: _submitted ? Icons.check_circle : Icons.timer_outlined,
+                completed: _submitted,
+              ),
+              PlayInfoChip(
+                icon: Icons.format_list_numbered_rounded,
+                label: '${_currentIndex + 1}/${q.length}',
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: PageView.builder(
+              controller: _pageController,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: q.length,
+              itemBuilder: (_, i) => Padding(
+                padding: const EdgeInsets.all(12),
+                child: _questionCard(q[i], i),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: LinearProgressIndicator(
+              value: (_currentIndex + 1) / q.length,
+              minHeight: 8,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStandardContent({
+    required List<Question> q,
+    required String title,
+    TextStyle? instructionsTitleStyle,
+    TextStyle? instructionsBodyStyle,
+  }) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.plain,
+      safeAreaTop: true,
+      safeAreaBottom: true,
+      bodyPadding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      body: Column(
+        children: [
+          PlayPanelHeader(
+            icon: Icons.school_rounded,
+            title: title,
+            subtitle: 'Session individuelle',
+            chips: [
+              PlayCountdownChip(
+                label: _submitted ? 'Terminé' : _format(remaining),
+                icon: _submitted ? Icons.check_circle : Icons.timer_outlined,
+                completed: _submitted,
+              ),
+              PlayInfoChip(
+                icon: Icons.format_list_numbered_rounded,
+                label: '${q.length} questions',
+              ),
+              PlayInfoChip(
+                icon: Icons.gavel_rounded,
+                label: 'Barème ${widget.scoring}',
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          PlayPanelSurface(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Instructions',
+                  style: instructionsTitleStyle ??
+                      textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold) ??
+                      const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Barème: ${widget.scoring}  •  Temps total: ${_format(remaining)}',
+                  style: instructionsBodyStyle ?? textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Répondez à toutes les questions. Le barème négatif s’applique aux mauvaises réponses.',
+                  style: instructionsBodyStyle ?? textTheme.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+              itemCount: q.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (_, i) => _questionCard(q[i], i),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonalIcon(
+                  onPressed: () async {
+                    if (_submitted) {
+                      _leaveExam(_lastResult);
+                      return;
+                    }
+                    final confirm = await showDialog<bool>(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        title: const Text('Quitter ?'),
+                        content: const Text(
+                            'Quitter l’épreuve mettra fin à l’examen en cours.'),
+                        actions: [
+                          TextButton(
+                              onPressed: () => Navigator.pop(context, false),
+                              child: const Text('Annuler')),
+                          TextButton(
+                              onPressed: () => Navigator.pop(context, true),
+                              child: const Text('Quitter')),
+                        ],
+                      ),
+                    );
+                    if (confirm == true) {
+                      _leaveExam(null);
+                    }
+                  },
+                  icon: Icon(_submitted ? Icons.check : Icons.close),
+                  label: Text(_submitted ? 'Terminer' : 'Quitter'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: PlayPrimaryButton(
+                  label: 'Soumettre',
+                  icon: Icons.flag_rounded,
+                  onPressed: _submitted ? null : () => _submit(),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -11,6 +11,8 @@ import '../services/question_history_store.dart';
 import '../services/exam_blueprint.dart';
 import '../data/ena_taxonomy.dart';
 import '../utils/palette_utils.dart';
+import '../widgets/play_mode_panels.dart';
+import '../widgets/play_themed_scaffold.dart';
 import 'exam_full_screen.dart';
 import 'exam_history_screen.dart';
 
@@ -415,74 +417,73 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final perQ = secondsPerQuestion(_difficulty);
-    return Scaffold(
-      appBar: AppBar(
-        title: const Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.flag),
-            SizedBox(width: 8),
-            Text('Parcours multi-épreuves ENA'),
-          ],
-        ),
-        centerTitle: true,
-      ),
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      panelHeightFactor: 0.92,
+      safeAreaTop: false,
       body: loading
           ? const Center(child: CircularProgressIndicator())
           : LayoutBuilder(
               builder: (context, constraints) {
                 return SingleChildScrollView(
-                  padding: const EdgeInsets.all(16),
+                  padding: const EdgeInsets.fromLTRB(24, 28, 24, 40),
                   child: ConstrainedBox(
                     constraints: BoxConstraints(minHeight: constraints.maxHeight),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          'Niveau de difficulté',
-                          style: textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
+                        PlayPanelHeader(
+                          icon: Icons.flag_rounded,
+                          title: 'Parcours multi-épreuves ENA',
+                          subtitle: 'Simulation officielle multi-sections',
+                          chips: [
+                            PlayInfoChip(
+                              icon: Icons.grid_view_rounded,
+                              label: '${sections.length} épreuves',
+                            ),
+                            PlayInfoChip(
+                              icon: Icons.trending_up_rounded,
+                              label: 'Difficulté : ${difficultyLabel(_difficulty)}',
+                            ),
+                          ],
                         ),
-                        const SizedBox(height: 8),
-                        _difficultyPicker(),
-                        const SizedBox(height: 12),
-                        if (perQ == null)
-                          Text(
-                            'Mode Normal : timings officiels des épreuves (réaliste).',
-                            style: textTheme.bodyLarge,
-                          )
-                        else
-                          Text(
-                            'Mode ${difficultyLabel(_difficulty)} : ~${perQ}s par question (temps total ajusté automatiquement).',
-                            style: textTheme.bodyLarge,
-                          ),
-                        const SizedBox(height: 16),
-                        Card(
+                        const SizedBox(height: 24),
+                        PlayPanelSurface(
                           child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              for (final s in sections)
-                                ListTile(
-                                  leading: Icon(_iconForSection(s.title)),
-                                  title: Text(
-                                    s.title,
-                                    style: textTheme.titleMedium,
-                                  ),
-                                  subtitle: Text(
-                                    'Barème: ${s.scoring} • Questions visées: ${s.targetCount}',
-                                    style: textTheme.bodyLarge,
-                                  ),
-                                  trailing: const Icon(Icons.chevron_right),
-                                ),
+                              Text('Niveau de difficulté',
+                                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
+                              const SizedBox(height: 12),
+                              _difficultyPicker(),
+                              const SizedBox(height: 16),
+                              Text(
+                                perQ == null
+                                    ? 'Mode Normal : timings officiels des épreuves (réaliste).'
+                                    : 'Mode ${difficultyLabel(_difficulty)} : ~${perQ}s par question (temps total ajusté automatiquement).',
+                                style: textTheme.bodyLarge,
+                              ),
                             ],
                           ),
                         ),
-                        const SizedBox(height: 24),
-                        SizedBox(
-                          width: double.infinity,
-                          child: ElevatedButton.icon(
-                            onPressed: _startFlow,
-                            icon: const Icon(Icons.play_arrow),
-                            label: const Text('Démarrer le parcours'),
+                        const SizedBox(height: 20),
+                        PlayPanelSurface(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text('Composition du parcours',
+                                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
+                              const SizedBox(height: 12),
+                              for (final section in sections)
+                                _buildSectionEntry(context, section, textTheme),
+                            ],
                           ),
+                        ),
+                        const Spacer(),
+                        PlayPrimaryButton(
+                          label: 'Démarrer le parcours',
+                          icon: Icons.play_arrow_rounded,
+                          onPressed: _startFlow,
                         ),
                       ],
                     ),
@@ -490,6 +491,75 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
                 );
               },
             ),
+    );
+  }
+
+  Widget _buildSectionEntry(
+      BuildContext context, ExamSection section, TextTheme textTheme) {
+    final theme = Theme.of(context);
+    final baseColor = theme.colorScheme.primary;
+    final background = baseColor.withOpacity(theme.brightness == Brightness.dark ? 0.18 : 0.12);
+    final iconBackground = baseColor.withOpacity(theme.brightness == Brightness.dark ? 0.35 : 0.25);
+    final iconForeground = ThemeData.estimateBrightnessForColor(iconBackground) == Brightness.dark
+        ? Colors.white
+        : theme.colorScheme.onPrimaryContainer;
+    final durationMinutes = section.duration.inMinutes;
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 6),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: iconBackground,
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Icon(
+                  _iconForSection(section.title),
+                  color: iconForeground,
+                  size: 26,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  section.title,
+                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 10,
+            runSpacing: 10,
+            children: [
+              PlayInfoChip(
+                icon: Icons.format_list_numbered_rounded,
+                label: '${section.targetCount} questions',
+              ),
+              PlayInfoChip(
+                icon: Icons.timer_rounded,
+                label: '$durationMinutes min',
+              ),
+              PlayInfoChip(
+                icon: Icons.gavel_rounded,
+                label: 'Barème ${section.scoring}',
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/official_intro_screen.dart
+++ b/lib/screens/official_intro_screen.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart';
-import '../services/scoring.dart';
+
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
 import '../utils/responsive_utils.dart';
+import '../widgets/play_mode_panels.dart';
+import '../widgets/play_themed_scaffold.dart';
 import 'multi_exam_flow.dart';
 
 class OfficialIntroScreen extends StatefulWidget {
@@ -13,7 +16,8 @@ class OfficialIntroScreen extends StatefulWidget {
   State<OfficialIntroScreen> createState() => _OfficialIntroScreenState();
 }
 
-class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTickerProviderStateMixin {
+class _OfficialIntroScreenState extends State<OfficialIntroScreen>
+    with SingleTickerProviderStateMixin {
   bool _accepted = false;
   bool _starting = false;
   int _count = 3;
@@ -47,77 +51,61 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<DesignConfig>(
-      valueListenable: DesignBus.notifier,
-      builder: (context, cfg, _) {
-        final theme = Theme.of(context);
-        final textTheme = theme.textTheme;
-        final overlayTextColor = theme.colorScheme.onSurface;
-        final mediaQuery = MediaQuery.of(context);
-        final scale = computeScaleFactor(mediaQuery);
-        final textScaler = MediaQuery.textScalerOf(context);
-        final double introTitleSize = scaledFontSize(
-          base: 18,
-          scale: scale,
-          textScaler: textScaler,
-          min: 16,
-          max: 24,
-        );
-        final double countdownFontSize = scaledFontSize(
-          base: 96,
-          scale: scale,
-          textScaler: textScaler,
-          min: 72,
-          max: 132,
-        );
-        final bodyStyle =
-            textTheme.bodyLarge ?? textTheme.bodyMedium ?? const TextStyle(fontSize: 16);
-        final double bodyFontSize = bodyStyle.fontSize ?? 16;
-        final baseCardTitleStyle =
-            textTheme.titleMedium ?? textTheme.titleLarge ?? bodyStyle;
-        final double cardTitleFontSize = (baseCardTitleStyle.fontSize != null &&
-                baseCardTitleStyle.fontSize! > bodyFontSize)
-            ? baseCardTitleStyle.fontSize!
-            : bodyFontSize + 2;
-        final cardTitleStyle = baseCardTitleStyle.copyWith(
-          fontWeight: FontWeight.w600,
-          fontSize: cardTitleFontSize,
-        );
-        final introTitleStyle =
-            (textTheme.titleLarge ?? textTheme.headlineSmall ?? baseCardTitleStyle)
-                .copyWith(
-          fontSize: introTitleSize,
-          fontWeight: FontWeight.bold,
-        );
-        return Scaffold(
-          backgroundColor: Colors.transparent,
-          appBar:
-              AppBar(title: const Text('Concours officiel — Consignes')),
-          body: Stack(
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      panelHeightFactor: 0.86,
+      safeAreaTop: false,
+      body: ValueListenableBuilder<DesignConfig>(
+        valueListenable: DesignBus.notifier,
+        builder: (context, cfg, _) {
+          final theme = Theme.of(context);
+          final textTheme = theme.textTheme;
+          final overlayTextColor = theme.colorScheme.onSurface;
+          final mediaQuery = MediaQuery.of(context);
+          final scale = computeScaleFactor(mediaQuery);
+          final textScaler = MediaQuery.textScalerOf(context);
+          final double countdownFontSize = scaledFontSize(
+            base: 96,
+            scale: scale,
+            textScaler: textScaler,
+            min: 72,
+            max: 132,
+          );
+          final bodyStyle =
+              textTheme.bodyLarge ?? textTheme.bodyMedium ?? const TextStyle(fontSize: 16);
+          final baseCardTitleStyle =
+              textTheme.titleMedium ?? textTheme.titleLarge ?? bodyStyle;
+          final cardTitleStyle = baseCardTitleStyle.copyWith(
+            fontWeight: FontWeight.w700,
+          );
+
+          return Stack(
             children: [
-              ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  Text('Simulation du concours ENA (pré‑sélection)',
-                      style: introTitleStyle),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Vous allez enchaîner 4 épreuves :\n'
-                    '1) Culture Générale (Côte d’Ivoire)\n'
-                    '2) Aptitude Verbale (Vocabulaire & règles)\n'
-                    '3) Organisation & Logique (Classements & déductions)\n'
-                    '4) Aptitude Numérique (Bases & proportionnalité)\n',
-                    style: bodyStyle,
-                  ),
-                  const SizedBox(height: 12),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12),
+              SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(24, 32, 24, 48),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    PlayPanelHeader(
+                      icon: Icons.flag_rounded,
+                      title: 'Concours officiel — Consignes',
+                      subtitle: 'Simulation du concours ENA (pré‑sélection)',
+                      description:
+                          'Vous allez enchaîner 4 épreuves chronométrées. Assurez-vous d’être prêt avant de lancer la simulation.',
+                      chips: const [
+                        PlayInfoChip(
+                            icon: Icons.grid_view_rounded, label: '4 épreuves enchaînées'),
+                        PlayInfoChip(icon: Icons.timer_rounded, label: '60 min/épreuve'),
+                        PlayInfoChip(icon: Icons.gavel_rounded, label: 'Barème négatif'),
+                      ],
+                    ),
+                    const SizedBox(height: 24),
+                    PlayPanelSurface(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text('Durée & barème', style: cardTitleStyle),
-                          const SizedBox(height: 6),
+                          const SizedBox(height: 12),
                           Text('• Durée : 60 minutes par épreuve (total ~4h).',
                               style: bodyStyle),
                           Text(
@@ -131,16 +119,13 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
                         ],
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12),
+                    const SizedBox(height: 18),
+                    PlayPanelSurface(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text('Règles', style: cardTitleStyle),
-                          const SizedBox(height: 6),
+                          const SizedBox(height: 12),
                           Text(
                             '• Une fois le chrono lancé, vous ne pouvez pas revenir en arrière.',
                             style: bodyStyle,
@@ -156,35 +141,32 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
                         ],
                       ),
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Checkbox(
-                        value: _accepted,
-                        onChanged: (v) =>
-                            setState(() => _accepted = v ?? false),
+                    const SizedBox(height: 18),
+                    PlayPanelSurface(
+                      child: Row(
+                        children: [
+                          Checkbox(
+                            value: _accepted,
+                            onChanged: (v) => setState(() => _accepted = v ?? false),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Text(
+                              'Je comprends les règles et je suis prêt(e) à commencer.',
+                              style: bodyStyle,
+                            ),
+                          ),
+                        ],
                       ),
-                      Expanded(
-                        child: Text(
-                          'Je comprends les règles et je suis prêt(e) à commencer.',
-                          style: bodyStyle,
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed:
-                          _accepted && !_starting ? _startCountdown : null,
-                      icon: const Icon(Icons.flag),
-                      label:
-                          const Text('Démarrer la simulation officielle'),
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 20),
+                    PlayPrimaryButton(
+                      label: 'Démarrer la simulation officielle',
+                      icon: Icons.flag_rounded,
+                      onPressed: _accepted && !_starting ? _startCountdown : null,
+                    ),
+                  ],
+                ),
               ),
               if (_starting)
                 Positioned.fill(
@@ -203,9 +185,9 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
                   ),
                 ),
             ],
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -1,17 +1,20 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import '../services/question_loader.dart';
+
 import '../models/question.dart';
-import '../services/scoring.dart';
-import '../services/question_randomizer.dart';
-import '../services/question_history_store.dart';
 import '../models/training_history_entry.dart';
-import '../services/training_history_store.dart';
-import 'exam_full_screen.dart';
 import '../services/leaderboard_hooks.dart';
 import '../services/ongoing_quiz_store.dart';
+import '../services/question_history_store.dart';
+import '../services/question_loader.dart';
+import '../services/question_randomizer.dart';
+import '../services/scoring.dart';
+import '../services/training_history_store.dart';
 import '../widgets/chip_selector.dart';
+import '../widgets/play_mode_panels.dart';
+import '../widgets/play_themed_scaffold.dart';
+import 'exam_full_screen.dart';
 
 class TrainingQuickStartScreen extends StatefulWidget {
   const TrainingQuickStartScreen({super.key});
@@ -246,48 +249,78 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
     final total = Duration(seconds: _perQuestionSeconds * _questionCount);
     String two(int x) => x.toString().padLeft(2, '0');
     final totalLabel = '${two(total.inMinutes)}:${two(total.inSeconds % 60)}';
-    final textTheme = Theme.of(context).textTheme;
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('Entraînement (5–10s/question)')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Temps par question', style: textTheme.titleMedium),
-            const SizedBox(height: 8),
-            ChipSelector<int>(
-              options: _secondOptions,
-              selected: _perQuestionSeconds,
-              onSelected: (s) => setState(() => _perQuestionSeconds = s),
-              spacing: 8,
-              runSpacing: 8,
-              labelBuilder: (s) => '${s}s',
-            ),
-            const SizedBox(height: 16),
-            Text('Nombre de questions', style: textTheme.titleMedium),
-            const SizedBox(height: 8),
-            ChipSelector<int>(
-              options: _countOptions,
-              selected: _questionCount,
-              onSelected: (n) => setState(() => _questionCount = n),
-              spacing: 8,
-              labelBuilder: (n) => '$n',
-            ),
-            const SizedBox(height: 16),
-            Text('Temps total : $totalLabel', style: textTheme.bodyLarge),
-            const Spacer(),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                onPressed: _loading ? null : _start,
-                icon: const Icon(Icons.play_arrow),
-                label: Text(_loading ? 'Chargement...' : 'Commencer'),
+    return PlayThemedScaffold(
+      bodyMode: PlayThemedScaffoldBodyMode.panel,
+      panelHeightFactor: 0.74,
+      safeAreaTop: false,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(24, 28, 24, 36),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PlayPanelHeader(
+                    icon: Icons.bolt_rounded,
+                    title: 'Entraînement (5–10s/question)',
+                    subtitle: 'Lancez un quiz rapide et chronométré',
+                    chips: [
+                      PlayInfoChip(
+                        icon: Icons.speed_rounded,
+                        label: '${_perQuestionSeconds}s/question',
+                      ),
+                      PlayInfoChip(
+                        icon: Icons.format_list_numbered_rounded,
+                        label: '$_questionCount questions',
+                      ),
+                      PlayCountdownChip(label: 'Temps total : $totalLabel'),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  PlayPanelSurface(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Temps par question', style: textTheme.titleMedium),
+                        const SizedBox(height: 12),
+                        ChipSelector<int>(
+                          options: _secondOptions,
+                          selected: _perQuestionSeconds,
+                          onSelected: (s) => setState(() => _perQuestionSeconds = s),
+                          spacing: 8,
+                          runSpacing: 8,
+                          labelBuilder: (s) => '${s}s',
+                        ),
+                        const SizedBox(height: 24),
+                        Text('Nombre de questions', style: textTheme.titleMedium),
+                        const SizedBox(height: 12),
+                        ChipSelector<int>(
+                          options: _countOptions,
+                          selected: _questionCount,
+                          onSelected: (n) => setState(() => _questionCount = n),
+                          spacing: 8,
+                          labelBuilder: (n) => '$n',
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Spacer(),
+                  PlayPrimaryButton(
+                    label: _loading ? 'Chargement…' : 'Commencer',
+                    icon: Icons.play_arrow_rounded,
+                    busy: _loading,
+                    onPressed: _loading ? null : _start,
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/widgets/play_mode_panels.dart
+++ b/lib/widgets/play_mode_panels.dart
@@ -1,0 +1,328 @@
+import 'package:flutter/material.dart';
+
+import '../models/design_config.dart';
+import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
+
+class PlayPanelSurface extends StatelessWidget {
+  const PlayPanelSurface({
+    super.key,
+    required this.child,
+    this.padding,
+    this.margin,
+    this.borderRadius = 26,
+    this.boxShadow,
+  });
+
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry? margin;
+  final double borderRadius;
+  final List<BoxShadow>? boxShadow;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final palette = pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode);
+        final start = Color.lerp(
+          palette.first,
+          cfg.darkMode ? Colors.black : Colors.white,
+          cfg.darkMode ? 0.05 : 0.45,
+        );
+        final end = Color.lerp(
+          palette.length > 1 ? palette.last : palette.first,
+          cfg.darkMode ? Colors.black : Colors.white,
+          cfg.darkMode ? 0.08 : 0.6,
+        );
+        final resolvedShadow = boxShadow ??
+            [
+              BoxShadow(
+                color: Colors.black.withOpacity(cfg.darkMode ? 0.2 : 0.08),
+                blurRadius: cfg.darkMode ? 18 : 24,
+                offset: const Offset(0, 10),
+              ),
+            ];
+
+        return Container(
+          margin: margin,
+          padding: padding ?? const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [start ?? palette.first, end ?? palette.last],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(borderRadius),
+            boxShadow: resolvedShadow,
+          ),
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+class PlayInfoChip extends StatelessWidget {
+  const PlayInfoChip({
+    super.key,
+    required this.icon,
+    required this.label,
+    this.color,
+    this.compact = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color? color;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final palette = pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode);
+        final baseColor = color ?? palette.last;
+        final background = Color.lerp(
+          baseColor,
+          cfg.darkMode ? Colors.black : Colors.white,
+          cfg.darkMode ? 0.65 : 0.85,
+        )!;
+        final borderColor = baseColor.withOpacity(cfg.darkMode ? 0.35 : 0.28);
+        final brightness = ThemeData.estimateBrightnessForColor(background);
+        final foreground =
+            brightness == Brightness.dark ? Colors.white : theme.colorScheme.onSurface;
+
+        return Container(
+          padding: EdgeInsets.symmetric(
+            horizontal: compact ? 10 : 14,
+            vertical: compact ? 6 : 8,
+          ),
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: borderColor, width: 1.2),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: compact ? 16 : 18, color: baseColor.darken(0.1)),
+              SizedBox(width: compact ? 6 : 8),
+              Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: foreground,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+extension on Color {
+  Color darken([double amount = 0.1]) {
+    assert(amount >= 0 && amount <= 1);
+    final hsl = HSLColor.fromColor(this);
+    final lightness = (hsl.lightness - amount).clamp(0.0, 1.0);
+    return hsl.withLightness(lightness).toColor();
+  }
+}
+
+class PlayCountdownChip extends StatelessWidget {
+  const PlayCountdownChip({
+    super.key,
+    required this.label,
+    this.icon = Icons.timer_outlined,
+    this.completed = false,
+  });
+
+  final String label;
+  final IconData icon;
+  final bool completed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Color? chipColor = completed
+        ? theme.colorScheme.secondary
+        : theme.colorScheme.primary;
+    return PlayInfoChip(
+      icon: icon,
+      label: label,
+      color: chipColor,
+    );
+  }
+}
+
+class PlayPrimaryButton extends StatelessWidget {
+  const PlayPrimaryButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.icon,
+    this.busy = false,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final colors = playIconColors(cfg.bgPaletteName);
+        final background = colors.first;
+        final brightness = ThemeData.estimateBrightnessForColor(background);
+        final foreground =
+            brightness == Brightness.dark ? Colors.white : Colors.black87;
+        final button = icon != null
+            ? FilledButton.icon(
+                icon: busy
+                    ? SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(foreground),
+                        ),
+                      )
+                    : Icon(icon, size: 20),
+                label: Text(
+                  label,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  backgroundColor: background,
+                  foregroundColor: foreground,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(18),
+                  ),
+                ),
+                onPressed: busy ? null : onPressed,
+              )
+            : FilledButton(
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  backgroundColor: background,
+                  foregroundColor: foreground,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(18),
+                  ),
+                ),
+                onPressed: busy ? null : onPressed,
+                child: busy
+                    ? SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(foreground),
+                        ),
+                      )
+                    : Text(
+                        label,
+                        style: const TextStyle(fontWeight: FontWeight.w700),
+                      ),
+              );
+        return SizedBox(width: double.infinity, child: button);
+      },
+    );
+  }
+}
+
+class PlayPanelHeader extends StatelessWidget {
+  const PlayPanelHeader({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.subtitle,
+    this.description,
+    this.chips = const <Widget>[],
+  });
+
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final String? description;
+  final List<Widget> chips;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return PlayPanelSurface(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Container(
+                width: 52,
+                height: 52,
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.18),
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: Icon(icon, size: 30, color: Colors.white),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    if (subtitle != null) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        subtitle!,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: Colors.white.withOpacity(0.8),
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (description != null) ...[
+            const SizedBox(height: 16),
+            Text(
+              description!,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: Colors.white.withOpacity(0.9),
+              ),
+            ),
+          ],
+          if (chips.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: chips,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable PlayScreen-inspired widgets for pastel panels, info chips, countdown badges, and primary buttons
- migrate intro, training, chapter, multi-exam, arcade, competition, and exam flows to PlayThemedScaffold with pastel panels and consistent headers
- refactor exam full screen to share the new PlayPanel layout for competition and standard sessions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68daaec7f024832f900af1886908a388