### PR TITLE
Adjust contest calendar DateTime initialization

### DIFF
--- a/lib/screens/categories/contest_calendar_screen.dart
+++ b/lib/screens/categories/contest_calendar_screen.dart
@@ -24,12 +24,13 @@ class ContestEvent {
   });
 }
 
-const DateTime _calendarFirstDay = DateTime(2024, 1, 1);
-const DateTime _calendarLastDay = DateTime(2025, 12, 31);
-const DateTime _calendarStartMonth = DateTime(2024, 1, 1);
-const DateTime _calendarEndMonth = DateTime(2025, 12, 1);
+final DateTime _calendarFirstDay = DateTime(2024, 1, 1);
+final DateTime _calendarLastDay = DateTime(2025, 12, 31);
+final DateTime _calendarStartMonth = DateTime(2024, 1, 1);
+final DateTime _calendarEndMonth = DateTime(2025, 12, 1);
 
-const List<ContestEvent> _contestEventList = <ContestEvent>[
+final List<ContestEvent> _contestEventList =
+    List<ContestEvent>.unmodifiable(<ContestEvent>[
   ContestEvent(
     date: DateTime(2024, 1, 15),
     title: 'Ouverture des inscriptions en ligne',
@@ -182,7 +183,7 @@ const List<ContestEvent> _contestEventList = <ContestEvent>[
         'Accueil des admis 2025 et lancement du programme de formation initiale à l’ENA.',
     category: ContestEventCategory.integration,
   ),
-];
+]);
 
 Map<DateTime, List<ContestEvent>> _buildEventIndex() {
   final Map<DateTime, List<ContestEvent>> grouped =


### PR DESCRIPTION
## Summary
- replace contest calendar `const DateTime` declarations with runtime-initialized finals
- wrap the contest event definitions in a runtime-created unmodifiable list instead of a const literal

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26cbad3f8832f959ef189c587d386