### PR TITLE
Add French labels for design palette options

### DIFF
--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -33,6 +33,18 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
     'calmPastels',
   ];
 
+  static const Map<String, String> _paletteLabels = {
+    'civFlag': 'Civique',
+    'navyCyanAmber': 'Marine',
+    'indigoPurpleSky': 'Indigo',
+    'emeraldTealMint': 'Émeraude',
+    'royalBlueGold': 'Royal',
+    'charcoalElectric': 'Électrique',
+    'forestSandTerracotta': 'Terracotta',
+    'cobaltLimeSlate': 'Cobalt',
+    'calmPastels': 'Pastel',
+  };
+
   @override
   void initState() {
     super.initState();
@@ -537,6 +549,11 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
   }
 
   String _readablePalette(String name) {
+    final directLabel = _paletteLabels[name];
+    if (directLabel != null) {
+      return directLabel;
+    }
+
     final spaced = name
         .replaceAllMapped(RegExp(r'(?<=[a-z])(?=[A-Z])'), (m) => ' ')
         .replaceAll('_', ' ')


### PR DESCRIPTION
## Summary
- add explicit French labels for design palettes in the customization screen
- keep automatic fallback naming for any palettes without explicit labels

## Testing
- not run (environment missing Dart SDK for formatting)


------
https://chatgpt.com/codex/tasks/task_e_68e1cf5fd088832fae9250ba5031e231