### PR TITLE
Restrict OfficialIntroScreen import visibility

### DIFF
--- a/lib/screens/categories/prepa_ena_screen.dart
+++ b/lib/screens/categories/prepa_ena_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../official_intro_screen.dart';
+import '../official_intro_screen.dart' show OfficialIntroScreen;
 import '../subject_list_screen.dart';
 import 'category_definitions.dart';
 import 'category_helpers.dart';

--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -47,7 +47,7 @@ import 'categories/ressources_officielles_screen.dart';
 import 'categories/historique_suivi_screen.dart';
 import 'categories/defis_classement_screen.dart';
 import 'categories/aide_themes_screen.dart';
-import 'official_intro_screen.dart';
+import 'official_intro_screen.dart' show OfficialIntroScreen;
 
 /// ============================================================================
 /// === CONFIG UI (éditable facilement) ========================================


### PR DESCRIPTION
## Summary
- limit the play screen import of the official intro screen to only expose OfficialIntroScreen
- adjust the prepa ENA screen import to only expose OfficialIntroScreen

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de89d8a8d4832faa21d8028f4d0402