### PR TITLE
Enable arcade level tile tap for current level

### DIFF
--- a/lib/screens/arcade_mode_screen.dart
+++ b/lib/screens/arcade_mode_screen.dart
@@ -762,6 +762,11 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
                           level: entry.level,
                           isCompleted: entry.isCompleted,
                           isCurrent: entry.isCurrent,
+                          onTap: entry.isCurrent
+                              ? (_preparing || _loadingProgress
+                                  ? null
+                                  : _startArcade)
+                              : null,
                         );
                       },
                       separatorBuilder: (_, __) => Divider(
@@ -1053,11 +1058,13 @@ class _LevelListTile extends StatelessWidget {
   final _ArcadeLevel level;
   final bool isCompleted;
   final bool isCurrent;
+  final VoidCallback? onTap;
 
   const _LevelListTile({
     required this.level,
     required this.isCompleted,
     required this.isCurrent,
+    this.onTap,
   });
 
   @override
@@ -1086,7 +1093,7 @@ class _LevelListTile extends StatelessWidget {
         highlightCurrent ? scheme.onPrimary : scheme.onSurfaceVariant;
 
     return InkWell(
-      onTap: null, // aperçu non cliquable (la session démarre via les CTA)
+      onTap: onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
         decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- allow `_LevelListTile` to accept an optional tap callback and forward it to InkWell
- enable tapping the current level tile to start arcade mode when preparation/loading is idle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07c194828832fae46922a3245634c