### PR TITLE
Document Git LFS asset retrieval limitations

### DIFF
--- a/docs/git_lfs_report.md
+++ b/docs/git_lfs_report.md
@@ -3,10 +3,17 @@
 ## Summary
 - `git lfs install` completed successfully and hooks were initialized.
 - `git lfs pull` failed because the repository has no configured remote URL; Git reports `missing protocol: ""`.
-- The tracked image files such as `assets/images/1.png` and `assets/images/logo_splash.png` remain Git LFS pointer files instead of binary PNGs.
-- Flutter tooling is unavailable in the container (`flutter` command not found), so asset-dependent build commands cannot be executed.
+- The tracked image files such as `assets/images/1.png` and `assets/images/logo_splash.png` remain Git LFS pointer files instead of binary PNGs (each file is only 129 bytes on disk).
+- Because the real PNGs are unavailable, image viewers cannot display the assets and image-related Flutter issues cannot be validated.
+- Flutter tooling is unavailable in the container (`flutter` command not found), so the application cannot be re-run here to confirm asset loading.
 
 ## Command Output
+```
+$ git lfs install
+Updated Git hooks.
+Git LFS initialized.
+```
+
 ```
 $ git lfs pull
 batch request: missing protocol: "", 0 B | 0 B/s
@@ -17,16 +24,29 @@ Failed to fetch some objects from ''
 ```
 $ head -n 5 assets/images/1.png
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4f22c9a9eb0698febe77ece36391f1b219d989fba768e566be92bdb13fc547c
-size 96534
+oid sha256:dc8e5c2a3762a8d0583c965017ba68c19ccda070577c05de367ee3c8929d4958
+size 1820
 ```
 
 ```
-$ flutter clean
+$ head -n 5 assets/images/logo_splash.png
+version https://git-lfs.github.com/spec/v1
+oid sha256:e53d8c06d37c992aab240cad8f37542e081f8eb36b1de002a100f076a4c29871
+size 1820
+```
+
+```
+$ wc -c assets/images/1.png assets/images/logo_splash.png
+129 assets/images/1.png
+129 assets/images/logo_splash.png
+258 total
+```
+
+```
+$ flutter --version
 bash: command not found: flutter
 ```
 
 ## Next Steps
 - Configure a Git remote that hosts the Git LFS objects and rerun `git lfs pull` to download the real binary assets.
-- Install Flutter or provide access to the Flutter SDK in the environment to perform `flutter clean` and `flutter run`.
-- After the assets are downloaded and Flutter is available, rerun the checks to confirm that the splash screen and other asset-dependent views render without errors.
+- Install Flutter or provide access to the Flutter SDK in the environment to run `flutter run` and confirm the splash screen and other asset-dependent views render without errors.


### PR DESCRIPTION
## Summary
- document that `git lfs install` succeeds but `git lfs pull` fails because no remote is configured
- record that image assets remain Git LFS pointer files and Flutter tooling is unavailable in the container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc5aa8d88832fab6d6ecb6d70b500