### PR TITLE
Add play bottom navigation to standalone screens

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -18,7 +18,9 @@ import '../models/user_profile.dart';
 import 'profile_edit_screen.dart';
 import '../utils/arcade_level_utils.dart';
 import '../widgets/arcade_badge_chip.dart';
+import '../widgets/play_bottom_nav_bar.dart';
 import '../widgets/play_themed_scaffold.dart';
+import 'play_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -254,6 +256,31 @@ class _DashboardScreenState extends State<DashboardScreen> {
       bodyMode: PlayThemedScaffoldBodyMode.panel,
       safeAreaTop: true,
       bodyPadding: const EdgeInsets.fromLTRB(16, kToolbarHeight + 16, 16, 24),
+      bottomNavigationBar: Builder(
+        builder: (context) {
+          final theme = Theme.of(context);
+          final Color brand = theme.colorScheme.primary;
+          final Color onBrand = theme.colorScheme.onPrimary;
+          final Color navHighlight =
+              Color.alphaBlend(onBrand.withOpacity(0.14), brand);
+          return PlayBottomNavBar(
+            destinations: playNavDestinations,
+            selectedIndex: 1,
+            backgroundColor: brand,
+            highlightColor: navHighlight,
+            foregroundColor: onBrand,
+            onDestinationSelected: (index) {
+              if (index == 1) return;
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PlayScreen(initialIndex: index),
+                ),
+              );
+            },
+          );
+        },
+      ),
       appBar: AppBar(
         title: const Text('Mon dashboard'),
         actions: [

--- a/lib/screens/design_settings_screen.dart
+++ b/lib/screens/design_settings_screen.dart
@@ -9,6 +9,8 @@ import '../models/design_config.dart';
 import '../services/design_bus.dart';
 import '../services/design_prefs.dart';
 import '../utils/palette_utils.dart';
+import '../widgets/play_bottom_nav_bar.dart';
+import 'play_screen.dart';
 
 class DesignSettingsScreen extends StatefulWidget {
   const DesignSettingsScreen({super.key});
@@ -86,6 +88,8 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
     final backgroundColor =
         Color.lerp(Colors.white, backgroundGradient.last, 0.9) ??
             backgroundGradient.last;
+    final Color navHighlight =
+        Color.alphaBlend(onAccent.withOpacity(0.14), accent);
 
     return Scaffold(
       backgroundColor: backgroundColor,
@@ -193,6 +197,22 @@ class _DesignSettingsScreenState extends State<DesignSettingsScreen> {
             ],
           ),
         ),
+      ),
+      bottomNavigationBar: PlayBottomNavBar(
+        destinations: playNavDestinations,
+        selectedIndex: 5,
+        backgroundColor: accent,
+        highlightColor: navHighlight,
+        foregroundColor: onAccent,
+        onDestinationSelected: (index) {
+          if (index == 5) return;
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(
+              builder: (_) => PlayScreen(initialIndex: index),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/screens/exam_history_screen.dart
+++ b/lib/screens/exam_history_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import '../models/exam_history_entry.dart';
 import '../services/history_store.dart';
 import '../services/local_history_persistence.dart';
+import '../widgets/play_bottom_nav_bar.dart';
+import 'play_screen.dart';
 
 /// Palette cohérente (violet + surface claire)
 class _Brand {
@@ -234,6 +236,31 @@ class _ExamHistoryScreenState extends State<ExamHistoryScreen> {
               );
             },
           ),
+        ),
+        bottomNavigationBar: Builder(
+          builder: (context) {
+            final theme = Theme.of(context);
+            final Color brand = theme.colorScheme.primary;
+            final Color onBrand = theme.colorScheme.onPrimary;
+            final Color navHighlight =
+                Color.alphaBlend(onBrand.withOpacity(0.14), brand);
+            return PlayBottomNavBar(
+              destinations: playNavDestinations,
+              selectedIndex: 3,
+              backgroundColor: brand,
+              highlightColor: navHighlight,
+              foregroundColor: onBrand,
+              onDestinationSelected: (index) {
+                if (index == 3) return;
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => PlayScreen(initialIndex: index),
+                  ),
+                );
+              },
+            );
+          },
         ),
       ),
     );

--- a/lib/screens/profile_edit_screen.dart
+++ b/lib/screens/profile_edit_screen.dart
@@ -17,6 +17,8 @@ import '../services/competition_service.dart';
 import '../services/private_scores_store.dart';
 import 'dashboard_screen.dart';
 import '../utils/arcade_level_utils.dart';
+import '../widgets/play_bottom_nav_bar.dart';
+import 'play_screen.dart';
 
 /// Palette cohérente (violet + surface claire)
 class _Brand {
@@ -517,6 +519,31 @@ class _ProfileEditScreenState extends State<ProfileEditScreen> {
               ),
             ),
           ),
+        ),
+        bottomNavigationBar: Builder(
+          builder: (context) {
+            final theme = Theme.of(context);
+            final Color brand = theme.colorScheme.primary;
+            final Color onBrand = theme.colorScheme.onPrimary;
+            final Color navHighlight =
+                Color.alphaBlend(onBrand.withOpacity(0.14), brand);
+            return PlayBottomNavBar(
+              destinations: playNavDestinations,
+              selectedIndex: 4,
+              backgroundColor: brand,
+              highlightColor: navHighlight,
+              foregroundColor: onBrand,
+              onDestinationSelected: (index) {
+                if (index == 4) return;
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => PlayScreen(initialIndex: index),
+                  ),
+                );
+              },
+            );
+          },
         ),
       ),
     );

--- a/lib/screens/subject_list_screen.dart
+++ b/lib/screens/subject_list_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 
 import '../data/ena_taxonomy.dart';
 import '../services/question_loader.dart';
+import '../widgets/play_bottom_nav_bar.dart';
 import 'chapter_list_screen.dart';
+import 'play_screen.dart';
 
 /// Palette cohérente (violet + surface claire)
 class _Brand {
@@ -185,6 +187,31 @@ class _SubjectListScreenState extends State<SubjectListScreen> {
       child: Scaffold(
         appBar: AppBar(title: const Text('Choisir une matière')),
         body: _buildBody(),
+        bottomNavigationBar: Builder(
+          builder: (context) {
+            final theme = Theme.of(context);
+            final Color brand = theme.colorScheme.primary;
+            final Color onBrand = theme.colorScheme.onPrimary;
+            final Color navHighlight =
+                Color.alphaBlend(onBrand.withOpacity(0.14), brand);
+            return PlayBottomNavBar(
+              destinations: playNavDestinations,
+              selectedIndex: 2,
+              backgroundColor: brand,
+              highlightColor: navHighlight,
+              foregroundColor: onBrand,
+              onDestinationSelected: (index) {
+                if (index == 2) return;
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => PlayScreen(initialIndex: index),
+                  ),
+                );
+              },
+            );
+          },
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add the play screen bottom navigation bar to the dashboard, subject list, exam history, profile edit, and design settings pages
- use themed colors for the bar and route selections back to the corresponding PlayScreen tab

## Testing
- not run (flutter unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2cbc75348832fa24083ff1953f1a9