### PR TITLE
Refactor play navigation bar and update official intro

### DIFF
--- a/lib/screens/official_intro_screen.dart
+++ b/lib/screens/official_intro_screen.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import '../services/scoring.dart';
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
 import '../utils/responsive_utils.dart';
+import '../widgets/play_bottom_nav_bar.dart';
 import 'multi_exam_flow.dart';
+import 'play_screen.dart';
 
 class OfficialIntroScreen extends StatefulWidget {
   const OfficialIntroScreen({super.key});
@@ -52,10 +55,14 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
       builder: (context, cfg, _) {
         final theme = Theme.of(context);
         final textTheme = theme.textTheme;
-        final overlayTextColor = theme.colorScheme.onSurface;
         final mediaQuery = MediaQuery.of(context);
         final scale = computeScaleFactor(mediaQuery);
         final textScaler = MediaQuery.textScalerOf(context);
+        final Color playPurple = PlayBottomNavBar.defaultBackgroundColor;
+        final Color backdropColor = darken(playPurple, 0.08);
+        final Color textOnPurple = Colors.white.withOpacity(0.92);
+        final Color secondaryText = Colors.white.withOpacity(0.78);
+        final Color cardColor = Colors.white.withOpacity(0.12);
         final double introTitleSize = scaledFontSize(
           base: 18,
           scale: scale,
@@ -80,111 +87,188 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
             ? baseCardTitleStyle.fontSize!
             : bodyFontSize + 2;
         final cardTitleStyle = baseCardTitleStyle.copyWith(
-          fontWeight: FontWeight.w600,
+          fontWeight: FontWeight.w700,
           fontSize: cardTitleFontSize,
+          color: Colors.white,
         );
         final introTitleStyle =
             (textTheme.titleLarge ?? textTheme.headlineSmall ?? baseCardTitleStyle)
                 .copyWith(
           fontSize: introTitleSize,
           fontWeight: FontWeight.bold,
+          color: Colors.white,
         );
+        final bodyTextStyle = bodyStyle.copyWith(
+          color: textOnPurple,
+          height: 1.45,
+        );
+        final subduedTextStyle = bodyTextStyle.copyWith(color: secondaryText);
+        final checkboxSide = BorderSide(color: Colors.white.withOpacity(0.7));
+
         return Scaffold(
-          backgroundColor: Colors.transparent,
-          appBar:
-              AppBar(title: const Text('Concours officiel — Consignes')),
+          extendBody: true,
+          backgroundColor: backdropColor,
+          appBar: AppBar(
+            backgroundColor: Colors.transparent,
+            elevation: 0,
+            foregroundColor: Colors.white,
+            title: const Text('Concours officiel — Consignes'),
+          ),
+          bottomNavigationBar: PlayBottomNavBar(
+            destinations: playNavDestinations,
+            selectedIndex: 2,
+            onDestinationSelected: (index) {
+              if (index == 2) return;
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PlayScreen(initialIndex: index),
+                ),
+              );
+            },
+          ),
           body: Stack(
             children: [
-              ListView(
-                padding: const EdgeInsets.all(16),
-                children: [
-                  Text('Simulation du concours ENA (pré‑sélection)',
-                      style: introTitleStyle),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Vous allez enchaîner 4 épreuves :\n'
-                    '1) Culture Générale (Côte d’Ivoire)\n'
-                    '2) Aptitude Verbale (Vocabulaire & règles)\n'
-                    '3) Organisation & Logique (Classements & déductions)\n'
-                    '4) Aptitude Numérique (Bases & proportionnalité)\n',
-                    style: bodyStyle,
-                  ),
-                  const SizedBox(height: 12),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text('Durée & barème', style: cardTitleStyle),
-                          const SizedBox(height: 6),
-                          Text('• Durée : 60 minutes par épreuve (total ~4h).',
-                              style: bodyStyle),
-                          Text(
-                            '• Barème : +1 bonne, 0 blanc, −1 mauvaise (barème négatif).',
-                            style: bodyStyle,
-                          ),
-                          Text(
-                            '• Coefficient : ×2 par épreuve (pondération finale).',
-                            style: bodyStyle,
-                          ),
-                        ],
-                      ),
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: Container(
+                  height: 240,
+                  decoration: const BoxDecoration(
+                    color: PlayBottomNavBar.defaultBackgroundColor,
+                    borderRadius: BorderRadius.only(
+                      bottomLeft: Radius.circular(24),
+                      bottomRight: Radius.circular(24),
                     ),
                   ),
-                  const SizedBox(height: 8),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text('Règles', style: cardTitleStyle),
-                          const SizedBox(height: 6),
-                          Text(
-                            '• Une fois le chrono lancé, vous ne pouvez pas revenir en arrière.',
-                            style: bodyStyle,
-                          ),
-                          Text(
-                            '• À la fin du temps, l’épreuve est automatiquement soumise.',
-                            style: bodyStyle,
-                          ),
-                          Text(
-                            '• Évitez de quitter l’app pendant une épreuve.',
-                            style: bodyStyle,
-                          ),
-                        ],
-                      ),
+                ),
+              ),
+              SafeArea(
+                child: ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 140, 16, 120),
+                  children: [
+                    Text(
+                      'Simulation du concours ENA (pré‑sélection)',
+                      style: introTitleStyle,
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Checkbox(
-                        value: _accepted,
-                        onChanged: (v) =>
-                            setState(() => _accepted = v ?? false),
+                    const SizedBox(height: 12),
+                    Text(
+                      'Vous allez enchaîner 4 épreuves :\n'
+                      '1) Culture Générale (Côte d’Ivoire)\n'
+                      '2) Aptitude Verbale (Vocabulaire & règles)\n'
+                      '3) Organisation & Logique (Classements & déductions)\n'
+                      '4) Aptitude Numérique (Bases & proportionnalité)\n',
+                      style: bodyTextStyle,
+                    ),
+                    const SizedBox(height: 16),
+                    Card(
+                      color: cardColor,
+                      shadowColor: Colors.transparent,
+                      surfaceTintColor: Colors.transparent,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
                       ),
-                      Expanded(
-                        child: Text(
-                          'Je comprends les règles et je suis prêt(e) à commencer.',
-                          style: bodyStyle,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Durée & barème', style: cardTitleStyle),
+                            const SizedBox(height: 8),
+                            Text(
+                              '• Durée : 60 minutes par épreuve (total ~4h).',
+                              style: bodyTextStyle,
+                            ),
+                            Text(
+                              '• Barème : +1 bonne, 0 blanc, −1 mauvaise (barème négatif).',
+                              style: bodyTextStyle,
+                            ),
+                            Text(
+                              '• Coefficient : ×2 par épreuve (pondération finale).',
+                              style: bodyTextStyle,
+                            ),
+                          ],
                         ),
                       ),
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton.icon(
-                      onPressed:
-                          _accepted && !_starting ? _startCountdown : null,
-                      icon: const Icon(Icons.flag),
-                      label:
-                          const Text('Démarrer la simulation officielle'),
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 12),
+                    Card(
+                      color: cardColor,
+                      shadowColor: Colors.transparent,
+                      surfaceTintColor: Colors.transparent,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Règles', style: cardTitleStyle),
+                            const SizedBox(height: 8),
+                            Text(
+                              '• Une fois le chrono lancé, vous ne pouvez pas revenir en arrière.',
+                              style: bodyTextStyle,
+                            ),
+                            Text(
+                              '• À la fin du temps, l’épreuve est automatiquement soumise.',
+                              style: bodyTextStyle,
+                            ),
+                            Text(
+                              '• Évitez de quitter l’app pendant une épreuve.',
+                              style: bodyTextStyle,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Checkbox(
+                          value: _accepted,
+                          onChanged: (v) => setState(() => _accepted = v ?? false),
+                          activeColor: Colors.white,
+                          checkColor: playPurple,
+                          side: checkboxSide,
+                          fillColor: MaterialStateProperty.resolveWith((states) {
+                            if (states.contains(MaterialState.selected)) {
+                              return Colors.white;
+                            }
+                            return Colors.white.withOpacity(0.2);
+                          }),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            'Je comprends les règles et je suis prêt(e) à commencer.',
+                            style: subduedTextStyle,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 20),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton.icon(
+                        onPressed: _accepted && !_starting ? _startCountdown : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.white,
+                          foregroundColor: playPurple,
+                          minimumSize: const Size.fromHeight(52),
+                          textStyle: bodyStyle.copyWith(
+                            fontWeight: FontWeight.w600,
+                            fontSize: bodyFontSize + 2,
+                          ),
+                        ),
+                        icon: const Icon(Icons.flag),
+                        label: const Text('Démarrer la simulation officielle'),
+                      ),
+                    ),
+                  ],
+                ),
               ),
               if (_starting)
                 Positioned.fill(
@@ -195,7 +279,7 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> with SingleTi
                         '$_count',
                         style: TextStyle(
                           fontSize: countdownFontSize,
-                          color: overlayTextColor,
+                          color: Colors.white,
                           fontWeight: FontWeight.bold,
                         ),
                       ),

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -24,6 +24,7 @@ import '../utils/rank_display_helper.dart';
 import '../utils/responsive_utils.dart';
 
 import '../widgets/arcade_badge_chip.dart';
+import '../widgets/play_bottom_nav_bar.dart';
 
 import '../models/question.dart';
 
@@ -188,28 +189,30 @@ const CalendarOverlayConfig CAL = CalendarOverlayConfig();
 /// === ÉCRAN ==================================================================
 /// ============================================================================
 class PlayScreen extends StatelessWidget {
-  const PlayScreen({super.key});
+  const PlayScreen({super.key, this.initialIndex = 0});
+
+  final int initialIndex;
 
   @override
   Widget build(BuildContext context) {
-    return const HomeShell();
+    return HomeShell(initialIndex: initialIndex);
   }
 }
 
 class HomeShell extends StatefulWidget {
-  const HomeShell({super.key});
+  const HomeShell({super.key, this.initialIndex = 0});
+
+  final int initialIndex;
 
   @override
   State<HomeShell> createState() => _HomeShellState();
 }
 
 class _HomeShellState extends State<HomeShell> {
-  static const Color _bottomBarColor = Color(0xFF6C4DFF);
-  static const Color _bottomBarHighlight = Color(0x29FFFFFF);
   static const Color _fabForeground = Color(0xFF6C4DFF);
 
-  int _selectedNavIndex = 0;
-  late final List<_NavDestination> _navItems;
+  late int _selectedNavIndex;
+  late final List<PlayNavDestination> _navItems;
 
   final CompetitionService _competitionService = CompetitionService();
   List<LeaderboardEntry> _topEntries = const [];
@@ -257,32 +260,12 @@ class _HomeShellState extends State<HomeShell> {
     super.initState();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
-    _navItems = const [
-      _NavDestination(
-        icon: Icons.home_outlined,
-        label: 'Accueil',
-      ),
-      _NavDestination(
-        icon: Icons.dashboard_outlined,
-        label: 'Dashboard',
-      ),
-      _NavDestination(
-        icon: Icons.quiz_outlined,
-        label: 'Quiz',
-      ),
-      _NavDestination(
-        icon: Icons.history,
-        label: 'Historique',
-      ),
-      _NavDestination(
-        icon: Icons.person_outline,
-        label: 'Profil',
-      ),
-      _NavDestination(
-        icon: Icons.settings_outlined,
-        label: 'Paramètres',
-      ),
-    ];
+    _navItems = playNavDestinations;
+
+    _selectedNavIndex =
+        (widget.initialIndex >= 0 && widget.initialIndex < _navItems.length)
+            ? widget.initialIndex
+            : 0;
 
     _promoController = PageController(viewportFraction: 1.0);
     _startAutoPlay();
@@ -292,6 +275,19 @@ class _HomeShellState extends State<HomeShell> {
     unawaited(_loadTopEntries());
     unawaited(_loadArcadeProgress());
     unawaited(_loadProfileNickname());
+  }
+
+  @override
+  void didUpdateWidget(covariant HomeShell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialIndex != widget.initialIndex &&
+        widget.initialIndex >= 0 &&
+        widget.initialIndex < _navItems.length &&
+        widget.initialIndex != _selectedNavIndex) {
+      setState(() {
+        _selectedNavIndex = widget.initialIndex;
+      });
+    }
   }
 
   Future<void> _loadProfileNickname() async {
@@ -670,7 +666,11 @@ class _HomeShellState extends State<HomeShell> {
                 _selectedNavIndex == 0 ? _buildMainFab() : null,
             floatingActionButtonLocation:
                 FloatingActionButtonLocation.centerDocked,
-            bottomNavigationBar: _buildBottomAppBar(),
+            bottomNavigationBar: PlayBottomNavBar(
+              destinations: _navItems,
+              selectedIndex: _selectedNavIndex,
+              onDestinationSelected: _onNavItemSelected,
+            ),
             body: _buildShellBody(
               backgroundColor: bgColor,
               surfaceColor: Theme.of(context).scaffoldBackgroundColor,
@@ -812,76 +812,6 @@ class _HomeShellState extends State<HomeShell> {
       child: ColoredBox(
         color: backgroundColor,
         child: child,
-      ),
-    );
-  }
-
-  /// NAV BAR
-  Widget _buildBottomAppBar() {
-    final buttons = <Widget>[];
-
-    final notchIndex = (_navItems.length / 2).floor();
-    for (var i = 0; i < _navItems.length; i++) {
-      if (i == notchIndex) {
-        buttons.add(const SizedBox(width: 68));
-      }
-      buttons.add(
-        Expanded(
-          child: _buildNavButton(i),
-        ),
-      );
-    }
-
-    return BottomAppBar(
-      shape: const CircularNotchedRectangle(),
-      notchMargin: 8,
-      color: _bottomBarColor,
-      elevation: 16,
-      clipBehavior: Clip.antiAlias,
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 10),
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            children: buttons,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildNavButton(int index) {
-    final item = _navItems[index];
-    final isSelected = _selectedNavIndex == index;
-    final Color foreground =
-        isSelected ? Colors.white : Colors.white.withOpacity(0.72);
-
-    return Center(
-      child: Semantics(
-        label: item.label,
-        selected: isSelected,
-        button: true,
-        child: Material(
-          color: Colors.transparent,
-          child: Tooltip(
-            message: item.label,
-            child: InkWell(
-              onTap: () => _onNavItemSelected(index),
-              borderRadius: BorderRadius.circular(18),
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color:
-                      isSelected ? _bottomBarHighlight : Colors.transparent,
-                  borderRadius: BorderRadius.circular(18),
-                ),
-                child: Icon(item.icon, color: foreground, size: 24),
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }
@@ -2057,12 +1987,3 @@ class _PromoCarousel extends StatelessWidget {
   }
 }
 
-class _NavDestination {
-  final IconData icon;
-  final String label;
-
-  const _NavDestination({
-    required this.icon,
-    required this.label,
-  });
-}

--- a/lib/widgets/play_bottom_nav_bar.dart
+++ b/lib/widgets/play_bottom_nav_bar.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+class PlayNavDestination {
+  final IconData icon;
+  final String label;
+
+  const PlayNavDestination({
+    required this.icon,
+    required this.label,
+  });
+}
+
+const List<PlayNavDestination> playNavDestinations = [
+  PlayNavDestination(
+    icon: Icons.home_outlined,
+    label: 'Accueil',
+  ),
+  PlayNavDestination(
+    icon: Icons.dashboard_outlined,
+    label: 'Dashboard',
+  ),
+  PlayNavDestination(
+    icon: Icons.quiz_outlined,
+    label: 'Quiz',
+  ),
+  PlayNavDestination(
+    icon: Icons.history,
+    label: 'Historique',
+  ),
+  PlayNavDestination(
+    icon: Icons.person_outline,
+    label: 'Profil',
+  ),
+  PlayNavDestination(
+    icon: Icons.settings_outlined,
+    label: 'Paramètres',
+  ),
+];
+
+class PlayBottomNavBar extends StatelessWidget {
+  const PlayBottomNavBar({
+    super.key,
+    required this.destinations,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+    this.notchShape = const CircularNotchedRectangle(),
+    this.notchMargin = 8,
+    this.addCenterFabSpacing = true,
+    this.fabSpacingWidth = 68,
+    this.backgroundColor = defaultBackgroundColor,
+    this.highlightColor = defaultHighlightColor,
+    this.foregroundColor,
+  });
+
+  static const Color defaultBackgroundColor = Color(0xFF6C4DFF);
+  static const Color defaultHighlightColor = Color(0x29FFFFFF);
+
+  final List<PlayNavDestination> destinations;
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+  final NotchedShape? notchShape;
+  final double notchMargin;
+  final bool addCenterFabSpacing;
+  final double fabSpacingWidth;
+  final Color backgroundColor;
+  final Color highlightColor;
+  final Color? foregroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final buttons = <Widget>[];
+    final total = destinations.length;
+    final centerIndex = addCenterFabSpacing ? (total / 2).floor() : null;
+
+    for (var i = 0; i < total; i++) {
+      if (addCenterFabSpacing && centerIndex != null && i == centerIndex) {
+        buttons.add(SizedBox(width: fabSpacingWidth));
+      }
+      buttons.add(
+        Expanded(
+          child: _NavButton(
+            destination: destinations[i],
+            index: i,
+            isSelected: i == selectedIndex,
+            onSelected: onDestinationSelected,
+            highlightColor: highlightColor,
+            foregroundColor: foregroundColor,
+          ),
+        ),
+      );
+    }
+
+    return BottomAppBar(
+      shape: notchShape,
+      notchMargin: notchMargin,
+      color: backgroundColor,
+      elevation: 16,
+      clipBehavior: Clip.antiAlias,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 10),
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            children: buttons,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NavButton extends StatelessWidget {
+  const _NavButton({
+    required this.destination,
+    required this.index,
+    required this.isSelected,
+    required this.onSelected,
+    required this.highlightColor,
+    this.foregroundColor,
+  });
+
+  final PlayNavDestination destination;
+  final int index;
+  final bool isSelected;
+  final ValueChanged<int> onSelected;
+  final Color highlightColor;
+  final Color? foregroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color baseForeground = foregroundColor ?? Colors.white;
+    final Color iconColor =
+        isSelected ? baseForeground : baseForeground.withOpacity(0.72);
+
+    return Center(
+      child: Semantics(
+        label: destination.label,
+        selected: isSelected,
+        button: true,
+        child: Material(
+          color: Colors.transparent,
+          child: Tooltip(
+            message: destination.label,
+            child: InkWell(
+              onTap: () => onSelected(index),
+              borderRadius: BorderRadius.circular(18),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 200),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: isSelected ? highlightColor : Colors.transparent,
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: Icon(destination.icon, color: iconColor, size: 24),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract the play bottom navigation bar into a reusable widget with shared destinations and styling
- allow PlayScreen and HomeShell to accept an initial index while using the new PlayBottomNavBar
- refresh the OfficialIntroScreen with the shared navigation bar, palette alignment, and updated styling

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db1f9d0f98832faa41f17b1263748a