### PR TITLE
Document Git LFS fetch limitations

### DIFF
--- a/docs/git_lfs_report.md
+++ b/docs/git_lfs_report.md
@@ -1,11 +1,10 @@
 # Git LFS Asset Retrieval Report
 
 ## Summary
-- `git lfs install` completed successfully and hooks were initialized.
-- `git lfs pull` failed because the repository has no configured remote URL; Git reports `missing protocol: ""`.
-- The tracked image files such as `assets/images/1.png` and `assets/images/logo_splash.png` remain Git LFS pointer files instead of binary PNGs (each file is only 129 bytes on disk).
-- Because the real PNGs are unavailable, image viewers cannot display the assets and image-related Flutter issues cannot be validated.
-- Flutter tooling is unavailable in the container (`flutter` command not found), so the application cannot be re-run here to confirm asset loading.
+- `git lfs install` completed successfully and initialized the hooks locally.
+- `git lfs pull` still fails because the repository has no remote URL configured; Git reports `missing protocol: ""`.
+- As a consequence, tracked assets such as `assets/images/logo_splash.png` remain Git LFS pointer files of ~129 bytes instead of real PNG binaries, so they cannot be opened.
+- The Flutter SDK is not available in this container (`flutter` command is missing), preventing a local run of the application to re-test the splash screen images.
 
 ## Command Output
 ```
@@ -21,13 +20,7 @@ batch request: missing protocol: ""
 Failed to fetch some objects from ''
 ```
 
-```
-$ head -n 5 assets/images/1.png
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc8e5c2a3762a8d0583c965017ba68c19ccda070577c05de367ee3c8929d4958
-size 1820
-```
-
+### Asset Verification
 ```
 $ head -n 5 assets/images/logo_splash.png
 version https://git-lfs.github.com/spec/v1
@@ -36,17 +29,20 @@ size 1820
 ```
 
 ```
-$ wc -c assets/images/1.png assets/images/logo_splash.png
-129 assets/images/1.png
+$ wc -c assets/images/logo_splash.png assets/images/1.png
 129 assets/images/logo_splash.png
+129 assets/images/1.png
 258 total
 ```
 
+Because only the pointer files are present, no PNG viewer can open the assets for validation.
+
+### Flutter Tooling
 ```
 $ flutter --version
 bash: command not found: flutter
 ```
 
 ## Next Steps
-- Configure a Git remote that hosts the Git LFS objects and rerun `git lfs pull` to download the real binary assets.
-- Install Flutter or provide access to the Flutter SDK in the environment to run `flutter run` and confirm the splash screen and other asset-dependent views render without errors.
+- Configure a Git remote that hosts the Git LFS objects and rerun `git lfs pull` (or `git lfs fetch`/`git lfs checkout`) to download the real binary assets.
+- Provide access to the Flutter SDK in the environment so the application can be rebuilt (e.g., `flutter clean` and `flutter run`) once the assets are restored.


### PR DESCRIPTION
## Summary
- record the outcome of running `git lfs install` and the subsequent failure of `git lfs pull` due to the missing remote URL
- capture evidence that the tracked PNG assets remain Git LFS pointer files and cannot be opened in this environment
- document that the Flutter SDK is unavailable, preventing a rerun of the application for validation

## Testing
- git lfs install
- git lfs pull
- head -n 5 assets/images/logo_splash.png
- wc -c assets/images/logo_splash.png assets/images/1.png
- flutter --version

------
https://chatgpt.com/codex/tasks/task_e_68ddc8eee76c832f986bb9050ef38dcc