### PR TITLE
Ensure per-question override uses minimum bound

### DIFF
--- a/lib/screens/exam_full_screen.dart
+++ b/lib/screens/exam_full_screen.dart
@@ -3,6 +3,7 @@
 // IMPORTS
 // =======================
 import 'dart:async'; // Pour Timer.periodic (le compte à rebours)
+import 'dart:math' as math;
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugPrint, debugPrintStack, defaultTargetPlatform, kIsWeb; // Utilitaires de plateforme & debug
 import 'package:flutter/material.dart'; // Widgets de base
@@ -54,7 +55,7 @@ class ExamFullScreen extends StatefulWidget {
   final bool showLocalSummary;    // Afficher le résumé local en fin d’épreuve ou non
 
   /// Si défini (>0), remplace la durée totale par: (sec/par question) × nbQuestions
-  /// (clamp entre 5..10 s par question) — utile pour des modes "speed".
+  /// (avec une borne basse de 5 s par question) — utile pour des modes "speed".
   final int? overridePerQuestionSeconds;
 
   final bool competitionMode; // Active verrouillage, orientation, etc.
@@ -174,7 +175,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     // --- Durée initiale ---
     remaining = widget.duration.inSeconds;
     if (widget.overridePerQuestionSeconds != null && widget.overridePerQuestionSeconds! > 0) {
-      final perQ = widget.overridePerQuestionSeconds!.clamp(5, 10); // borne 5..10
+      final perQ = math.max(5, widget.overridePerQuestionSeconds!); // borne basse 5 s
       remaining = perQ * widget.questions.length; // recalcule durée totale
     }
     if (widget.initialRemainingSeconds != null && widget.initialRemainingSeconds! > 0) {

--- a/lib/screens/multi_exam_flow.dart
+++ b/lib/screens/multi_exam_flow.dart
@@ -3,6 +3,7 @@
 // IMPORTS
 // =======================
 import 'dart:async'; // Pour Timer.periodic (le compte à rebours)
+import 'dart:math' as math;
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugPrint, debugPrintStack, defaultTargetPlatform, kIsWeb; // Utilitaires de plateforme & debug
 import 'package:flutter/material.dart'; // Widgets de base
@@ -54,7 +55,7 @@ class ExamFullScreen extends StatefulWidget {
   final bool showLocalSummary;    // Afficher le résumé local en fin d’épreuve ou non
 
   /// Si défini (>0), remplace la durée totale par: (sec/par question) × nbQuestions
-  /// (clamp entre 5..10 s par question) — utile pour des modes "speed".
+  /// (avec une borne basse de 5 s par question) — utile pour des modes "speed".
   final int? overridePerQuestionSeconds;
 
   final bool competitionMode; // Active verrouillage, orientation, etc.
@@ -174,7 +175,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     // --- Durée initiale ---
     remaining = widget.duration.inSeconds;
     if (widget.overridePerQuestionSeconds != null && widget.overridePerQuestionSeconds! > 0) {
-      final perQ = widget.overridePerQuestionSeconds!.clamp(5, 10); // borne 5..10
+      final perQ = math.max(5, widget.overridePerQuestionSeconds!); // borne basse 5 s
       remaining = perQ * widget.questions.length; // recalcule durée totale
     }
     if (widget.initialRemainingSeconds != null && widget.initialRemainingSeconds! > 0) {

--- a/lib/screens/official_intro_screen.dart
+++ b/lib/screens/official_intro_screen.dart
@@ -3,7 +3,7 @@
 // IMPORTS
 // =======================
 import 'dart:async'; // Pour Timer.periodic (le compte à rebours)
-import 'dart:math';
+import 'dart:math' as math;
 import 'package:flutter/foundation.dart'
     show TargetPlatform, debugPrint, debugPrintStack, defaultTargetPlatform, kIsWeb; // Utilitaires de plateforme & debug
 import 'package:flutter/material.dart'; // Widgets de base
@@ -187,7 +187,7 @@ class _OfficialIntroScreenState extends State<OfficialIntroScreen> {
   }
 
   Future<List<Question>> _prepareQuestions(List<Question> all) async {
-    final rng = Random();
+    final rng = math.Random();
     final selected = <Question>[];
     final usedIds = <String>{};
 
@@ -994,7 +994,7 @@ class ExamFullScreen extends StatefulWidget {
   final bool showLocalSummary;    // Afficher le résumé local en fin d’épreuve ou non
 
   /// Si défini (>0), remplace la durée totale par: (sec/par question) × nbQuestions
-  /// (clamp entre 5..10 s par question) — utile pour des modes "speed".
+  /// (avec une borne basse de 5 s par question) — utile pour des modes "speed".
   final int? overridePerQuestionSeconds;
 
   final bool competitionMode; // Active verrouillage, orientation, etc.
@@ -1114,7 +1114,7 @@ class _ExamFullScreenState extends State<ExamFullScreen> with WidgetsBindingObse
     // --- Durée initiale ---
     remaining = widget.duration.inSeconds;
     if (widget.overridePerQuestionSeconds != null && widget.overridePerQuestionSeconds! > 0) {
-      final perQ = widget.overridePerQuestionSeconds!.clamp(5, 10); // borne 5..10
+      final perQ = math.max(5, widget.overridePerQuestionSeconds!); // borne basse 5 s
       remaining = perQ * widget.questions.length; // recalcule durée totale
     }
     if (widget.initialRemainingSeconds != null && widget.initialRemainingSeconds! > 0) {


### PR DESCRIPTION
## Summary
- ensure per-question override durations use a 5-second minimum across exam flows
- align comments and math imports accordingly in the duplicated screen copies

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e03d735084832fb96a2eb8ecdd1d07