### PR TITLE
Animate CircleAvatar rank transitions

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -961,23 +961,40 @@ class _HomeShellState extends State<HomeShell> {
                     radius: 24,
                     backgroundColor:
                         rankStyle?.backgroundColor ?? Colors.white,
-                    child: rank != null && rankStyle != null
-                        ? Text(
-                            '$rank',
-                            style: TextStyle(
-                              color: rankStyle.foregroundColor,
-                              fontWeight: FontWeight.w700,
-                              fontSize: 20,
-                            ),
-                          )
-                        : Text(
-                            avatarLabel,
-                            style: const TextStyle(
-                              color: Color(0xFF6C4DFF),
-                              fontWeight: FontWeight.w700,
-                              fontSize: 20,
-                            ),
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 350),
+                      switchInCurve: Curves.easeOut,
+                      switchOutCurve: Curves.easeIn,
+                      transitionBuilder: (child, animation) {
+                        final fadeTransition =
+                            FadeTransition(opacity: animation, child: child);
+                        return RotationTransition(
+                          turns: animation.drive(
+                            Tween<double>(begin: 0.98, end: 1.0),
                           ),
+                          child: fadeTransition,
+                        );
+                      },
+                      child: rank != null && rankStyle != null
+                          ? Text(
+                              '$rank',
+                              key: const ValueKey('rank'),
+                              style: TextStyle(
+                                color: rankStyle.foregroundColor,
+                                fontWeight: FontWeight.w700,
+                                fontSize: 20,
+                              ),
+                            )
+                          : Text(
+                              avatarLabel,
+                              key: const ValueKey('initial'),
+                              style: const TextStyle(
+                                color: Color(0xFF6C4DFF),
+                                fontWeight: FontWeight.w700,
+                                fontSize: 20,
+                              ),
+                            ),
+                    ),
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary
- wrap the profile rank CircleAvatar contents with an AnimatedSwitcher
- fade and slightly rotate between initials and rank text with unique ValueKeys

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddb5277bd0832faf5427237de9a0e7