### PR TITLE
Fix quick training layout spacing

### DIFF
--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -321,12 +321,15 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
                       ],
                     ),
                   ),
-                  const Spacer(),
-                  PlayPrimaryButton(
-                    label: _loading ? 'Chargement…' : 'Commencer',
-                    icon: Icons.play_arrow_rounded,
-                    busy: _loading,
-                    onPressed: _loading ? null : _start,
+                  const SizedBox(height: 24),
+                  Align(
+                    alignment: Alignment.center,
+                    child: PlayPrimaryButton(
+                      label: _loading ? 'Chargement…' : 'Commencer',
+                      icon: Icons.play_arrow_rounded,
+                      busy: _loading,
+                      onPressed: _loading ? null : _start,
+                    ),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- replace the flex spacer in the quick training screen with a fixed gap to avoid layout errors in the scroll view
- wrap the primary play button in an Align so it retains positioning without relying on flex

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dacba767d4832faca346d8962e2052