### PR TITLE
Pass onBrand through shell body

### DIFF
--- a/lib/screens/play_screen.dart
+++ b/lib/screens/play_screen.dart
@@ -733,11 +733,13 @@ class _HomeShellState extends State<HomeShell> {
     required double scale,
     required double panelHeightFactor,
     required Color brand,
+    required Color onBrand,
     required Color accent,
     required Color brandOverlay,
     required Color accentOverlay,
     required Color brandVariant,
   }) {
+    final shellOnBrand = onBrand;
     final tabChildren = <Widget>[
       KeyedSubtree(
         key: const ValueKey('home_tab'),
@@ -753,7 +755,7 @@ class _HomeShellState extends State<HomeShell> {
           scale: scale,
           panelHeightFactor: panelHeightFactor,
           brand: brand,
-          onBrand: onBrand,
+          onBrand: shellOnBrand,
           accent: accent,
           brandOverlay: brandOverlay,
           accentOverlay: accentOverlay,
@@ -847,6 +849,7 @@ class _HomeShellState extends State<HomeShell> {
           scale: scale,
           panelHeightFactor: panelHeightFactor,
           brand: brand,
+          onBrand: onBrand,
           accent: accent,
           brandOverlay: brandOverlay,
           accentOverlay: accentOverlay,


### PR DESCRIPTION
## Summary
- require an onBrand color when building the shell body and keep a local reference
- forward the onBrand color to the home tab and section builders so they receive the same value

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de8c12b598832f844c4c73f214c1c3