### PR TITLE
Stop saving mix training results to leaderboard

### DIFF
--- a/lib/screens/training_quick_start.dart
+++ b/lib/screens/training_quick_start.dart
@@ -9,7 +9,6 @@ import '../services/question_history_store.dart';
 import '../models/training_history_entry.dart';
 import '../services/training_history_store.dart';
 import 'exam_full_screen.dart';
-import '../services/leaderboard_hooks.dart';
 import '../services/ongoing_quiz_store.dart';
 import '../widgets/chip_selector.dart';
 
@@ -145,18 +144,6 @@ class _TrainingQuickStartScreenState extends State<TrainingQuickStartScreen> {
           abandoned: false,
         );
         await TrainingHistoryStore.add(entry);
-        await LeaderboardHooks.saveTraining(
-          context: context,
-          subject: 'Entraînement (mix)',
-          chapter: 'Général',
-          total: res.total,
-          correct: res.correctCount,
-          wrong: res.wrongCount,
-          blank: res.blankCount,
-          durationSec: elapsedSeconds,
-          percent: res.total == 0 ? 0.0 : (res.correctCount / res.total) * 100.0,
-        );
-
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(success ? 'Tentative enregistrée — Validé.' : 'Tentative enregistrée — Échoué.')),


### PR DESCRIPTION
## Summary
- stop invoking the leaderboard save hook for quick mix training results
- remove the now-unused leaderboard hook import from the quick start screen

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddb44583d8832f866bc6b12d937216