### PR TITLE
Fix SelectedDayDetailsCard runtime key handling

### DIFF
--- a/lib/screens/categories/contest_calendar_screen.dart
+++ b/lib/screens/categories/contest_calendar_screen.dart
@@ -492,6 +492,7 @@ class _ContestCalendarScreenState extends State<ContestCalendarScreen> {
               child: _selectedDate == null
                   ? const SizedBox.shrink()
                   : _SelectedDayDetailsCard(
+                      key: ValueKey<DateTime>(_selectedDate!),
                       date: _selectedDate!,
                       events: selectedEvents,
                       resolveColor: (ContestEventCategory category) =>
@@ -794,11 +795,12 @@ class _EventTile extends StatelessWidget {
 }
 
 class _SelectedDayDetailsCard extends StatelessWidget {
-  const _SelectedDayDetailsCard({
+  _SelectedDayDetailsCard({
+    super.key,
     required this.date,
     required this.events,
     required this.resolveColor,
-  }) : super(key: ValueKey<DateTime>(date));
+  });
 
   final DateTime date;
   final List<ContestEvent> events;


### PR DESCRIPTION
## Summary
- ensure AnimatedSwitcher provides a ValueKey based on the selected date
- update _SelectedDayDetailsCard to accept an injected key so the key is created at runtime

## Testing
- flutter analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e26cbf88ec832fa97d45a730e89c03