### PR TITLE
Refactor play bottom navigation into shared widget

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -11,10 +11,12 @@ import '../services/question_history_store.dart';
 import '../services/exam_blueprint.dart';
 import '../data/ena_taxonomy.dart';
 import '../utils/palette_utils.dart';
+import '../widgets/play_bottom_navigation.dart';
 import '../widgets/play_mode_panels.dart';
 import '../widgets/play_themed_scaffold.dart';
 import 'exam_full_screen.dart';
 import 'exam_history_screen.dart';
+import 'play_screen.dart';
 
 enum ExamDifficulty { facile, normal, difficile, expert }
 
@@ -125,6 +127,18 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
   /// Minimum success rate required to pass the exam.
   /// Expressed as a fraction of correct answers over total questions.
   static const double PASS_MIN_SUCCESS_RATE = 0.5;
+
+  void _handleBottomNavSelection(BuildContext context, int index) {
+    if (index == kPlayBottomNavQuizIndex) {
+      return;
+    }
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(
+        builder: (_) => PlayScreen(initialTabIndex: index),
+      ),
+      (route) => false,
+    );
+  }
 
   @override
   void initState() {
@@ -421,6 +435,12 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
       bodyMode: PlayThemedScaffoldBodyMode.panel,
       panelHeightFactor: 0.92,
       safeAreaTop: false,
+      bottomNavigationBar: PlayBottomNavigationBar(
+        items: kPlayBottomNavDestinations,
+        selectedIndex: kPlayBottomNavQuizIndex,
+        showFabNotch: false,
+        onItemSelected: (index) => _handleBottomNavSelection(context, index),
+      ),
       body: loading
           ? const Center(child: CircularProgressIndicator())
           : LayoutBuilder(

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -24,6 +24,7 @@ import '../utils/rank_display_helper.dart';
 import '../utils/responsive_utils.dart';
 
 import '../widgets/arcade_badge_chip.dart';
+import '../widgets/play_bottom_navigation.dart';
 
 import '../models/question.dart';
 
@@ -188,16 +189,20 @@ const CalendarOverlayConfig CAL = CalendarOverlayConfig();
 /// === ÉCRAN ==================================================================
 /// ============================================================================
 class PlayScreen extends StatelessWidget {
-  const PlayScreen({super.key});
+  const PlayScreen({super.key, this.initialTabIndex = 0});
+
+  final int initialTabIndex;
 
   @override
   Widget build(BuildContext context) {
-    return const HomeShell();
+    return HomeShell(initialNavIndex: initialTabIndex);
   }
 }
 
 class HomeShell extends StatefulWidget {
-  const HomeShell({super.key});
+  const HomeShell({super.key, this.initialNavIndex = 0});
+
+  final int initialNavIndex;
 
   @override
   State<HomeShell> createState() => _HomeShellState();
@@ -208,8 +213,8 @@ class _HomeShellState extends State<HomeShell> {
   static const Color _bottomBarHighlight = Color(0x29FFFFFF);
   static const Color _fabForeground = Color(0xFF6C4DFF);
 
-  int _selectedNavIndex = 0;
-  late final List<_NavDestination> _navItems;
+  late int _selectedNavIndex;
+  late final List<PlayNavDestination> _navItems;
 
   final CompetitionService _competitionService = CompetitionService();
   List<LeaderboardEntry> _topEntries = const [];
@@ -257,32 +262,8 @@ class _HomeShellState extends State<HomeShell> {
     super.initState();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
-    _navItems = const [
-      _NavDestination(
-        icon: Icons.home_outlined,
-        label: 'Accueil',
-      ),
-      _NavDestination(
-        icon: Icons.dashboard_outlined,
-        label: 'Dashboard',
-      ),
-      _NavDestination(
-        icon: Icons.quiz_outlined,
-        label: 'Quiz',
-      ),
-      _NavDestination(
-        icon: Icons.history,
-        label: 'Historique',
-      ),
-      _NavDestination(
-        icon: Icons.person_outline,
-        label: 'Profil',
-      ),
-      _NavDestination(
-        icon: Icons.settings_outlined,
-        label: 'Paramètres',
-      ),
-    ];
+    _navItems = kPlayBottomNavDestinations;
+    _selectedNavIndex = widget.initialNavIndex.clamp(0, _navItems.length - 1);
 
     _promoController = PageController(viewportFraction: 1.0);
     _startAutoPlay();
@@ -670,7 +651,14 @@ class _HomeShellState extends State<HomeShell> {
                 _selectedNavIndex == 0 ? _buildMainFab() : null,
             floatingActionButtonLocation:
                 FloatingActionButtonLocation.centerDocked,
-            bottomNavigationBar: _buildBottomAppBar(),
+            bottomNavigationBar: PlayBottomNavigationBar(
+              items: _navItems,
+              selectedIndex: _selectedNavIndex,
+              onItemSelected: _onNavItemSelected,
+              showFabNotch: _selectedNavIndex == 0,
+              backgroundColor: _bottomBarColor,
+              highlightColor: _bottomBarHighlight,
+            ),
             body: _buildShellBody(
               backgroundColor: bgColor,
               surfaceColor: Theme.of(context).scaffoldBackgroundColor,
@@ -812,76 +800,6 @@ class _HomeShellState extends State<HomeShell> {
       child: ColoredBox(
         color: backgroundColor,
         child: child,
-      ),
-    );
-  }
-
-  /// NAV BAR
-  Widget _buildBottomAppBar() {
-    final buttons = <Widget>[];
-
-    final notchIndex = (_navItems.length / 2).floor();
-    for (var i = 0; i < _navItems.length; i++) {
-      if (i == notchIndex) {
-        buttons.add(const SizedBox(width: 68));
-      }
-      buttons.add(
-        Expanded(
-          child: _buildNavButton(i),
-        ),
-      );
-    }
-
-    return BottomAppBar(
-      shape: const CircularNotchedRectangle(),
-      notchMargin: 8,
-      color: _bottomBarColor,
-      elevation: 16,
-      clipBehavior: Clip.antiAlias,
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 10),
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            children: buttons,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildNavButton(int index) {
-    final item = _navItems[index];
-    final isSelected = _selectedNavIndex == index;
-    final Color foreground =
-        isSelected ? Colors.white : Colors.white.withOpacity(0.72);
-
-    return Center(
-      child: Semantics(
-        label: item.label,
-        selected: isSelected,
-        button: true,
-        child: Material(
-          color: Colors.transparent,
-          child: Tooltip(
-            message: item.label,
-            child: InkWell(
-              onTap: () => _onNavItemSelected(index),
-              borderRadius: BorderRadius.circular(18),
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color:
-                      isSelected ? _bottomBarHighlight : Colors.transparent,
-                  borderRadius: BorderRadius.circular(18),
-                ),
-                child: Icon(item.icon, color: foreground, size: 24),
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }
@@ -2057,12 +1975,3 @@ class _PromoCarousel extends StatelessWidget {
   }
 }
 
-class _NavDestination {
-  final IconData icon;
-  final String label;
-
-  const _NavDestination({
-    required this.icon,
-    required this.label,
-  });
-}

--- a/lib/widgets/play_bottom_navigation.dart
+++ b/lib/widgets/play_bottom_navigation.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+class PlayNavDestination {
+  final IconData icon;
+  final String label;
+
+  const PlayNavDestination({
+    required this.icon,
+    required this.label,
+  });
+}
+
+const List<PlayNavDestination> kPlayBottomNavDestinations = [
+  PlayNavDestination(
+    icon: Icons.home_outlined,
+    label: 'Accueil',
+  ),
+  PlayNavDestination(
+    icon: Icons.dashboard_outlined,
+    label: 'Dashboard',
+  ),
+  PlayNavDestination(
+    icon: Icons.quiz_outlined,
+    label: 'Quiz',
+  ),
+  PlayNavDestination(
+    icon: Icons.history,
+    label: 'Historique',
+  ),
+  PlayNavDestination(
+    icon: Icons.person_outline,
+    label: 'Profil',
+  ),
+  PlayNavDestination(
+    icon: Icons.settings_outlined,
+    label: 'Paramètres',
+  ),
+];
+
+const int kPlayBottomNavQuizIndex = 2;
+
+class PlayBottomNavigationBar extends StatelessWidget {
+  const PlayBottomNavigationBar({
+    super.key,
+    required this.items,
+    required this.selectedIndex,
+    required this.onItemSelected,
+    this.showFabNotch = true,
+    this.backgroundColor = const Color(0xFF6C4DFF),
+    this.highlightColor = const Color(0x29FFFFFF),
+    this.selectedIconColor = Colors.white,
+    this.unselectedIconColor,
+    this.padding = const EdgeInsets.symmetric(horizontal: 6, vertical: 10),
+    this.notchMargin = 8,
+    this.fabGapWidth = 68,
+  })  : assert(items.length > 1, 'items must contain at least two destinations.'),
+        assert(selectedIndex >= 0 && selectedIndex < items.length,
+            'selectedIndex must be within the bounds of items.');
+
+  final List<PlayNavDestination> items;
+  final int selectedIndex;
+  final ValueChanged<int>? onItemSelected;
+  final bool showFabNotch;
+  final Color backgroundColor;
+  final Color highlightColor;
+  final Color selectedIconColor;
+  final Color? unselectedIconColor;
+  final EdgeInsetsGeometry padding;
+  final double notchMargin;
+  final double fabGapWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final unselected = unselectedIconColor ?? selectedIconColor.withOpacity(0.72);
+    final notchIndex = (items.length / 2).floor();
+    final buttons = <Widget>[];
+
+    for (var i = 0; i < items.length; i++) {
+      if (showFabNotch && i == notchIndex) {
+        buttons.add(SizedBox(width: fabGapWidth));
+      }
+      buttons.add(
+        Expanded(
+          child: _NavButton(
+            destination: items[i],
+            isSelected: selectedIndex == i,
+            highlightColor: highlightColor,
+            selectedColor: selectedIconColor,
+            unselectedColor: unselected,
+            onTap: onItemSelected == null ? null : () => onItemSelected!(i),
+          ),
+        ),
+      );
+    }
+
+    return BottomAppBar(
+      shape: showFabNotch ? const CircularNotchedRectangle() : null,
+      notchMargin: showFabNotch ? notchMargin : 0,
+      color: backgroundColor,
+      elevation: 16,
+      clipBehavior: Clip.antiAlias,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: padding,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            children: buttons,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NavButton extends StatelessWidget {
+  const _NavButton({
+    required this.destination,
+    required this.isSelected,
+    required this.highlightColor,
+    required this.selectedColor,
+    required this.unselectedColor,
+    this.onTap,
+  });
+
+  final PlayNavDestination destination;
+  final bool isSelected;
+  final Color highlightColor;
+  final Color selectedColor;
+  final Color unselectedColor;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final iconColor = isSelected ? selectedColor : unselectedColor;
+    return Center(
+      child: Semantics(
+        label: destination.label,
+        selected: isSelected,
+        button: true,
+        child: Material(
+          color: Colors.transparent,
+          child: Tooltip(
+            message: destination.label,
+            child: InkWell(
+              onTap: onTap,
+              borderRadius: BorderRadius.circular(18),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: isSelected ? highlightColor : Colors.transparent,
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: Icon(destination.icon, color: iconColor, size: 24),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract the play bottom navigation destinations and BottomAppBar construction into a reusable `PlayBottomNavigationBar`
- update `HomeShell`/`PlayScreen` to consume the shared widget and support selecting an initial tab
- adopt the shared navigation bar in `MultiExamFlowScreen` with navigation back to the appropriate play tab

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dad5138094832fb67a1246a1b282ff