### PR TITLE
Align exam flows with design palette updates

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -15,6 +15,8 @@ import 'package:device_info_plus/device_info_plus.dart'; // Détecter si l’app
 import '../models/question.dart'; // Modèle Question
 import '../services/scoring.dart'; // Calcul de score
 import '../app/theme.dart'; // Optionnel (ex: thèmes globaux)
+import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
 import '../utils/responsive_utils.dart'; // Helpers pour tailles de texte responsives
 
 // Ces deux imports sont pour ton bottom nav existant :
@@ -62,8 +64,8 @@ class ExamFullScreen extends StatefulWidget {
   final void Function(int remainingSeconds, List<int?> answers)? onStateChanged; // Callback régulier
   final VoidCallback? onStateCleared; // Callback à la sortie de l’exam
 
-  /// Couleur de marque pour l’épreuve (par défaut #5336C6).
-  final Color brandColor;
+  /// Couleur de marque pour l’épreuve (si null, déduite de la palette active).
+  final Color? brandColor;
 
   const ExamFullScreen({
     super.key,
@@ -78,7 +80,7 @@ class ExamFullScreen extends StatefulWidget {
     this.initialRemainingSeconds,
     this.onStateChanged,
     this.onStateCleared,
-    this.brandColor = const Color(0xFF5336C6),
+    this.brandColor,
   });
 
   @override
@@ -111,7 +113,25 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
   bool _secureFlagActive = false;   // FLAG_SECURE actif ?
 
   // --- Couleur de marque ---
-  Color get _brand => widget.brandColor;
+  Color _brandColor(BuildContext context) {
+    if (widget.brandColor != null) return widget.brandColor!;
+    final cfg = DesignBus.notifier.value;
+    final palette = playIconColors(cfg.bgPaletteName);
+    if (palette.isNotEmpty) {
+      return palette.first;
+    }
+    return Theme.of(context).colorScheme.primary;
+  }
+
+  Color _accentColor() {
+    final cfg = DesignBus.notifier.value;
+    return complementaryColor(cfg.bgPaletteName);
+  }
+
+  Color _onBrand(Color brand) {
+    final brightness = ThemeData.estimateBrightnessForColor(brand);
+    return brightness == Brightness.dark ? Colors.white : Colors.black;
+  }
 
   // =======================
   // LIFECYCLE: init / dispose
@@ -515,10 +535,9 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
   // =======================
   // UI: HEADER
   // =======================
-  Widget _header(BuildContext context, String title, int step, int total) {
+  Widget _header(
+      BuildContext context, String title, int step, int total, Color brand, Color onBrand) {
     final mq = MediaQuery.of(context);
-    final brand = _brand;         // couleur de marque
-    final onBrand = Colors.white; // texte blanc sur fond violet
     final progress = (step + 1) / total; // progression 0..1
 
     return SizedBox(
@@ -561,15 +580,17 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                     );
                     if (ok == true) _leaveExam(null);
                   },
-                  icon: const Icon(Icons.arrow_back, color: Colors.white),
+                  icon: Icon(Icons.arrow_back, color: onBrand),
                 ),
                 // Titre centré
                 Expanded(
                   child: Text(
                     title,
                     textAlign: TextAlign.center,
-                    style: const TextStyle(
-                      color: Colors.white, fontWeight: FontWeight.w700, fontSize: 18,
+                    style: TextStyle(
+                      color: onBrand,
+                      fontWeight: FontWeight.w700,
+                      fontSize: 18,
                     ),
                   ),
                 ),
@@ -578,12 +599,12 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                   margin: const EdgeInsets.only(right: 8),
                   padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
                   decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(.2),
+                    color: onBrand.withOpacity(.18),
                     borderRadius: BorderRadius.circular(18),
                   ),
                   child: Text(
                     _format(remaining),
-                    style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
+                    style: TextStyle(color: onBrand, fontWeight: FontWeight.w700),
                   ),
                 ),
               ],
@@ -601,8 +622,8 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                 LinearProgressIndicator(
                   value: progress,
                   minHeight: 6,
-                  backgroundColor: Colors.white.withOpacity(.25),
-                  color: Colors.white,
+                  backgroundColor: onBrand.withOpacity(.25),
+                  color: onBrand,
                 ),
                 const SizedBox(height: 12),
                 Row(
@@ -612,8 +633,8 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                       value: step + 1,
                       total: total,
                       size: 56,
-                      foreground: Colors.white,
-                      background: Colors.white.withOpacity(.35),
+                      foreground: onBrand,
+                      background: onBrand.withOpacity(.35),
                     ),
                     const SizedBox(width: 12),
                     // Label FR
@@ -630,8 +651,8 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                     OutlinedButton.icon(
                       onPressed: _submitted ? null : () => _submit(),
                       style: OutlinedButton.styleFrom(
-                        foregroundColor: Colors.white,
-                        side: BorderSide(color: Colors.white.withOpacity(.8)),
+                        foregroundColor: onBrand,
+                        side: BorderSide(color: onBrand.withOpacity(.8)),
                         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
                       ),
@@ -651,7 +672,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
   // =======================
   // UI: Question + actions bas
   // =======================
-  Widget _questionArea(Question q, int index) {
+  Widget _questionArea(Question q, int index, Color brand, Color onBrand) {
     final mediaQuery = MediaQuery.of(context);
     final scale = computeScaleFactor(mediaQuery);          // facteur device
     final textScaler = MediaQuery.textScalerOf(context);   // facteur accessibilité
@@ -666,7 +687,6 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     scaledFontSize(base: 18, scale: scale, textScaler: textScaler, min: 16, max: 22);
 
     final onSurface = Theme.of(context).colorScheme.onSurface;
-    final brand = _brand;
 
     return SafeArea(
       top: false,
@@ -721,6 +741,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                                   onTap: _submitted ? null : () => _onAnswer(index, c),
                                   fontSize: optionFontSize,
                                   brand: brand,
+                                  onBrand: onBrand,
                                   onSurface: onSurface,
                                 ),
                                 const SizedBox(height: 10),
@@ -763,7 +784,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                       style: ElevatedButton.styleFrom(
                         minimumSize: const Size.fromHeight(56),
                         backgroundColor: brand,
-                        foregroundColor: Colors.white,
+                        foregroundColor: onBrand,
                         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
                         textStyle: const TextStyle(fontWeight: FontWeight.w700),
                       ),
@@ -792,13 +813,25 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
   Widget build(BuildContext context) {
     final q = widget.questions;               // questions
     final title = widget.title ?? 'Examen';   // titre fallback
+    final Color brand = _brandColor(context);
+    final Brightness brandBrightness =
+        ThemeData.estimateBrightnessForColor(brand);
+    final Color onBrand =
+        brandBrightness == Brightness.dark ? Colors.white : Colors.black;
+    final Color accent = _accentColor();
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final Color navHighlight = accent.withOpacity(isDark ? 0.32 : 0.20);
+    final Brightness overlayIconBrightness =
+        brandBrightness == Brightness.dark ? Brightness.light : Brightness.dark;
+    final Brightness overlayStatusBrightness =
+        brandBrightness == Brightness.dark ? Brightness.dark : Brightness.light;
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       // Teinte des icônes de la status bar au-dessus du header violet
       value: SystemUiOverlayStyle(
-        statusBarColor: _brand,
-        statusBarIconBrightness: Brightness.light,
-        statusBarBrightness: Brightness.dark,
+        statusBarColor: brand,
+        statusBarIconBrightness: overlayIconBrightness,
+        statusBarBrightness: overlayStatusBrightness,
       ),
       child: SelectionContainer.disabled(
         child: Scaffold(
@@ -818,7 +851,9 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
               : PlayBottomNavBar(
             destinations: playNavDestinations,
             selectedIndex: 2,          // onglet courant
-            backgroundColor: _brand,   // teinte violette
+            backgroundColor: brand,
+            highlightColor: navHighlight,
+            foregroundColor: onBrand,
             onDestinationSelected: _handleBottomNavSelection,
           ),
 
@@ -834,7 +869,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
           // Corps: header + PageView des questions
           body: Column(
             children: [
-              _header(context, title, _currentIndex, q.length),
+              _header(context, title, _currentIndex, q.length, brand, onBrand),
               Expanded(
                 child: PageView.builder(
                   controller: _pageController,
@@ -844,7 +879,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
                       : const BouncingScrollPhysics(),
                   onPageChanged: (i) => setState(() => _currentIndex = i),
                   itemCount: q.length,
-                  itemBuilder: (_, i) => _questionArea(q[i], i),
+                  itemBuilder: (_, i) => _questionArea(q[i], i, brand, onBrand),
                 ),
               ),
             ],
@@ -864,6 +899,7 @@ class _OptionPill extends StatelessWidget {
   final VoidCallback? onTap; // callback au tap
   final double fontSize;  // taille du texte
   final Color brand;      // couleur de marque
+  final Color onBrand;    // couleur du texte sur marque
   final Color onSurface;  // couleur du texte standard
 
   const _OptionPill({
@@ -872,6 +908,7 @@ class _OptionPill extends StatelessWidget {
     required this.onTap,
     required this.fontSize,
     required this.brand,
+    required this.onBrand,
     required this.onSurface,
   });
 
@@ -881,7 +918,7 @@ class _OptionPill extends StatelessWidget {
     final Color unselectedBg = dark ? const Color(0xFF222329) : Colors.white; // fond non sélectionné
     final Color unselectedBorder = const Color(0xFFE0E0E6);                   // bord fin
     final Color bg = selected ? brand : unselectedBg;                          // fond si sélectionné
-    final Color fg = selected ? Colors.white : onSurface.withOpacity(.9);      // texte
+    final Color fg = selected ? onBrand : onSurface.withOpacity(.9);      // texte
 
     return Semantics(
       button: true,

--- a/lib/screens/leaderboard_screen.dart
+++ b/lib/screens/leaderboard_screen.dart
@@ -1,11 +1,17 @@
 // lib/screens/leaderboard_screen.dart
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../models/design_config.dart';
 import '../models/leaderboard_entry.dart';
 import '../services/competition_service.dart';
+import '../services/design_bus.dart';
 import '../utils/arcade_level_utils.dart';
 import '../utils/rank_display_helper.dart';
+import '../utils/palette_utils.dart';
 import '../widgets/arcade_badge_chip.dart';
+import '../widgets/play_bottom_nav_bar.dart';
 import '../widgets/play_themed_scaffold.dart';
+import 'play_screen.dart';
 
 enum _Period { weekly, allTime }
 
@@ -16,8 +22,6 @@ class LeaderboardScreen extends StatefulWidget {
 }
 
 class _LeaderboardScreenState extends State<LeaderboardScreen> {
-  static const Color _brand = Color(0xFF5336C6);
-
   List<LeaderboardEntry> _entries = const [];
   String _query = '';
   _Period _period = _Period.allTime;
@@ -61,91 +65,121 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   Widget build(BuildContext context) {
     final filtered = _filtered;
 
-    return PlayThemedScaffold(
-      safeAreaTop: true,
-      bodyMode: PlayThemedScaffoldBodyMode.panel,
-      // on laisse l'appbar du PlayThemedScaffold pour l'intégration globale
-      appBar: AppBar(
-        backgroundColor: _brand,
-        elevation: 0,
-        title: const Text('Classement'),
-        actions: [
-          IconButton(icon: const Icon(Icons.refresh), onPressed: _load),
-        ],
-      ),
-      // padding interne: on met notre header custom, donc padding simple
-      bodyPadding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // ==== Segmented control Hebdo / Tout temps ====
-          _SegmentedPeriod(
-            value: _period,
-            onChanged: (_Period p) => setState(() => _period = p),
-            brand: _brand,
-          ),
-          const SizedBox(height: 16),
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final palette = playIconColors(cfg.bgPaletteName);
+        final Color brand = palette.first;
+        final Brightness brandBrightness =
+            ThemeData.estimateBrightnessForColor(brand);
+        final Color onBrand =
+            brandBrightness == Brightness.dark ? Colors.white : Colors.black;
+        final Color accent = complementaryColor(cfg.bgPaletteName);
+        final bool isDark = Theme.of(context).brightness == Brightness.dark;
+        final Color navHighlight = accent.withOpacity(isDark ? 0.32 : 0.20);
 
-          // ==== Barre de recherche ====
-          TextField(
-            decoration: InputDecoration(
-              isDense: true,
-              prefixIcon: const Icon(Icons.search),
-              hintText: 'Chercher (nom / matière / chapitre)',
-              filled: true,
-              fillColor: Theme.of(context).brightness == Brightness.dark
-                  ? const Color(0xFF1F1F22)
-                  : Colors.white,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(16),
-                borderSide: BorderSide(color: Colors.black.withOpacity(0.06)),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(16),
-                borderSide: BorderSide(color: Colors.black.withOpacity(0.06)),
-              ),
+        return PlayThemedScaffold(
+          safeAreaTop: true,
+          bodyMode: PlayThemedScaffoldBodyMode.panel,
+          appBar: AppBar(
+            backgroundColor: brand,
+            foregroundColor: onBrand,
+            elevation: 0,
+            title: const Text('Classement'),
+            systemOverlayStyle: SystemUiOverlayStyle(
+              statusBarColor: brand,
+              statusBarIconBrightness:
+                  brandBrightness == Brightness.dark ? Brightness.light : Brightness.dark,
+              statusBarBrightness:
+                  brandBrightness == Brightness.dark ? Brightness.dark : Brightness.light,
             ),
-            onChanged: (v) => setState(() => _query = v),
+            actions: [
+              IconButton(icon: const Icon(Icons.refresh), onPressed: _load),
+            ],
           ),
-          const SizedBox(height: 16),
+          bodyPadding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+          body: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _SegmentedPeriod(
+                value: _period,
+                onChanged: (_Period p) => setState(() => _period = p),
+                brand: brand,
+                onBrand: onBrand,
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                decoration: InputDecoration(
+                  isDense: true,
+                  prefixIcon: const Icon(Icons.search),
+                  hintText: 'Chercher (nom / matière / chapitre)',
+                  filled: true,
+                  fillColor: Theme.of(context).brightness == Brightness.dark
+                      ? const Color(0xFF1F1F22)
+                      : Colors.white,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    borderSide: BorderSide(color: Colors.black.withOpacity(0.06)),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    borderSide: BorderSide(color: Colors.black.withOpacity(0.06)),
+                  ),
+                ),
+                onChanged: (v) => setState(() => _query = v),
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: filtered.isEmpty
+                    ? const _EmptyState()
+                    : ListView.separated(
+                        itemCount: filtered.length,
+                        separatorBuilder: (_, __) => const SizedBox(height: 10),
+                        padding: const EdgeInsets.only(bottom: 24),
+                        itemBuilder: (context, i) {
+                          final e = filtered[i];
+                          final rank = i + 1;
+                          final isFirst = rank == 1;
+                          final badgeLabel = normalizeArcadeLevel(e.arcadeLevel);
 
-          // ==== Liste ====
-          Expanded(
-            child: filtered.isEmpty
-                ? const _EmptyState()
-                : ListView.separated(
-              itemCount: filtered.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 10),
-              padding: const EdgeInsets.only(bottom: 24),
-              itemBuilder: (context, i) {
-                final e = filtered[i];
-                final rank = i + 1;
-                final isFirst = rank == 1;
-                final badgeLabel = normalizeArcadeLevel(e.arcadeLevel);
-
-                return _LeaderboardCard(
-                  rank: rank,
-                  name: e.name,
-                  subtitle:
-                  'Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}'
-                      '${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}',
-                  rightTopText: '${e.percent.toStringAsFixed(1)} %',
-                  rightBottomText:
-                  '${e.correct}/${e.total} • ${_fmtDuration(e.durationSec)}',
-                  // Avatar “initiale”
-                  avatarText: _initials(e.name),
-                  crown: isFirst,
-                  badge: badgeLabel,
-                  brand: _brand,
-                );
-              },
-            ),
+                          return _LeaderboardCard(
+                            rank: rank,
+                            name: e.name,
+                            subtitle:
+                                'Compétition • ${e.subject.isEmpty ? 'Général' : e.subject}'
+                                '${e.chapter.isEmpty ? '' : ' / ${e.chapter}'}',
+                            rightTopText: '${e.percent.toStringAsFixed(1)} %',
+                            rightBottomText:
+                                '${e.correct}/${e.total} • ${_fmtDuration(e.durationSec)}',
+                            avatarText: _initials(e.name),
+                            crown: isFirst,
+                            badge: badgeLabel,
+                            brand: brand,
+                            onBrand: onBrand,
+                          );
+                        },
+                      ),
+              ),
+            ],
           ),
-        ],
-      ),
+          bottomNavigationBar: PlayBottomNavBar(
+            destinations: playNavDestinations,
+            selectedIndex: 2,
+            backgroundColor: brand,
+            highlightColor: navHighlight,
+            foregroundColor: onBrand,
+            onDestinationSelected: (index) {
+              if (index == 2) return;
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(builder: (_) => PlayScreen(initialIndex: index)),
+              );
+            },
+          ),
+        );
+      },
     );
   }
-
   String _fmtDuration(int s) {
     final m = s ~/ 60;
     final r = s % 60;
@@ -169,21 +203,31 @@ class _SegmentedPeriod extends StatelessWidget {
   final _Period value;
   final ValueChanged<_Period> onChanged;
   final Color brand;
+  final Color onBrand;
 
   const _SegmentedPeriod({
     required this.value,
     required this.onChanged,
     required this.brand,
+    required this.onBrand,
   });
 
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool brandIsDark = ThemeData.estimateBrightnessForColor(brand) == Brightness.dark;
+    final Color trackColor = brand.withOpacity(isDark ? 0.30 : 0.25);
+    final Color selectedBackground =
+        brandIsDark ? onBrand : brand.withOpacity(isDark ? 0.65 : 0.85);
+    final Color selectedTextColor = brandIsDark ? brand : onBrand;
+    final Color unselectedTextColor =
+        onBrand.withOpacity(brandIsDark ? 0.9 : 0.75);
+    final Color rippleColor = brand.withOpacity(0.16);
 
     return Container(
       height: 44,
       decoration: BoxDecoration(
-        color: brand.withOpacity(isDark ? 0.30 : 0.25),
+        color: trackColor,
         borderRadius: BorderRadius.circular(22),
       ),
       child: LayoutBuilder(
@@ -203,7 +247,10 @@ class _SegmentedPeriod extends StatelessWidget {
                         label: 'Hebdo',
                         selected: value == _Period.weekly,
                         onTap: () => onChanged(_Period.weekly),
-                        brand: brand,
+                        selectedBackground: selectedBackground,
+                        selectedTextColor: selectedTextColor,
+                        unselectedTextColor: unselectedTextColor,
+                        rippleColor: rippleColor,
                       ),
                       const SizedBox(width: 4),
                       _SegmentButton(
@@ -211,7 +258,10 @@ class _SegmentedPeriod extends StatelessWidget {
                         label: 'Tout temps',
                         selected: value == _Period.allTime,
                         onTap: () => onChanged(_Period.allTime),
-                        brand: brand,
+                        selectedBackground: selectedBackground,
+                        selectedTextColor: selectedTextColor,
+                        unselectedTextColor: unselectedTextColor,
+                        rippleColor: rippleColor,
                       ),
                     ],
                   ),
@@ -230,14 +280,20 @@ class _SegmentButton extends StatelessWidget {
   final String label;
   final bool selected;
   final VoidCallback onTap;
-  final Color brand;
+  final Color selectedBackground;
+  final Color selectedTextColor;
+  final Color unselectedTextColor;
+  final Color rippleColor;
 
   const _SegmentButton({
     required this.width,
     required this.label,
     required this.selected,
     required this.onTap,
-    required this.brand,
+    required this.selectedBackground,
+    required this.selectedTextColor,
+    required this.unselectedTextColor,
+    required this.rippleColor,
   });
 
   @override
@@ -247,7 +303,7 @@ class _SegmentButton extends StatelessWidget {
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 180),
         decoration: BoxDecoration(
-          color: selected ? Colors.white : Colors.white.withOpacity(0.0),
+          color: selected ? selectedBackground : Colors.transparent,
           borderRadius: BorderRadius.circular(18),
           boxShadow: selected
               ? [BoxShadow(color: Colors.black.withOpacity(0.10), blurRadius: 8, offset: const Offset(0, 3))]
@@ -258,6 +314,7 @@ class _SegmentButton extends StatelessWidget {
           child: InkWell(
             borderRadius: BorderRadius.circular(18),
             onTap: onTap,
+            splashColor: rippleColor,
             child: Center(
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
@@ -265,7 +322,7 @@ class _SegmentButton extends StatelessWidget {
                   label,
                   style: TextStyle(
                     fontWeight: FontWeight.w700,
-                    color: selected ? brand : Colors.white,
+                    color: selected ? selectedTextColor : unselectedTextColor,
                   ),
                 ),
               ),
@@ -287,6 +344,7 @@ class _LeaderboardCard extends StatelessWidget {
   final bool crown;
   final String badge;
   final Color brand;
+  final Color onBrand;
 
   const _LeaderboardCard({
     required this.rank,
@@ -298,6 +356,7 @@ class _LeaderboardCard extends StatelessWidget {
     required this.crown,
     required this.badge,
     required this.brand,
+    required this.onBrand,
   });
 
   @override
@@ -326,7 +385,7 @@ class _LeaderboardCard extends StatelessWidget {
             backgroundColor: brand,
             child: Text(
               avatarText,
-              style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
+              style: TextStyle(color: onBrand, fontWeight: FontWeight.w700),
             ),
           ),
           const SizedBox(width: 12),

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../models/design_config.dart';
 import '../models/question.dart';
 import '../services/scoring.dart';
 import '../services/question_loader.dart';
@@ -12,6 +13,7 @@ import '../services/question_randomizer.dart';
 import '../services/question_history_store.dart';
 import '../services/exam_blueprint.dart';
 import '../data/ena_taxonomy.dart';
+import '../services/design_bus.dart';
 import '../utils/palette_utils.dart';
 import '../widgets/play_bottom_nav_bar.dart';
 import '../widgets/play_themed_scaffold.dart';
@@ -177,6 +179,9 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
     abandoned = false;
     final perQ = secondsPerQuestion(_difficulty);
 
+    final design = DesignBus.notifier.value;
+    final Color brandColor = playIconColors(design.bgPaletteName).first;
+
     await QuestionHistoryStore.clear();
 
     for (final sec in sections) {
@@ -259,8 +264,8 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
             scoring: sec.scoring,
             title: 'Épreuve : ${sec.title} • ${difficultyLabel(_difficulty)}',
             showLocalSummary: false,
-            // ---> on propage la couleur #5336C6 dans l’épreuve
-            brandColor: const Color(0xFF5336C6),
+            // Propage la couleur de marque actuelle
+            brandColor: brandColor,
           ),
         ),
       );
@@ -427,197 +432,226 @@ class _MultiExamFlowScreenState extends State<MultiExamFlowScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    final bool isDark = scheme.brightness == Brightness.dark;
+    return ValueListenableBuilder<DesignConfig>(
+      valueListenable: DesignBus.notifier,
+      builder: (context, cfg, _) {
+        final scheme = Theme.of(context).colorScheme;
+        final bool isDark = scheme.brightness == Brightness.dark;
+        final palette = playIconColors(cfg.bgPaletteName);
+        final Color brand = palette.first;
+        final Color accent = complementaryColor(cfg.bgPaletteName);
+        final Brightness brandBrightness =
+            ThemeData.estimateBrightnessForColor(brand);
+        final Color onBrand =
+            brandBrightness == Brightness.dark ? Colors.white : Colors.black;
+        final Color pageBg =
+            isDark ? const Color(0xFF111318) : const Color(0xFFF7F8FA);
+        final Color onPage =
+            isDark ? Colors.white.withOpacity(0.92) : const Color(0xFF1B1B1F);
+        final Color cardColor =
+            isDark ? const Color(0xFF1F1F22) : Colors.white;
+        final Color navHighlight =
+            accent.withOpacity(isDark ? 0.32 : 0.20);
 
-    // === Marque globale ===
-    final Color brand = PlayBottomNavBar.defaultBackgroundColor;
-    final Color pageBg = isDark ? const Color(0xFF111318) : const Color(0xFFF7F8FA);
-    final Color onPage = isDark ? Colors.white.withOpacity(0.92) : const Color(0xFF1B1B1F);
-    final Color cardColor = isDark ? const Color(0xFF1F1F22) : Colors.white;
+        final perQ = secondsPerQuestion(_difficulty);
 
-    final perQ = secondsPerQuestion(_difficulty);
-
-    final Widget content = loading
-        ? const Center(child: CircularProgressIndicator())
-        : ListView(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 140),
-            children: [
-              // ===== HERO CARD =====
-              Container(
-                decoration: BoxDecoration(
-                  color: brand,
-                  borderRadius: BorderRadius.circular(24),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.08),
-                      blurRadius: 14,
-                      offset: const Offset(0, 6),
-                    ),
-                  ],
-                ),
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Puce
-                    Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withOpacity(0.18),
-                        borderRadius: BorderRadius.circular(16),
-                      ),
-                      child: const Text(
-                        'Parcours multi-épreuves',
-                        style: TextStyle(color: Colors.white, fontWeight: FontWeight.w700),
-                      ),
-                    ),
-                    const SizedBox(height: 12),
-                    const Text(
-                      'Concours ENA — Simulation complète',
-                      style: TextStyle(
-                        fontWeight: FontWeight.w800,
-                        fontSize: 22,
-                        color: Colors.white,
-                        letterSpacing: .2,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Row(
-                      children: [
-                        const Icon(Icons.timer, size: 18, color: Colors.white),
-                        const SizedBox(width: 8),
-                        Text(
-                          perQ == null
-                              ? 'Mode Normal — timings officiels'
-                              : 'Mode ${difficultyLabel(_difficulty)} — ~${perQ}s/question',
-                          style: TextStyle(
-                            color: Colors.white.withOpacity(0.92),
-                            fontWeight: FontWeight.w600,
-                          ),
+        final Widget content = loading
+            ? const Center(child: CircularProgressIndicator())
+            : ListView(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 140),
+                children: [
+                  // ===== HERO CARD =====
+                  Container(
+                    decoration: BoxDecoration(
+                      color: brand,
+                      borderRadius: BorderRadius.circular(24),
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.08),
+                          blurRadius: 14,
+                          offset: const Offset(0, 6),
                         ),
                       ],
                     ),
-                    const SizedBox(height: 12),
-                    _difficultyPicker(context),
-                  ],
-                ),
-              ),
-
-              const SizedBox(height: 22),
-
-              // ===== Rappel important =====
-              Text(
-                'Rappel important',
-                style: TextStyle(
-                  fontWeight: FontWeight.w700,
-                  fontSize: 18,
-                  color: onPage,
-                ),
-              ),
-              const SizedBox(height: 10),
-              _InfoBadgeCard(
-                icon: Icons.rule,
-                primary: 'Barème',
-                secondary: '+1 bonne · 0 blanc · −1 mauvaise',
-                brand: brand,
-                onPage: onPage,
-                cardColor: cardColor,
-              ),
-              const SizedBox(height: 10),
-              _InfoBadgeCard(
-                icon: Icons.calculate,
-                primary: 'Coefficient',
-                secondary: '×2 par épreuve',
-                brand: brand,
-                onPage: onPage,
-                cardColor: cardColor,
-              ),
-
-              const SizedBox(height: 22),
-
-              // ===== Liste des épreuves =====
-              Text(
-                'Épreuves',
-                style: TextStyle(
-                  fontWeight: FontWeight.w700,
-                  fontSize: 18,
-                  color: onPage,
-                ),
-              ),
-              const SizedBox(height: 12),
-              for (final s in sections) ...[
-                _SectionTile(
-                  icon: _iconForSection(s.title),
-                  title: s.title,
-                  subtitle:
-                      'Questions visées : ${s.targetCount} · Barème ${s.scoring.toStringShort()}',
-                  rightLabel: perQ == null
-                      ? _formatShort(s.duration)
-                      : _formatShort(Duration(seconds: (perQ * s.targetCount))),
-                  cardColor: cardColor,
-                  brand: brand,
-                  onPage: onPage,
-                ),
-                const SizedBox(height: 10),
-              ],
-
-              const SizedBox(height: 8),
-              // ===== CTA =====
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton.icon(
-                  onPressed: _startFlow,
-                  icon: const Icon(Icons.play_arrow),
-                  label: const Text('Démarrer le parcours'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: brand,
-                    foregroundColor: Colors.white,
-                    minimumSize: const Size.fromHeight(56),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(28),
-                    ),
-                    textStyle: const TextStyle(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 18,
+                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Puce
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 6),
+                          decoration: BoxDecoration(
+                            color: onBrand.withOpacity(0.16),
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: Text(
+                            'Parcours multi-épreuves',
+                            style: TextStyle(
+                              color: onBrand,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Concours ENA — Simulation complète',
+                          style: TextStyle(
+                            fontWeight: FontWeight.w800,
+                            fontSize: 22,
+                            color: onBrand,
+                            letterSpacing: .2,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            Icon(Icons.timer, size: 18, color: accent),
+                            const SizedBox(width: 8),
+                            Text(
+                              perQ == null
+                                  ? 'Mode Normal — timings officiels'
+                                  : 'Mode ${difficultyLabel(_difficulty)} — ~${perQ}s/question',
+                              style: TextStyle(
+                                color: onBrand.withOpacity(0.92),
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        _difficultyPicker(context),
+                      ],
                     ),
                   ),
-                ),
-              ),
-            ],
-          );
 
-    return PlayThemedScaffold(
-      extendBodyBehindAppBar: false,
-      appBar: AppBar(
-        leading: const BackButton(),
-        title: const Text('Parcours multi-épreuves'),
-        backgroundColor: brand,
-        foregroundColor: Colors.white,
-        elevation: 0,
-        surfaceTintColor: Colors.transparent,
-        systemOverlayStyle: SystemUiOverlayStyle(
-          statusBarColor: brand,
-          statusBarIconBrightness: Brightness.light,
-          statusBarBrightness: Brightness.dark,
-        ),
-      ),
-      body: DecoratedBox(
-        decoration: BoxDecoration(color: pageBg),
-        child: content,
-      ),
-      bottomNavigationBar: PlayBottomNavBar(
-        destinations: playNavDestinations,
-        selectedIndex: 2,
-        backgroundColor: brand,
-        onDestinationSelected: (index) {
-          if (index == 2) return;
-          Navigator.pushReplacement(
-            context,
-            MaterialPageRoute(builder: (_) => PlayScreen(initialIndex: index)),
-          );
-        },
-      ),
+                  const SizedBox(height: 22),
+
+                  // ===== Rappel important =====
+                  Text(
+                    'Rappel important',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 18,
+                      color: onPage,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  _InfoBadgeCard(
+                    icon: Icons.rule,
+                    primary: 'Barème',
+                    secondary: '+1 bonne · 0 blanc · −1 mauvaise',
+                    brand: brand,
+                    onPage: onPage,
+                    cardColor: cardColor,
+                  ),
+                  const SizedBox(height: 10),
+                  _InfoBadgeCard(
+                    icon: Icons.calculate,
+                    primary: 'Coefficient',
+                    secondary: '×2 par épreuve',
+                    brand: brand,
+                    onPage: onPage,
+                    cardColor: cardColor,
+                  ),
+
+                  const SizedBox(height: 22),
+
+                  // ===== Liste des épreuves =====
+                  Text(
+                    'Épreuves',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 18,
+                      color: onPage,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  for (final s in sections) ...[
+                    _SectionTile(
+                      icon: _iconForSection(s.title),
+                      title: s.title,
+                      subtitle:
+                          'Questions visées : ${s.targetCount} · Barème ${s.scoring.toStringShort()}',
+                      rightLabel: perQ == null
+                          ? _formatShort(s.duration)
+                          : _formatShort(Duration(seconds: (perQ * s.targetCount))),
+                      cardColor: cardColor,
+                      brand: brand,
+                      onPage: onPage,
+                    ),
+                    const SizedBox(height: 10),
+                  ],
+
+                  const SizedBox(height: 8),
+                  // ===== CTA =====
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton.icon(
+                      onPressed: _startFlow,
+                      icon: Icon(Icons.play_arrow, color: onBrand),
+                      label: Text(
+                        'Démarrer le parcours',
+                        style: TextStyle(color: onBrand),
+                      ),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: brand,
+                        foregroundColor: onBrand,
+                        minimumSize: const Size.fromHeight(56),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(28),
+                        ),
+                        textStyle: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 18,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+
+        final Brightness overlayIconBrightness =
+            brandBrightness == Brightness.dark ? Brightness.light : Brightness.dark;
+        final Brightness overlayStatusBrightness =
+            brandBrightness == Brightness.dark ? Brightness.dark : Brightness.light;
+
+        return PlayThemedScaffold(
+          extendBodyBehindAppBar: false,
+          appBar: AppBar(
+            leading: const BackButton(),
+            title: const Text('Parcours multi-épreuves'),
+            backgroundColor: brand,
+            foregroundColor: onBrand,
+            elevation: 0,
+            surfaceTintColor: Colors.transparent,
+            systemOverlayStyle: SystemUiOverlayStyle(
+              statusBarColor: brand,
+              statusBarIconBrightness: overlayIconBrightness,
+              statusBarBrightness: overlayStatusBrightness,
+            ),
+          ),
+          body: DecoratedBox(
+            decoration: BoxDecoration(color: pageBg),
+            child: content,
+          ),
+          bottomNavigationBar: PlayBottomNavBar(
+            destinations: playNavDestinations,
+            selectedIndex: 2,
+            backgroundColor: brand,
+            highlightColor: navHighlight,
+            foregroundColor: onBrand,
+            onDestinationSelected: (index) {
+              if (index == 2) return;
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => PlayScreen(initialIndex: index)),
+              );
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/screens/official_intro_screen.dart
+++ b/lib/screens/official_intro_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../models/design_config.dart';
 import '../services/design_bus.dart';
+import '../utils/palette_utils.dart';
 import '../utils/responsive_utils.dart';
 import '../widgets/play_bottom_nav_bar.dart';
 import 'multi_exam_flow.dart';
@@ -61,7 +62,17 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
         final textScaler = MediaQuery.textScalerOf(context);
 
         // Palette / surfaces
-        final Color brand = PlayBottomNavBar.defaultBackgroundColor; // ton violet
+        final iconPalette = playIconColors(cfg.bgPaletteName);
+        final Color brand = iconPalette.first;
+        final Color accent = complementaryColor(cfg.bgPaletteName);
+        final Brightness brandBrightness =
+            ThemeData.estimateBrightnessForColor(brand);
+        final Brightness overlayIconBrightness =
+            brandBrightness == Brightness.dark ? Brightness.light : Brightness.dark;
+        final Brightness overlayStatusBrightness =
+            brandBrightness == Brightness.dark ? Brightness.dark : Brightness.light;
+        final Color onBrand =
+            brandBrightness == Brightness.dark ? Colors.white : Colors.black;
         final Color pageBg = scheme.brightness == Brightness.dark
             ? const Color(0xFF111318)
             : const Color(0xFFF7F8FA);
@@ -110,14 +121,18 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
             automaticallyImplyLeading: false,
             systemOverlayStyle: SystemUiOverlayStyle(
               statusBarColor: brand,
-              statusBarIconBrightness: Brightness.light,
-              statusBarBrightness: Brightness.dark,
+              statusBarIconBrightness: overlayIconBrightness,
+              statusBarBrightness: overlayStatusBrightness,
             ),
           ),
 
           bottomNavigationBar: PlayBottomNavBar(
             destinations: playNavDestinations,
             selectedIndex: 2,
+            backgroundColor: brand,
+            highlightColor:
+                accent.withOpacity(scheme.brightness == Brightness.dark ? 0.32 : 0.20),
+            foregroundColor: onBrand,
             onDestinationSelected: (index) {
               if (index == 2) return;
               Navigator.pushReplacement(
@@ -144,13 +159,15 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
                     // ===== HERO CARD (inspirée "Top Picks") =====
                     _HeroIntroCard(
                       brand: brand,
+                      onBrand: onBrand,
+                      accent: accent,
                       titleStyle: TextStyle(
                         fontWeight: FontWeight.w800,
                         fontSize: introTitleSize,
-                        color: Colors.white,
+                        color: onBrand,
                         letterSpacing: .2,
                       ),
-                      bodyStyle: bodyTextStyle.copyWith(color: Colors.white.withOpacity(0.92)),
+                      bodyStyle: bodyTextStyle.copyWith(color: onBrand.withOpacity(0.92)),
                     ),
 
                     const SizedBox(height: 20),
@@ -243,7 +260,7 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
                           value: _accepted,
                           onChanged: (v) => setState(() => _accepted = v ?? false),
                           activeColor: brand,
-                          checkColor: Colors.white,
+                          checkColor: onBrand,
                           side: BorderSide(color: onPage.withOpacity(0.5)),
                           fillColor: MaterialStateProperty.resolveWith((states) {
                             if (states.contains(MaterialState.selected)) return brand;
@@ -266,7 +283,7 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
                         onPressed: _accepted && !_starting ? _startCountdown : null,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: brand,
-                          foregroundColor: Colors.white,
+                          foregroundColor: onBrand,
                           minimumSize: const Size.fromHeight(56),
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(28),
@@ -312,10 +329,14 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
 
 class _HeroIntroCard extends StatelessWidget {
   final Color brand;
+  final Color onBrand;
+  final Color accent;
   final TextStyle titleStyle;
   final TextStyle bodyStyle;
   const _HeroIntroCard({
     required this.brand,
+    required this.onBrand,
+    required this.accent,
     required this.titleStyle,
     required this.bodyStyle,
   });
@@ -336,17 +357,20 @@ class _HeroIntroCard extends StatelessWidget {
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             decoration: BoxDecoration(
-              color: Colors.white.withOpacity(0.18),
+              color: onBrand.withOpacity(0.16),
               borderRadius: BorderRadius.circular(16),
             ),
-            child: const Text('Prépa officielle', style: TextStyle(color: Colors.white, fontWeight: FontWeight.w700)),
+            child: Text(
+              'Prépa officielle',
+              style: TextStyle(color: onBrand, fontWeight: FontWeight.w700),
+            ),
           ),
           const SizedBox(height: 12),
           Text('Concours officiel — Consignes', style: titleStyle),
           const SizedBox(height: 8),
           Row(
             children: [
-              const Icon(Icons.add_circle, size: 18, color: Colors.white),
+              Icon(Icons.add_circle, size: 18, color: accent),
               const SizedBox(width: 8),
               Text('4 épreuves • ENA Côte d’Ivoire', style: bodyStyle),
             ],


### PR DESCRIPTION
## Summary
- update the official intro screen to source brand and accent colors from the active DesignBus palette and apply them to the hero card, CTA, and bottom navigation
- wrap the multi-exam flow in a design ValueListenableBuilder to recolor cards, actions, the app bar, bottom nav, and pass the resolved brand to ExamFullScreen
- let ExamFullScreen derive its brand palette when absent and propagate it through the header, question controls, and footer navigation
- refresh the leaderboard screen so its app bar, segmented control, leaderboard cards, and bottom nav follow the current palette

## Testing
- not run (flutter tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68de71eb2c00832f8efe16f487819204