### PR TITLE
Move difficulty selector near header in official intro screen

### DIFF
--- a/lib/screens/official_intro_screen.dart
+++ b/lib/screens/official_intro_screen.dart
@@ -368,7 +368,11 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
                       child: Padding(
                         padding: const EdgeInsets.symmetric(horizontal: 24),
                         child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: [
+                            const SizedBox(height: 16),
+                            _buildDifficultySelector(theme, brand),
+                            const SizedBox(height: 28),
                             Row(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
@@ -383,14 +387,13 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
                                 ),
                               ],
                             ),
-                            const SizedBox(height: 32),
+                            const SizedBox(height: 28),
                             _buildRulesCard(theme, brand),
                             const SizedBox(height: 24),
                             _buildDistributionCard(theme, brand),
                             const SizedBox(height: 24),
                             _buildAgreementCard(theme, brand),
                             const SizedBox(height: 24),
-                            _buildDifficultySelector(theme, brand),
                             if (_errorMessage != null) ...[
                               const SizedBox(height: 16),
                               Text(
@@ -482,6 +485,7 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
         Wrap(
           spacing: 12,
           runSpacing: 12,
+          alignment: WrapAlignment.start,
           children: [
             _buildDifficultyChip(
               theme,


### PR DESCRIPTION
## Summary
- move the difficulty selector to appear directly below the hero header on the official intro screen
- adjust spacing and alignment so the chips wrap cleanly and the surrounding cards keep consistent gaps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e036274018832fa53ade3ef6f87130