### PR TITLE
Adjust multi-exam pacing for difficulty levels

### DIFF
--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -52,13 +52,13 @@ String difficultyHint(ExamDifficulty d) {
 int? secondsPerQuestion(ExamDifficulty d) {
   switch (d) {
     case ExamDifficulty.facile:
-      return 90;
+      return 216;
     case ExamDifficulty.normal:
       return null;
     case ExamDifficulty.difficile:
-      return 45;
+      return 108;
     case ExamDifficulty.expert:
-      return 30;
+      return 72;
   }
 }
 

--- a/test/multi_exam_seconds_per_question_test.dart
+++ b/test/multi_exam_seconds_per_question_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:civexam_pro/screens/multi_exam_flow.dart';
+
+void main() {
+  group('secondsPerQuestion', () {
+    test('returns 216 seconds for facile (+50%)', () {
+      expect(secondsPerQuestion(ExamDifficulty.facile), 216);
+    });
+
+    test('returns null for normal (default pacing)', () {
+      expect(secondsPerQuestion(ExamDifficulty.normal), isNull);
+    });
+
+    test('returns 108 seconds for difficile (-25%)', () {
+      expect(secondsPerQuestion(ExamDifficulty.difficile), 108);
+    });
+
+    test('returns 72 seconds for expert (-50%)', () {
+      expect(secondsPerQuestion(ExamDifficulty.expert), 72);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- adjust the per-question timing in multi_exam_flow to match the 60-minute, 25-question baseline
- add a unit test that verifies the updated secondsPerQuestion values for each difficulty level

## Testing
- flutter test test/multi_exam_seconds_per_question_test.dart *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd96c8468832fa2ac8bed9145b4bd