### PR TITLE
Document Git LFS asset retrieval limitations

### DIFF
--- a/docs/git_lfs_report.md
+++ b/docs/git_lfs_report.md
@@ -1,0 +1,32 @@
+# Git LFS Asset Retrieval Report
+
+## Summary
+- `git lfs install` completed successfully and hooks were initialized.
+- `git lfs pull` failed because the repository has no configured remote URL; Git reports `missing protocol: ""`.
+- The tracked image files such as `assets/images/1.png` and `assets/images/logo_splash.png` remain Git LFS pointer files instead of binary PNGs.
+- Flutter tooling is unavailable in the container (`flutter` command not found), so asset-dependent build commands cannot be executed.
+
+## Command Output
+```
+$ git lfs pull
+batch request: missing protocol: "", 0 B | 0 B/s
+batch request: missing protocol: ""
+Failed to fetch some objects from ''
+```
+
+```
+$ head -n 5 assets/images/1.png
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4f22c9a9eb0698febe77ece36391f1b219d989fba768e566be92bdb13fc547c
+size 96534
+```
+
+```
+$ flutter clean
+bash: command not found: flutter
+```
+
+## Next Steps
+- Configure a Git remote that hosts the Git LFS objects and rerun `git lfs pull` to download the real binary assets.
+- Install Flutter or provide access to the Flutter SDK in the environment to perform `flutter clean` and `flutter run`.
+- After the assets are downloaded and Flutter is available, rerun the checks to confirm that the splash screen and other asset-dependent views render without errors.


### PR DESCRIPTION
## Summary
- note that git lfs install succeeds but git lfs pull fails because no remote is configured
- capture the resulting pointer files and lack of flutter tooling in a troubleshooting report
- document next steps required to download binary assets and run flutter commands

## Testing
- not run (environment lacks Flutter SDK and LFS remote)

------
https://chatgpt.com/codex/tasks/task_e_68ddc10821f0832fbf5b629528c9f3e7