### PR TITLE
Ensure current arcade preview level appears first

### DIFF
--- a/lib/screens/arcade_mode_screen.dart
+++ b/lib/screens/arcade_mode_screen.dart
@@ -846,12 +846,12 @@ class _ArcadeModeScreenState extends State<ArcadeModeScreen> {
       );
     }
 
-    entries.add(
-      _PreviewLevelEntry(
-        level: _previewLevelAt(safeIndex),
-        isCurrent: true,
-      ),
+    final currentEntry = _PreviewLevelEntry(
+      level: _previewLevelAt(safeIndex),
+      isCurrent: true,
     );
+
+    entries.insert(0, currentEntry);
 
     return entries;
   }


### PR DESCRIPTION
## Summary
- insert the current arcade preview entry at the front of the preview list so it renders before completed levels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e089478500832f82efcf346ea58ba4