### PR TITLE
Style competition option pills with badges

### DIFF
--- a/lib/screens/competition_screen.dart
+++ b/lib/screens/competition_screen.dart
@@ -75,6 +75,16 @@ class _CompetitionScreenState extends State<CompetitionScreen>
     );
   }
 
+  String _optionBadgeLabel(int index) {
+    const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    if (index < letters.length) {
+      return letters[index];
+    }
+    final prefix = letters[index % letters.length];
+    final suffix = (index ~/ letters.length) + 1;
+    return '$prefix$suffix';
+  }
+
   @override
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
@@ -325,23 +335,38 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                     final bool isSelected = _selected == i;
                     final bool isHighlighted = _highlighted == i;
                     final borderRadius =
-                    BorderRadius.circular(theme.optionCardRadius);
+                        BorderRadius.circular(theme.optionCardRadius);
                     final Color baseColor = theme.optionCardColor;
-                    final Color highlightOverlay =
-                        theme.selectedChipBackgroundColor.withOpacity(0.06);
-                    final Color selectedOverlay =
-                        theme.selectedChipBackgroundColor.withOpacity(0.12);
-                    final Color resolvedColor = isSelected
-                        ? Color.alphaBlend(selectedOverlay, baseColor)
+                    final Color hoverOverlay =
+                        theme.optionSelectedBackgroundColor.withOpacity(0.06);
+                    final Color resolvedBackground = isSelected
+                        ? theme.optionSelectedBackgroundColor
                         : isHighlighted
-                            ? Color.alphaBlend(highlightOverlay, baseColor)
+                            ? Color.alphaBlend(hoverOverlay, baseColor)
                             : baseColor;
+                    final TextStyle resolvedTextStyle = theme.optionTextStyle
+                        .copyWith(
+                      fontSize: optionFontSize,
+                      color: isSelected
+                          ? theme.optionSelectedTextColor
+                          : theme.optionTextStyle.color,
+                      fontWeight: isSelected
+                          ? FontWeight.w700
+                          : theme.optionTextStyle.fontWeight,
+                    );
+                    final Color badgeBackground = isSelected
+                        ? theme.optionBadgeSelectedBackgroundColor
+                        : theme.optionBadgeBackgroundColor;
+                    final Color badgeForeground = isSelected
+                        ? theme.optionBadgeSelectedForegroundColor
+                        : theme.optionBadgeForegroundColor;
+                    final double badgeSize = theme.optionBadgeSize;
 
                     return Padding(
                       padding: const EdgeInsets.symmetric(vertical: 8),
                       child: Container(
                         width: double.infinity,
-                        constraints: const BoxConstraints(maxWidth: 400),
+                        constraints: const BoxConstraints(maxWidth: 460),
                         child: AnimatedScale(
                           scale: isHighlighted ? 0.97 : 1.0,
                           duration: const Duration(milliseconds: 140),
@@ -351,10 +376,11 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                             borderRadius: borderRadius,
                             child: InkWell(
                               borderRadius: borderRadius,
-                              splashColor:
-                                  theme.selectedChipBackgroundColor.withOpacity(0.08),
+                              splashColor: theme.optionSelectedBackgroundColor
+                                  .withOpacity(0.08),
                               highlightColor:
-                                  theme.selectedChipBackgroundColor.withOpacity(0.04),
+                                  theme.optionSelectedBackgroundColor
+                                      .withOpacity(0.04),
                               onHighlightChanged: (value) {
                                 if (_selected >= 0 || _advanced) return;
                                 setState(() {
@@ -368,10 +394,12 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                                 duration: const Duration(milliseconds: 200),
                                 curve: Curves.easeOut,
                                 width: double.infinity,
-                                padding:
-                                const EdgeInsets.symmetric(vertical: 16),
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 14,
+                                  horizontal: 20,
+                                ),
                                 decoration: BoxDecoration(
-                                  color: resolvedColor,
+                                  color: resolvedBackground,
                                   borderRadius: borderRadius,
                                   boxShadow: theme.optionCardShadow,
                                   border: Border.all(
@@ -381,11 +409,35 @@ class _CompetitionScreenState extends State<CompetitionScreen>
                                     width: 2,
                                   ),
                                 ),
-                                child: Text(
-                                  _currentQuestion.choices[i],
-                                  textAlign: TextAlign.center,
-                                  style: theme.optionTextStyle
-                                      .copyWith(fontSize: optionFontSize),
+                                child: Row(
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    Container(
+                                      width: badgeSize,
+                                      height: badgeSize,
+                                      decoration: BoxDecoration(
+                                        color: badgeBackground,
+                                        borderRadius: BorderRadius.circular(
+                                            theme.optionBadgeRadius),
+                                      ),
+                                      alignment: Alignment.center,
+                                      child: Text(
+                                        _optionBadgeLabel(i),
+                                        style: theme.optionTextStyle.copyWith(
+                                          fontSize: optionFontSize * 0.9,
+                                          fontWeight: FontWeight.bold,
+                                          color: badgeForeground,
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 16),
+                                    Expanded(
+                                      child: Text(
+                                        _currentQuestion.choices[i],
+                                        style: resolvedTextStyle,
+                                      ),
+                                    ),
+                                  ],
                                 ),
                               ),
                             ),

--- a/lib/theme/competition_theme.dart
+++ b/lib/theme/competition_theme.dart
@@ -22,6 +22,14 @@ class CompetitionTheme {
   final double optionCardRadius;
   final List<BoxShadow> optionCardShadow;
   final Color optionSelectedBorderColor;
+  final Color optionSelectedBackgroundColor;
+  final Color optionSelectedTextColor;
+  final Color optionBadgeBackgroundColor;
+  final Color optionBadgeForegroundColor;
+  final Color optionBadgeSelectedBackgroundColor;
+  final Color optionBadgeSelectedForegroundColor;
+  final double optionBadgeRadius;
+  final double optionBadgeSize;
 
   /// Color of the progress bar displayed under the question.
   final Color progressBarColor;
@@ -63,11 +71,19 @@ class CompetitionTheme {
       BoxShadow(color: Colors.black12, blurRadius: 6, offset: Offset(0, 3)),
     ],
     this.optionCardColor = Colors.white,
-    this.optionCardRadius = 24.0,
+    this.optionCardRadius = 999.0,
     this.optionCardShadow = const [
       BoxShadow(color: Colors.black12, blurRadius: 6, offset: Offset(0, 3)),
     ],
     this.optionSelectedBorderColor = Colors.pinkAccent,
+    this.optionSelectedBackgroundColor = Colors.pinkAccent,
+    this.optionSelectedTextColor = Colors.white,
+    this.optionBadgeBackgroundColor = const Color(0xFFEDE7FF),
+    this.optionBadgeForegroundColor = Colors.pinkAccent,
+    this.optionBadgeSelectedBackgroundColor = const Color(0x33FFFFFF),
+    this.optionBadgeSelectedForegroundColor = Colors.white,
+    this.optionBadgeRadius = 999.0,
+    this.optionBadgeSize = 36.0,
     this.progressBarColor = Colors.pinkAccent,
     this.appBarBackgroundColor = const Color(0xFF6C5CE7),
     this.appBarForegroundColor = Colors.white,
@@ -121,6 +137,12 @@ class CompetitionTheme {
       questionCardColor: theme.cardColor,
       optionCardColor: theme.cardColor,
       optionSelectedBorderColor: scheme.primary,
+      optionSelectedBackgroundColor: scheme.primary,
+      optionSelectedTextColor: scheme.onPrimary,
+      optionBadgeBackgroundColor: scheme.primary.withOpacity(0.08),
+      optionBadgeForegroundColor: scheme.primary,
+      optionBadgeSelectedBackgroundColor: scheme.onPrimary.withOpacity(0.20),
+      optionBadgeSelectedForegroundColor: scheme.onPrimary,
       progressBarColor: scheme.primary,
       appBarBackgroundColor: scheme.primary,
       appBarForegroundColor: scheme.onPrimary,
@@ -177,8 +199,20 @@ class CompetitionTheme {
       optionCardRadius: scaledDimension(
         base: optionCardRadius,
         scale: scale,
+        min: 24,
+        max: 999,
+      ),
+      optionBadgeRadius: scaledDimension(
+        base: optionBadgeRadius,
+        scale: scale,
         min: 16,
-        max: 32,
+        max: 999,
+      ),
+      optionBadgeSize: scaledDimension(
+        base: optionBadgeSize,
+        scale: scale,
+        min: 28,
+        max: 44,
       ),
       timerSize: scaledDimension(
         base: timerSize,
@@ -222,6 +256,14 @@ class CompetitionTheme {
     double? optionCardRadius,
     List<BoxShadow>? optionCardShadow,
     Color? optionSelectedBorderColor,
+    Color? optionSelectedBackgroundColor,
+    Color? optionSelectedTextColor,
+    Color? optionBadgeBackgroundColor,
+    Color? optionBadgeForegroundColor,
+    Color? optionBadgeSelectedBackgroundColor,
+    Color? optionBadgeSelectedForegroundColor,
+    double? optionBadgeRadius,
+    double? optionBadgeSize,
     Color? progressBarColor,
     Color? appBarBackgroundColor,
     Color? appBarForegroundColor,
@@ -253,6 +295,20 @@ class CompetitionTheme {
       optionCardShadow: optionCardShadow ?? this.optionCardShadow,
       optionSelectedBorderColor:
           optionSelectedBorderColor ?? this.optionSelectedBorderColor,
+      optionSelectedBackgroundColor:
+          optionSelectedBackgroundColor ?? this.optionSelectedBackgroundColor,
+      optionSelectedTextColor:
+          optionSelectedTextColor ?? this.optionSelectedTextColor,
+      optionBadgeBackgroundColor:
+          optionBadgeBackgroundColor ?? this.optionBadgeBackgroundColor,
+      optionBadgeForegroundColor:
+          optionBadgeForegroundColor ?? this.optionBadgeForegroundColor,
+      optionBadgeSelectedBackgroundColor: optionBadgeSelectedBackgroundColor ??
+          this.optionBadgeSelectedBackgroundColor,
+      optionBadgeSelectedForegroundColor: optionBadgeSelectedForegroundColor ??
+          this.optionBadgeSelectedForegroundColor,
+      optionBadgeRadius: optionBadgeRadius ?? this.optionBadgeRadius,
+      optionBadgeSize: optionBadgeSize ?? this.optionBadgeSize,
       progressBarColor: progressBarColor ?? this.progressBarColor,
       appBarBackgroundColor:
           appBarBackgroundColor ?? this.appBarBackgroundColor,


### PR DESCRIPTION
## Summary
- restyle competition answer options with leading letter badges, pill layout, and responsive spacing
- highlight the selected choice with the accent background and white text while keeping hover feedback intact
- extend `CompetitionTheme` with configurable colors and radii for option badges and selected states

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ded0908bb4832fa53635bd022857c1