### PR TITLE
Ensure Git LFS assets are materialized before Flutter setup

### DIFF
--- a/.github/workflows/2dart.yml
+++ b/.github/workflows/2dart.yml
@@ -24,6 +24,9 @@ jobs:
       # - uses: dart-lang/setup-dart@v1
       - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
 
+      - name: Ensure Git LFS assets
+        run: dart run tool/ensure_lfs_assets.dart
+
       - name: Install dependencies
         run: dart pub get
 

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -24,6 +24,9 @@ jobs:
       # - uses: dart-lang/setup-dart@v1
       - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
 
+      - name: Ensure Git LFS assets
+        run: dart run tool/ensure_lfs_assets.dart
+
       - name: Install dependencies
         run: dart pub get
 

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -30,6 +30,9 @@ jobs:
           channel: 'stable'
           cache: true                # accélère les runs suivants
 
+      - name: Ensure Git LFS assets
+        run: dart run tool/ensure_lfs_assets.dart
+
       - name: Flutter pub get
         run: flutter pub get
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 ## Lancer
 ```bash
+dart run tool/ensure_lfs_assets.dart
 flutter pub get
 # Générer plateformes si nécessaire
 flutter create .
 flutter run
 ```
+
+La commande `ensure_lfs_assets` configure Git LFS et télécharge les PNG
+hébergés côté serveur. Elle vérifie aussi que les binaires clés (logo de
+splash, etc.) ne sont pas de simples « pointeurs » de quelques octets.
+Ainsi, plus besoin de re-commiter les assets ou de diagnostiquer un échec
+`flutter run` : les bonnes images sont toujours présentes après un clone.
 
 ## Signature Android
 Pour les builds de production, les mots de passe du keystore ne sont plus inclus dans le dépôt.

--- a/tool/ensure_lfs_assets.dart
+++ b/tool/ensure_lfs_assets.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+Future<void> main(List<String> arguments) async {
+  stdout.writeln(
+      '[ensure_lfs_assets] Checking Git LFS assets in ${Directory.current.path}');
+
+  await _runCommand(
+    'git',
+    ['lfs', 'install'],
+    'Failed to run "git lfs install". Install Git LFS from https://git-lfs.com/.',
+  );
+
+  await _runCommand(
+    'git',
+    ['lfs', 'pull'],
+    'Failed to download LFS assets. Check your Git credentials or network access.',
+  );
+
+  final criticalFiles = <String>[
+    'assets/images/logo_splash.png',
+  ];
+
+  final missingAssets = <String>[];
+
+  for (final relativePath in criticalFiles) {
+    final file = File(relativePath);
+    if (!file.existsSync()) {
+      missingAssets.add('$relativePath (missing)');
+      continue;
+    }
+
+    final length = file.lengthSync();
+    if (length <= 1024) {
+      missingAssets.add(
+        '$relativePath (size: $length bytes — looks like an LFS pointer file)',
+      );
+    }
+  }
+
+  if (missingAssets.isNotEmpty) {
+    stderr.writeln('[ensure_lfs_assets] Some required assets were not downloaded:');
+    for (final asset in missingAssets) {
+      stderr.writeln('  • $asset');
+    }
+    stderr.writeln(
+      '[ensure_lfs_assets] Run `git lfs pull` manually and ensure you can access the remote LFS store.',
+    );
+    exit(1);
+  }
+
+  stdout.writeln('[ensure_lfs_assets] Git LFS assets are present.');
+}
+
+Future<void> _runCommand(
+  String executable,
+  List<String> arguments,
+  String errorMessage,
+) async {
+  stdout.writeln('[ensure_lfs_assets] Running: $executable ${arguments.join(' ')}');
+
+  ProcessResult result;
+  try {
+    result = await Process.run(executable, arguments, runInShell: true);
+  } on ProcessException catch (error) {
+    stderr.writeln('[ensure_lfs_assets] $errorMessage');
+    stderr.writeln('  $error');
+    exit(1);
+  }
+
+  final stdoutContent = result.stdout?.toString() ?? '';
+  if (stdoutContent.isNotEmpty) {
+    stdout.write(stdoutContent);
+  }
+
+  final stderrContent = result.stderr?.toString() ?? '';
+  if (stderrContent.isNotEmpty) {
+    stderr.write(stderrContent);
+  }
+
+  if (result.exitCode != 0) {
+    stderr.writeln('[ensure_lfs_assets] $errorMessage');
+    stderr.writeln('Command exited with status ${result.exitCode}.');
+    exit(result.exitCode);
+  }
+}


### PR DESCRIPTION
## Summary
- add a Dart helper that installs/pulls Git LFS assets and validates key PNGs
- run the helper from the Flutter and Dart CI workflows before dependency resolution
- document the workflow in the README so local clones hydrate assets automatically

## Testing
- not run (dart command is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddcc3faa70832f9e468d234b9df19e