### PR TITLE
Refactor play header into reusable widget and view model

### DIFF
--- a/lib/models/calendar_overlay_config.dart
+++ b/lib/models/calendar_overlay_config.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class CalendarOverlayConfig {
+  final bool showSeconds;
+  final bool use24h;
+  final EdgeInsets padding;
+  final double borderRadius;
+  final Color bgColor;
+  final Color iconColor;
+  final double iconSize;
+  final TextStyle textStyle;
+  final double spacing;
+  final List<BoxShadow>? shadows;
+
+  const CalendarOverlayConfig({
+    this.showSeconds = false,
+    this.use24h = true,
+    this.padding = const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+    this.borderRadius = 16,
+    this.bgColor = const Color(0xFF2E53B3),
+    this.iconColor = const Color(0xFFFFD740),
+    this.iconSize = 24,
+    this.textStyle = const TextStyle(
+      fontSize: 20,
+      fontWeight: FontWeight.w700,
+      color: Colors.white,
+    ),
+    this.spacing = 10,
+    this.shadows = const [
+      BoxShadow(color: Color(0x14000000), blurRadius: 8, offset: Offset(0, 2)),
+    ],
+  });
+}
+
+const CalendarOverlayConfig defaultCalendarOverlayConfig =
+    CalendarOverlayConfig();

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -1,16 +1,22 @@
 import 'dart:async';
 
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import '../models/question.dart';
-import '../services/scoring.dart';
-import '../services/question_loader.dart';
-import '../services/history_store.dart';
-import '../models/exam_history_entry.dart';
-import '../services/question_randomizer.dart';
-import '../services/question_history_store.dart';
-import '../services/exam_blueprint.dart';
+
 import '../data/ena_taxonomy.dart';
+import '../models/calendar_overlay_config.dart';
+import '../models/exam_history_entry.dart';
+import '../models/question.dart';
+import '../services/exam_blueprint.dart';
+import '../services/history_store.dart';
+import '../services/question_history_store.dart';
+import '../services/question_loader.dart';
+import '../services/question_randomizer.dart';
+import '../services/scoring.dart';
 import '../utils/palette_utils.dart';
+import '../utils/responsive_utils.dart';
+import '../viewmodels/play_header_view_model.dart';
+import '../widgets/play_greeting_header.dart';
 import '../widgets/play_mode_panels.dart';
 import '../widgets/play_themed_scaffold.dart';
 import 'exam_full_screen.dart';
@@ -122,6 +128,8 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
 
   ExamDifficulty _difficulty = ExamDifficulty.normal;
 
+  late final PlayHeaderViewModel _headerViewModel;
+
   /// Minimum success rate required to pass the exam.
   /// Expressed as a fraction of correct answers over total questions.
   static const double PASS_MIN_SUCCESS_RATE = 0.5;
@@ -129,6 +137,13 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
   @override
   void initState() {
     super.initState();
+
+    _headerViewModel = PlayHeaderViewModel(
+      clockTick: defaultCalendarOverlayConfig.showSeconds
+          ? const Duration(seconds: 1)
+          : const Duration(minutes: 1),
+    );
+    _headerViewModel.start();
 
     final counts = {
       'Culture Générale': ExamBlueprint.cultureGenerale,
@@ -151,6 +166,12 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
         ),
     ];
     _loadAll();
+  }
+
+  @override
+  void dispose() {
+    _headerViewModel.dispose();
+    super.dispose();
   }
 
   Future<void> _loadAll() async {
@@ -416,84 +437,145 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
+    final mq = MediaQuery.of(context);
+    final scale = computeScaleFactor(mq);
+    final textScaler = MediaQuery.textScalerOf(context);
+    final welcomeFontSize = scaledFontSize(
+      base: 22,
+      scale: scale,
+      textScaler: textScaler,
+      min: 18,
+      max: 28,
+    );
+    final nameFontSize = scaledFontSize(
+      base: 26,
+      scale: scale,
+      textScaler: textScaler,
+      min: 20,
+      max: 36,
+    );
+    final topInset = mq.viewPadding.top;
     final perQ = secondsPerQuestion(_difficulty);
+    final user = FirebaseAuth.instance.currentUser;
+    final name = user?.displayName ?? user?.email;
+    final hasName = name != null && name.isNotEmpty;
+    final headerHeight = PlayGreetingHeader.heightFor(topInset);
+    const double contentSpacingUnderHeader = 24;
+    final double contentTopPadding = headerHeight + contentSpacingUnderHeader;
+
+    Widget buildHeader() {
+      return AnimatedBuilder(
+        animation: _headerViewModel,
+        builder: (context, _) {
+          return PlayGreetingHeader(
+            topInset: topInset,
+            hasName: hasName,
+            name: name,
+            profileNickname: _headerViewModel.profileNickname,
+            welcomeFontSize: welcomeFontSize,
+            nameFontSize: nameFontSize,
+            arcadeProgress: _headerViewModel.arcadeProgress,
+            arcadeProgressLoading: _headerViewModel.arcadeProgressLoading,
+            leaderboardEntry: _headerViewModel.currentUserEntry,
+            rank: _headerViewModel.currentUserRank,
+            now: _headerViewModel.now,
+            calendarConfig: defaultCalendarOverlayConfig,
+          );
+        },
+      );
+    }
+
     return PlayThemedScaffold(
       bodyMode: PlayThemedScaffoldBodyMode.panel,
       panelHeightFactor: 0.92,
       safeAreaTop: false,
-      body: loading
-          ? const Center(child: CircularProgressIndicator())
-          : LayoutBuilder(
-              builder: (context, constraints) {
-                return SingleChildScrollView(
-                  padding: const EdgeInsets.fromLTRB(24, 28, 24, 40),
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(minHeight: constraints.maxHeight),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        PlayPanelHeader(
-                          icon: Icons.flag_rounded,
-                          title: 'Parcours multi-épreuves ENA',
-                          subtitle: 'Simulation officielle multi-sections',
-                          chips: [
-                            PlayInfoChip(
-                              icon: Icons.grid_view_rounded,
-                              label: '${sections.length} épreuves',
-                            ),
-                            PlayInfoChip(
-                              icon: Icons.trending_up_rounded,
-                              label: 'Difficulté : ${difficultyLabel(_difficulty)}',
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final header = buildHeader();
+          if (loading) {
+            return Stack(
+              fit: StackFit.expand,
+              children: [
+                const Center(child: CircularProgressIndicator()),
+                header,
+              ],
+            );
+          }
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              SingleChildScrollView(
+                padding: EdgeInsets.fromLTRB(24, contentTopPadding, 24, 40),
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      PlayPanelHeader(
+                        icon: Icons.flag_rounded,
+                        title: 'Parcours multi-épreuves ENA',
+                        subtitle: 'Simulation officielle multi-sections',
+                        chips: [
+                          PlayInfoChip(
+                            icon: Icons.grid_view_rounded,
+                            label: '${sections.length} épreuves',
+                          ),
+                          PlayInfoChip(
+                            icon: Icons.trending_up_rounded,
+                            label: 'Difficulté : ${difficultyLabel(_difficulty)}',
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      PlayPanelSurface(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Niveau de difficulté',
+                                style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
+                            const SizedBox(height: 12),
+                            _difficultyPicker(),
+                            const SizedBox(height: 16),
+                            Text(
+                              perQ == null
+                                  ? 'Mode Normal : timings officiels des épreuves (réaliste).'
+                                  : 'Mode ${difficultyLabel(_difficulty)} : ~${perQ}s par question (temps total ajusté automatiquement).',
+                              style: textTheme.bodyLarge,
                             ),
                           ],
                         ),
-                        const SizedBox(height: 24),
-                        PlayPanelSurface(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text('Niveau de difficulté',
-                                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
-                              const SizedBox(height: 12),
-                              _difficultyPicker(),
-                              const SizedBox(height: 16),
-                              Text(
-                                perQ == null
-                                    ? 'Mode Normal : timings officiels des épreuves (réaliste).'
-                                    : 'Mode ${difficultyLabel(_difficulty)} : ~${perQ}s par question (temps total ajusté automatiquement).',
-                                style: textTheme.bodyLarge,
-                              ),
-                            ],
-                          ),
+                      ),
+                      const SizedBox(height: 20),
+                      PlayPanelSurface(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Composition du parcours',
+                                style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
+                            const SizedBox(height: 12),
+                            for (final section in sections)
+                              _buildSectionEntry(context, section, textTheme),
+                          ],
                         ),
-                        const SizedBox(height: 20),
-                        PlayPanelSurface(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text('Composition du parcours',
-                                  style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600)),
-                              const SizedBox(height: 12),
-                              for (final section in sections)
-                                _buildSectionEntry(context, section, textTheme),
-                            ],
-                          ),
+                      ),
+                      const SizedBox(height: 24),
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: PlayPrimaryButton(
+                          label: 'Démarrer le parcours',
+                          icon: Icons.play_arrow_rounded,
+                          onPressed: _startFlow,
                         ),
-                        const SizedBox(height: 24),
-                        Align(
-                          alignment: Alignment.centerLeft,
-                          child: PlayPrimaryButton(
-                            label: 'Démarrer le parcours',
-                            icon: Icons.play_arrow_rounded,
-                            onPressed: _startFlow,
-                          ),
-                        ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
-                );
-              },
-            ),
+                ),
+              ),
+              header,
+            ],
+          );
+        },
+      ),
     );
   }
 

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -5,8 +5,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:characters/characters.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/calendar_overlay_config.dart';
 import '../models/design_config.dart';
 import '../models/exam_history_entry.dart';
 import '../models/leaderboard_entry.dart';
@@ -17,13 +17,12 @@ import '../services/scoring.dart';
 import '../services/history_store.dart';
 import '../services/competition_service.dart';
 import '../services/competition_quiz_launcher.dart';
-import '../services/arcade_progress_store.dart';
-import '../services/user_profile_service.dart';
 import '../utils/palette_utils.dart';
 import '../utils/rank_display_helper.dart';
 import '../utils/responsive_utils.dart';
 
-import '../widgets/arcade_badge_chip.dart';
+import '../viewmodels/play_header_view_model.dart';
+import '../widgets/play_greeting_header.dart';
 
 import '../models/question.dart';
 
@@ -81,36 +80,6 @@ class PlayUIConfig {
 }
 
 /// Overlay calendrier (configurable)
-class CalendarOverlayConfig {
-  final bool showSeconds;
-  final bool use24h;
-  final EdgeInsets padding;
-  final double borderRadius;
-  final Color bgColor;
-  final Color iconColor;
-  final double iconSize;
-  final TextStyle textStyle;
-  final double spacing;
-  final List<BoxShadow>? shadows;
-
-  const CalendarOverlayConfig({
-    this.showSeconds = false,
-    this.use24h = true,
-    this.padding = const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-    this.borderRadius = 16,
-    this.bgColor = const Color(0xFF2E53B3),
-    this.iconColor = const Color(0xFFFFD740),
-    this.iconSize = 24,
-    this.textStyle = const TextStyle(
-      fontSize: 20, fontWeight: FontWeight.w700, color: Colors.white,
-    ),
-    this.spacing = 10,
-    this.shadows = const [
-      BoxShadow(color: Color(0x14000000), blurRadius: 8, offset: Offset(0, 2)),
-    ],
-  });
-}
-
 /// Couleurs de base
 const _titleColor = Color(0xFF0E1420);
 const _cardWhite = Colors.white;
@@ -182,7 +151,7 @@ final PlayUIConfig UI = PlayUIConfig(
   spacingBetweenLogoAndWelcome: 1.0,
 );
 
-const CalendarOverlayConfig CAL = CalendarOverlayConfig();
+const CalendarOverlayConfig CAL = defaultCalendarOverlayConfig;
 
 /// ============================================================================
 /// === ÉCRAN ==================================================================
@@ -215,14 +184,8 @@ class _HomeShellState extends State<HomeShell> {
   List<LeaderboardEntry> _topEntries = const [];
   bool _topEntriesLoading = true;
   String? _topEntriesError;
-  LeaderboardEntry? _currentUserEntry;
-  int? _currentUserRank;
-  final UserProfileService _profileService = UserProfileService();
-  String? _profileNickname;
 
-  final ArcadeProgressStore _arcadeProgressStore = ArcadeProgressStore();
-  ArcadeProgressData? _arcadeProgress;
-  bool _arcadeProgressLoading = true;
+  late final PlayHeaderViewModel _headerViewModel;
 
   // Carrousel
   final List<String> _promoImages = const [
@@ -247,10 +210,6 @@ class _HomeShellState extends State<HomeShell> {
       const AssetImage('assets/images/background_playscreen.png');
   late final AssetImage _panelBg =
       const AssetImage('assets/images/background_playscreen2.png');
-
-  // Horloge
-  final ValueNotifier<DateTime> _now = ValueNotifier<DateTime>(DateTime.now());
-  Timer? _clockTimer;
 
   @override
   void initState() {
@@ -285,80 +244,15 @@ class _HomeShellState extends State<HomeShell> {
     ];
 
     _promoController = PageController(viewportFraction: 1.0);
+    _headerViewModel = PlayHeaderViewModel(
+      clockTick:
+          CAL.showSeconds ? const Duration(seconds: 1) : const Duration(minutes: 1),
+    );
+    _headerViewModel.start();
     _startAutoPlay();
-    _startClock();
     unawaited(OngoingQuickQuizStore.load());
     unawaited(HistoryStore.load());
     unawaited(_loadTopEntries());
-    unawaited(_loadArcadeProgress());
-    unawaited(_loadProfileNickname());
-  }
-
-  Future<void> _loadProfileNickname() async {
-    final uid = FirebaseAuth.instance.currentUser?.uid;
-    SharedPreferences? prefs;
-    try {
-      prefs = await SharedPreferences.getInstance();
-    } catch (e, st) {
-      debugPrint('Failed to get SharedPreferences: $e\n$st');
-    }
-
-    String? cachedNickname;
-    if (prefs != null) {
-      final cached = prefs.getString('nickname');
-      if (cached != null && cached.trim().isNotEmpty) {
-        cachedNickname = cached.trim();
-      }
-    }
-
-    String? resolvedNickname = cachedNickname;
-
-    if (uid != null) {
-      try {
-        final profile = await _profileService.loadProfile(uid);
-        final profileNickname = profile?.nickname;
-        final trimmed = profileNickname?.trim();
-        if (trimmed != null && trimmed.isNotEmpty) {
-          resolvedNickname = trimmed;
-          if (prefs != null) {
-            await prefs.setString('nickname', trimmed);
-          }
-        }
-      } catch (e, st) {
-        debugPrint('Failed to load profile nickname for $uid: $e\n$st');
-      }
-    }
-
-    if (!mounted) return;
-    setState(() {
-      final trimmed = resolvedNickname?.trim();
-      _profileNickname = (trimmed != null && trimmed.isNotEmpty) ? trimmed : null;
-    });
-  }
-
-  Future<void> _loadArcadeProgress() async {
-    if (mounted) {
-      setState(() {
-        _arcadeProgressLoading = true;
-      });
-    }
-    try {
-      final progress = await _arcadeProgressStore.load();
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _arcadeProgress = progress;
-        _arcadeProgressLoading = false;
-      });
-    } catch (e) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _arcadeProgressLoading = false;
-      });
-    }
   }
 
   void _startAutoPlay() {
@@ -376,45 +270,19 @@ class _HomeShellState extends State<HomeShell> {
     });
   }
 
-  void _startClock() {
-    _clockTimer?.cancel();
-    final interval =
-        CAL.showSeconds ? const Duration(seconds: 1) : const Duration(minutes: 1);
-    _clockTimer = Timer.periodic(interval, (_) {
-      _now.value = DateTime.now();
-    });
-  }
-
   Future<void> _loadTopEntries() async {
     setState(() {
       _topEntriesLoading = true;
       _topEntriesError = null;
-      _currentUserEntry = null;
-      _currentUserRank = null;
     });
     try {
       final entries = await _competitionService.topEntries(limit: 1000);
-      final uid = FirebaseAuth.instance.currentUser?.uid;
-      LeaderboardEntry? currentEntry;
-      int? currentRank;
-
-      if (uid != null) {
-        final index = entries.indexWhere((e) => e.userId == uid);
-        if (index >= 0) {
-          currentEntry = entries[index];
-          currentRank = index + 1;
-        } else {
-          currentEntry = await _competitionService.entryForUser(uid);
-        }
-      }
 
       if (!mounted) {
         return;
       }
       setState(() {
         _topEntries = entries.take(3).toList();
-        _currentUserEntry = currentEntry;
-        _currentUserRank = currentRank;
         _topEntriesLoading = false;
       });
     } catch (e) {
@@ -423,8 +291,6 @@ class _HomeShellState extends State<HomeShell> {
       }
       setState(() {
         _topEntries = const [];
-        _currentUserEntry = null;
-        _currentUserRank = null;
         _topEntriesLoading = false;
         _topEntriesError = "Impossible de récupérer le classement.";
       });
@@ -449,7 +315,7 @@ class _HomeShellState extends State<HomeShell> {
       MaterialPageRoute(builder: (_) => const ArcadeModeScreen()),
     );
     if (!mounted) return;
-    await _loadArcadeProgress();
+    await _headerViewModel.loadArcadeProgress();
   }
 
   Future<void> _handleLaunchOfficialQuiz() async {
@@ -468,6 +334,7 @@ class _HomeShellState extends State<HomeShell> {
     );
     if (!mounted) return;
     unawaited(_loadTopEntries());
+    unawaited(_headerViewModel.refreshLeaderboard());
   }
 
   Future<void> _handleResumeQuickQuiz(OngoingQuickQuizState state) async {
@@ -600,8 +467,7 @@ class _HomeShellState extends State<HomeShell> {
   void dispose() {
     _promoTimer?.cancel();
     _promoController.dispose();
-    _clockTimer?.cancel();
-    _now.dispose();
+    _headerViewModel.dispose();
     super.dispose();
   }
 
@@ -616,9 +482,6 @@ class _HomeShellState extends State<HomeShell> {
 
         final textColor =
             textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
-        final badgeColors = playIconColors(cfg.bgPaletteName);
-        final nameColor =
-            badgeColors.length > 1 ? badgeColors.last : badgeColors.first;
         final bgColor =
             pastelColors(cfg.bgPaletteName, darkMode: cfg.darkMode).first;
 
@@ -677,12 +540,12 @@ class _HomeShellState extends State<HomeShell> {
               topInset: topInset,
               hasName: hasName,
               name: name,
-              profileNickname: _profileNickname,
               welcomeFontSize: welcomeFontSize,
               nameFontSize: nameFontSize,
               sections: sections,
               scale: scale,
               panelHeightFactor: UI.panelHeightFactor,
+              headerViewModel: _headerViewModel,
             ),
           ),
         );
@@ -696,12 +559,12 @@ class _HomeShellState extends State<HomeShell> {
     required double topInset,
     required bool hasName,
     required String? name,
-    required String? profileNickname,
     required double welcomeFontSize,
     required double nameFontSize,
     required List<CategoryDefinition> sections,
     required double scale,
     required double panelHeightFactor,
+    required PlayHeaderViewModel headerViewModel,
   }) {
     final tabChildren = <Widget>[
       KeyedSubtree(
@@ -711,12 +574,12 @@ class _HomeShellState extends State<HomeShell> {
           topInset: topInset,
           hasName: hasName,
           name: name,
-          profileNickname: profileNickname,
           welcomeFontSize: welcomeFontSize,
           nameFontSize: nameFontSize,
           sections: sections,
           scale: scale,
           panelHeightFactor: panelHeightFactor,
+          headerViewModel: headerViewModel,
         ),
       ),
       _buildSurfaceTab(
@@ -767,12 +630,12 @@ class _HomeShellState extends State<HomeShell> {
     required double topInset,
     required bool hasName,
     required String? name,
-    required String? profileNickname,
     required double welcomeFontSize,
     required double nameFontSize,
     required List<CategoryDefinition> sections,
     required double scale,
     required double panelHeightFactor,
+    required PlayHeaderViewModel headerViewModel,
   }) {
     return Stack(
       fit: StackFit.expand,
@@ -783,15 +646,24 @@ class _HomeShellState extends State<HomeShell> {
             image: DecorationImage(image: _screenBg, fit: BoxFit.cover),
           ),
         ),
-        _buildHeader(
-          topInset: topInset,
-          hasName: hasName,
-          name: name,
-          profileNickname: profileNickname,
-          welcomeFontSize: welcomeFontSize,
-          nameFontSize: nameFontSize,
-          arcadeProgress: _arcadeProgress,
-          arcadeProgressLoading: _arcadeProgressLoading,
+        AnimatedBuilder(
+          animation: headerViewModel,
+          builder: (context, _) {
+            return PlayGreetingHeader(
+              topInset: topInset,
+              hasName: hasName,
+              name: name,
+              profileNickname: headerViewModel.profileNickname,
+              welcomeFontSize: welcomeFontSize,
+              nameFontSize: nameFontSize,
+              arcadeProgress: headerViewModel.arcadeProgress,
+              arcadeProgressLoading: headerViewModel.arcadeProgressLoading,
+              leaderboardEntry: headerViewModel.currentUserEntry,
+              rank: headerViewModel.currentUserRank,
+              now: headerViewModel.now,
+              calendarConfig: CAL,
+            );
+          },
         ),
         _buildSections(
           sections: sections,
@@ -895,166 +767,6 @@ class _HomeShellState extends State<HomeShell> {
       onPressed: _handleCreateQuickQuiz,
       tooltip: 'Nouveau quiz',
       child: const Icon(Icons.add, size: 30),
-    );
-  }
-
-  /// HEADER (logo + bienvenue)
-  Widget _buildHeader({
-    required double topInset,
-    required bool hasName,
-    required String? name,
-    required String? profileNickname,
-    required double welcomeFontSize,
-    required double nameFontSize,
-    required ArcadeProgressData? arcadeProgress,
-    required bool arcadeProgressLoading,
-  }) {
-    final trimmedProfileNickname = profileNickname?.trim();
-    final entryName = _currentUserEntry?.name.trim();
-    final leaderboardName =
-        entryName != null && entryName.isNotEmpty ? entryName : null;
-    final userName = hasName && (name?.trim().isNotEmpty ?? false)
-        ? name!.trim()
-        : null;
-    final displayName = (trimmedProfileNickname != null &&
-            trimmedProfileNickname.isNotEmpty)
-        ? trimmedProfileNickname
-        : (leaderboardName ?? userName ?? 'Utilisateur');
-    final avatarLabel = displayName.isNotEmpty
-        ? displayName.characters.first.toUpperCase()
-        : '?';
-
-    return ValueListenableBuilder<DateTime>(
-      valueListenable: _now,
-      builder: (_, now, __) {
-        final greeting = now.hour < 18 ? 'Bonjour' : 'Bonsoir';
-        final icon = (now.hour >= 6 && now.hour < 18)
-            ? Icons.wb_sunny_rounded
-            : Icons.nights_stay_rounded;
-        final formattedDate = _formatDateTime(now);
-        final int? rank = _currentUserRank;
-        final RankDisplayStyle? rankStyle =
-            rank != null ? rankDisplayStyleFor(rank) : null;
-
-        return Align(
-          alignment: Alignment.topCenter,
-          child: Container(
-            width: double.infinity,
-            padding: EdgeInsets.fromLTRB(24, topInset + 24, 24, 24),
-            decoration: const BoxDecoration(
-              color: Color(0xFF6C4DFF),
-              borderRadius: BorderRadius.only(
-                bottomLeft: Radius.circular(24),
-                bottomRight: Radius.circular(24),
-              ),
-            ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(icon, size: 16, color: Colors.white),
-                          const SizedBox(width: 6),
-                          Text(
-                            formattedDate,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                              height: 1.2,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 8),
-                      Text(
-                        greeting,
-                        style: TextStyle(
-                          color: Colors.white.withOpacity(0.75),
-                          fontSize: welcomeFontSize,
-                          fontWeight: FontWeight.w600,
-                          height: 1.1,
-                        ),
-                      ),
-                      const SizedBox(height: 6),
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          if (arcadeProgressLoading)
-                            const SizedBox(
-                              height: 28,
-                              width: 28,
-                              child: Padding(
-                                padding: EdgeInsets.all(6),
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2.5,
-                                  valueColor:
-                                      AlwaysStoppedAnimation<Color>(Colors.white),
-                                ),
-                              ),
-                            )
-                          else if (arcadeProgress != null)
-                            Padding(
-                              padding: const EdgeInsets.only(right: 8),
-                              child: ArcadeBadgeChip(
-                                label: arcadeProgress.levelLabel,
-                                compact: true,
-                              ),
-                            ),
-                          Flexible(
-                            child: Text(
-                              displayName,
-                              style: TextStyle(
-                                color: Colors.white,
-                                fontSize: nameFontSize,
-                                fontWeight: FontWeight.w800,
-                                height: 1.1,
-                              ),
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-                CircleAvatar(
-                  radius: 28,
-                  backgroundColor: Colors.white.withOpacity(0.2),
-                  child: CircleAvatar(
-                    radius: 24,
-                    backgroundColor:
-                        rankStyle?.backgroundColor ?? Colors.white,
-                    child: rank != null && rankStyle != null
-                        ? Text(
-                            '$rank',
-                            style: TextStyle(
-                              color: rankStyle.foregroundColor,
-                              fontWeight: FontWeight.w700,
-                              fontSize: 20,
-                            ),
-                          )
-                        : Text(
-                            avatarLabel,
-                            style: const TextStyle(
-                              color: Color(0xFF6C4DFF),
-                              fontWeight: FontWeight.w700,
-                              fontSize: 20,
-                            ),
-                          ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
     );
   }
 
@@ -1239,26 +951,6 @@ class _HomeShellState extends State<HomeShell> {
         ),
       ),
     );
-  }
-
-  /// Format date/heure
-  String _formatDateTime(DateTime now) {
-    String two(int n) => n.toString().padLeft(2, '0');
-    final y = now.year.toString();
-    final m = two(now.month);
-    final d = two(now.day);
-    int hour = now.hour;
-    String suffix = '';
-    if (!CAL.use24h) {
-      suffix = hour >= 12 ? ' PM' : ' AM';
-      hour = hour % 12;
-      if (hour == 0) hour = 12;
-    }
-    final h = two(hour);
-    final min = two(now.minute);
-    final sec = two(now.second);
-    final time = CAL.showSeconds ? '$h:$min:$sec' : '$h:$min';
-    return '$d/$m/$y  $time$suffix';
   }
 
   /// NAVIGATION

--- a/lib/viewmodels/play_header_view_model.dart
+++ b/lib/viewmodels/play_header_view_model.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/leaderboard_entry.dart';
+import '../services/arcade_progress_store.dart';
+import '../services/competition_service.dart';
+import '../services/user_profile_service.dart';
+
+class PlayHeaderViewModel extends ChangeNotifier {
+  PlayHeaderViewModel({
+    Duration? clockTick,
+    CompetitionService? competitionService,
+    UserProfileService? profileService,
+    ArcadeProgressStore? arcadeProgressStore,
+  })  : _clockTick = clockTick ?? const Duration(minutes: 1),
+        _competitionService = competitionService ?? CompetitionService(),
+        _profileService = profileService ?? UserProfileService(),
+        _arcadeProgressStore = arcadeProgressStore ?? ArcadeProgressStore();
+
+  final Duration _clockTick;
+  final CompetitionService _competitionService;
+  final UserProfileService _profileService;
+  final ArcadeProgressStore _arcadeProgressStore;
+
+  Timer? _clockTimer;
+  bool _started = false;
+  bool _disposed = false;
+
+  DateTime _now = DateTime.now();
+  String? _profileNickname;
+  ArcadeProgressData? _arcadeProgress;
+  bool _arcadeProgressLoading = true;
+  LeaderboardEntry? _currentUserEntry;
+  int? _currentUserRank;
+
+  DateTime get now => _now;
+  String? get profileNickname => _profileNickname;
+  ArcadeProgressData? get arcadeProgress => _arcadeProgress;
+  bool get arcadeProgressLoading => _arcadeProgressLoading;
+  LeaderboardEntry? get currentUserEntry => _currentUserEntry;
+  int? get currentUserRank => _currentUserRank;
+
+  void start() {
+    if (_started) {
+      return;
+    }
+    _started = true;
+    _startClock();
+    unawaited(loadProfileNickname());
+    unawaited(refreshLeaderboard());
+    unawaited(loadArcadeProgress());
+  }
+
+  Future<void> loadProfileNickname() async {
+    SharedPreferences? prefs;
+    try {
+      prefs = await SharedPreferences.getInstance();
+    } catch (e, st) {
+      debugPrint('Failed to get SharedPreferences: $e\n$st');
+    }
+
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+
+    String? cachedNickname;
+    if (prefs != null) {
+      final cached = prefs.getString('nickname');
+      if (cached != null && cached.trim().isNotEmpty) {
+        cachedNickname = cached.trim();
+      }
+    }
+
+    String? resolvedNickname = cachedNickname;
+
+    if (uid != null) {
+      try {
+        final profile = await _profileService.loadProfile(uid);
+        final trimmed = profile?.nickname.trim();
+        if (trimmed != null && trimmed.isNotEmpty) {
+          resolvedNickname = trimmed;
+          if (prefs != null) {
+            await prefs.setString('nickname', trimmed);
+          }
+        }
+      } catch (e, st) {
+        debugPrint('Failed to load profile nickname for $uid: $e\n$st');
+      }
+    }
+
+    if (_disposed) {
+      return;
+    }
+
+    final nextNickname = resolvedNickname?.trim();
+    if (nextNickname != null && nextNickname.isEmpty) {
+      if (_profileNickname != null) {
+        _profileNickname = null;
+        notifyListeners();
+      }
+      return;
+    }
+
+    if (nextNickname != _profileNickname) {
+      _profileNickname = nextNickname;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadArcadeProgress() async {
+    if (_disposed) return;
+    if (!_arcadeProgressLoading) {
+      _arcadeProgressLoading = true;
+      notifyListeners();
+    }
+    try {
+      final progress = await _arcadeProgressStore.load();
+      if (_disposed) {
+        return;
+      }
+      _arcadeProgress = progress;
+      _arcadeProgressLoading = false;
+      notifyListeners();
+    } catch (e) {
+      if (_disposed) {
+        return;
+      }
+      _arcadeProgressLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshLeaderboard() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (_disposed) {
+      return;
+    }
+    try {
+      LeaderboardEntry? currentEntry;
+      int? currentRank;
+
+      final entries = await _competitionService.topEntries(limit: 1000);
+      if (uid != null) {
+        final index = entries.indexWhere((e) => e.userId == uid);
+        if (index >= 0) {
+          currentEntry = entries[index];
+          currentRank = index + 1;
+        } else {
+          currentEntry = await _competitionService.entryForUser(uid);
+        }
+      }
+
+      if (_disposed) {
+        return;
+      }
+
+      _currentUserEntry = currentEntry;
+      _currentUserRank = currentRank;
+      notifyListeners();
+    } catch (e, st) {
+      debugPrint('Failed to refresh leaderboard: $e\n$st');
+      if (_disposed) {
+        return;
+      }
+      _currentUserEntry = null;
+      _currentUserRank = null;
+      notifyListeners();
+    }
+  }
+
+  void _startClock() {
+    _clockTimer?.cancel();
+    _clockTimer = Timer.periodic(_clockTick, (_) {
+      if (_disposed) {
+        return;
+      }
+      _now = DateTime.now();
+      notifyListeners();
+    });
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _clockTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/widgets/play_greeting_header.dart
+++ b/lib/widgets/play_greeting_header.dart
@@ -1,0 +1,206 @@
+import 'package:characters/characters.dart';
+import 'package:flutter/material.dart';
+
+import '../models/calendar_overlay_config.dart';
+import '../models/leaderboard_entry.dart';
+import '../services/arcade_progress_store.dart';
+import '../utils/rank_display_helper.dart';
+import 'arcade_badge_chip.dart';
+
+class PlayGreetingHeader extends StatelessWidget {
+  const PlayGreetingHeader({
+    super.key,
+    required this.topInset,
+    required this.hasName,
+    required this.name,
+    required this.profileNickname,
+    required this.welcomeFontSize,
+    required this.nameFontSize,
+    required this.arcadeProgress,
+    required this.arcadeProgressLoading,
+    required this.leaderboardEntry,
+    required this.rank,
+    required this.now,
+    required this.calendarConfig,
+  });
+
+  static const double _baseHeight = 150;
+
+  static double heightFor(double topInset) => topInset + _baseHeight;
+
+  final double topInset;
+  final bool hasName;
+  final String? name;
+  final String? profileNickname;
+  final double welcomeFontSize;
+  final double nameFontSize;
+  final ArcadeProgressData? arcadeProgress;
+  final bool arcadeProgressLoading;
+  final LeaderboardEntry? leaderboardEntry;
+  final int? rank;
+  final DateTime now;
+  final CalendarOverlayConfig calendarConfig;
+
+  @override
+  Widget build(BuildContext context) {
+    final trimmedProfileNickname = profileNickname?.trim();
+    final entryName = leaderboardEntry?.name.trim();
+    final leaderboardName =
+        entryName != null && entryName.isNotEmpty ? entryName : null;
+    final userName = hasName && (name?.trim().isNotEmpty ?? false)
+        ? name!.trim()
+        : null;
+    final displayName = (trimmedProfileNickname != null &&
+            trimmedProfileNickname.isNotEmpty)
+        ? trimmedProfileNickname
+        : (leaderboardName ?? userName ?? 'Utilisateur');
+    final avatarLabel = displayName.isNotEmpty
+        ? displayName.characters.first.toUpperCase()
+        : '?';
+
+    final greeting = now.hour < 18 ? 'Bonjour' : 'Bonsoir';
+    final icon = (now.hour >= 6 && now.hour < 18)
+        ? Icons.wb_sunny_rounded
+        : Icons.nights_stay_rounded;
+    final formattedDate = _formatDateTime(now);
+    final RankDisplayStyle? rankStyle =
+        rank != null ? rankDisplayStyleFor(rank!) : null;
+
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Container(
+        width: double.infinity,
+        padding: EdgeInsets.fromLTRB(24, topInset + 24, 24, 24),
+        decoration: const BoxDecoration(
+          color: Color(0xFF6C4DFF),
+          borderRadius: BorderRadius.only(
+            bottomLeft: Radius.circular(24),
+            bottomRight: Radius.circular(24),
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(icon, size: 16, color: Colors.white),
+                      const SizedBox(width: 6),
+                      Text(
+                        formattedDate,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          height: 1.2,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    greeting,
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.75),
+                      fontSize: welcomeFontSize,
+                      fontWeight: FontWeight.w600,
+                      height: 1.1,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      if (arcadeProgressLoading)
+                        const SizedBox(
+                          height: 28,
+                          width: 28,
+                          child: Padding(
+                            padding: EdgeInsets.all(6),
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2.5,
+                              valueColor:
+                                  AlwaysStoppedAnimation<Color>(Colors.white),
+                            ),
+                          ),
+                        )
+                      else if (arcadeProgress != null)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 8),
+                          child: ArcadeBadgeChip(
+                            label: arcadeProgress!.levelLabel,
+                            compact: true,
+                          ),
+                        ),
+                      Flexible(
+                        child: Text(
+                          displayName,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: nameFontSize,
+                            fontWeight: FontWeight.w800,
+                            height: 1.1,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            CircleAvatar(
+              radius: 28,
+              backgroundColor: Colors.white.withOpacity(0.2),
+              child: CircleAvatar(
+                radius: 24,
+                backgroundColor: rankStyle?.backgroundColor ?? Colors.white,
+                child: rank != null && rankStyle != null
+                    ? Text(
+                        '$rank',
+                        style: TextStyle(
+                          color: rankStyle.foregroundColor,
+                          fontWeight: FontWeight.w700,
+                          fontSize: 20,
+                        ),
+                      )
+                    : Text(
+                        avatarLabel,
+                        style: const TextStyle(
+                          color: Color(0xFF6C4DFF),
+                          fontWeight: FontWeight.w700,
+                          fontSize: 20,
+                        ),
+                      ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatDateTime(DateTime value) {
+    String two(int n) => n.toString().padLeft(2, '0');
+    final y = value.year.toString();
+    final m = two(value.month);
+    final d = two(value.day);
+    int hour = value.hour;
+    String suffix = '';
+    if (!calendarConfig.use24h) {
+      suffix = hour >= 12 ? ' PM' : ' AM';
+      hour = hour % 12;
+      if (hour == 0) hour = 12;
+    }
+    final h = two(hour);
+    final min = two(value.minute);
+    final sec = two(value.second);
+    final time = calendarConfig.showSeconds ? '$h:$min:$sec' : '$h:$min';
+    return '$d/$m/$y  $time$suffix';
+  }
+}


### PR DESCRIPTION
## Summary
- extract the play screen greeting banner into a reusable PlayGreetingHeader widget backed by the shared calendar overlay config
- introduce a PlayHeaderViewModel that centralises nickname, arcade progress, rank and clock updates for the header
- update HomeShell and the multi-exam flow to use the shared view model and display the banner above their scrollable content

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dad51607d4832f945421e46c225869