### PR TITLE
Adjust arcade mode nav bar palette usage

### DIFF
--- a/lib/screens/arcade_mode_screen.dart
+++ b/lib/screens/arcade_mode_screen.dart
@@ -684,6 +684,12 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
         final resumeIndex = math.max(0, _progressData?.resumeIndex ?? 0);
         final previewLevels = _buildPreviewLevels(resumeIndex);
         final bool isDark = base.brightness == Brightness.dark;
+        final Color navBackground = palette.primaryDark;
+        final Color navForeground =
+            ThemeData.estimateBrightnessForColor(navBackground) ==
+                    Brightness.dark
+                ? Colors.white
+                : Colors.black;
         final Color navHighlight =
             palette.secondary.withOpacity(isDark ? 0.32 : 0.20);
 
@@ -819,9 +825,9 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
             bottomNavigationBar: PlayBottomNavBar(
               destinations: playNavDestinations,
               selectedIndex: 2,
-              backgroundColor: palette.primary,
+              backgroundColor: navBackground,
               highlightColor: navHighlight,
-              foregroundColor: palette.onPrimary,
+              foregroundColor: navForeground,
               onDestinationSelected: (index) {
                 if (index == 2) return;
                 Navigator.pushReplacement(


### PR DESCRIPTION
## Summary
- derive the arcade bottom navigation colors from the current palette to improve consistency and contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e07c1cf30c832fa259511726a9a306