### PR TITLE
Remove const evaluation from splash scaffold

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -81,7 +81,7 @@ class _SplashScreenState extends State<SplashScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return const PlayThemedScaffold(
+    return PlayThemedScaffold(
       bodyMode: PlayThemedScaffoldBodyMode.plain,
       bodyPadding: EdgeInsets.all(24),
       body: Center(


### PR DESCRIPTION
## Summary
- remove the const keyword from the splash screen PlayThemedScaffold so it is built at runtime

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dab8e47600832fbd049afae7e35b1e