### PR TITLE
Fix layout spacing in multi exam flow screen

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -479,11 +479,14 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
                             ],
                           ),
                         ),
-                        const Spacer(),
-                        PlayPrimaryButton(
-                          label: 'Démarrer le parcours',
-                          icon: Icons.play_arrow_rounded,
-                          onPressed: _startFlow,
+                        const SizedBox(height: 24),
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: PlayPrimaryButton(
+                            label: 'Démarrer le parcours',
+                            icon: Icons.play_arrow_rounded,
+                            onPressed: _startFlow,
+                          ),
                         ),
                       ],
                     ),


### PR DESCRIPTION
## Summary
- replace the Spacer under the ENA composition panel with a fixed gap to avoid layout issues
- wrap the call-to-action button in an Align so it no longer relies on flex spacing

## Testing
- Not Run (flutter analyze) *(Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dacec306bc832fa10ee128575fceed