### PR TITLE
Remove arcade FAB and adjust list padding

### DIFF
--- a/lib/screens/arcade_mode_screen.dart
+++ b/lib/screens/arcade_mode_screen.dart
@@ -714,7 +714,7 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
             ),
             body: SafeArea(
               child: ListView(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 96),
                 children: [
                   // Bloc violet Featured avec CTA "Lancer la session"
                   _FeaturedCard(
@@ -788,33 +788,6 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
                 ],
               ),
             ),
-
-            // Gros bouton centré (comme le “+” de la maquette)
-            floatingActionButtonLocation:
-                FloatingActionButtonLocation.centerDocked,
-            floatingActionButton: Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
-              child: ElevatedButton.icon(
-                onPressed:
-                    _preparing || _loadingProgress ? null : _startArcade,
-                icon: _preparing
-                    ? SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: themed.colorScheme.onPrimary,
-                        ),
-                      )
-                    : const Icon(Icons.play_arrow),
-                label: Text(_preparing
-                    ? 'Préparation…'
-                    : _loadingProgress
-                        ? 'Chargement…'
-                        : 'Commencer maintenant'),
-              ),
-            ),
-
             // BottomNav CIVEXAM
             bottomNavigationBar: PlayBottomNavBar(
               destinations: playNavDestinations,


### PR DESCRIPTION
## Summary
- remove the floating action button from the Arcade mode screen scaffold
- increase the main list view bottom padding to preserve spacing above the navigation bar

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e07c174d34832f985ac0fb08ed7af2