### PR TITLE
Align primary color with selected palette accent

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -11,11 +11,18 @@ ThemeData buildAppTheme(DesignConfig cfg) {
   final textColor =
       textColorForPalette(cfg.bgPaletteName, darkMode: cfg.darkMode);
 
+  final seededScheme = ColorScheme.fromSeed(
+    seedColor: accent,
+    brightness: brightness,
+  );
+
+  final colorScheme = seededScheme.copyWith(
+    primary: accent,
+    onPrimary: onColor(accent),
+  );
+
   final base = ThemeData(
-    colorScheme: ColorScheme.fromSeed(
-      seedColor: accent,
-      brightness: brightness,
-    ),
+    colorScheme: colorScheme,
     useMaterial3: true,
     scaffoldBackgroundColor: Colors.transparent,
   );
@@ -36,6 +43,7 @@ ThemeData buildAppTheme(DesignConfig cfg) {
       );
 
   return base.copyWith(
+    colorScheme: colorScheme,
     textTheme: textTheme,
     iconTheme: IconThemeData(
       color: iconColors.last,


### PR DESCRIPTION
## Summary
- ensure the generated ColorScheme overrides primary/onPrimary with the palette accent
- pass the adjusted ColorScheme through ThemeData so consumers inherit the corrected accent

## Testing
- not run (environment does not include Flutter SDK)


------
https://chatgpt.com/codex/tasks/task_e_68dece48bba0832f869470acca456909