### PR TITLE
Require email verification only for password-authenticated users on splash

### DIFF
--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -16,6 +16,10 @@ class SplashScreen extends StatefulWidget {
 }
 
 class _SplashScreenState extends State<SplashScreen> {
+  bool _requiresEmailVerification(User user) {
+    return user.providerData.any((p) => p.providerId == 'password');
+  }
+
   @override
   void initState() {
     super.initState();
@@ -42,7 +46,9 @@ class _SplashScreenState extends State<SplashScreen> {
       }
       var refreshedUser = auth.currentUser;
       refreshedUser ??= user;
-      if (refreshedUser != null && !refreshedUser.emailVerified) {
+      if (refreshedUser != null &&
+          _requiresEmailVerification(refreshedUser) &&
+          !refreshedUser.emailVerified) {
         final unverifiedUser = refreshedUser;
         try {
           await auth.signOut();


### PR DESCRIPTION
### Motivation
- The splash flow previously applied the `emailVerified` gate to all Firebase providers which could sign out Google-authenticated users and hide sidebar/profile information.

### Description
- Added `bool _requiresEmailVerification(User user)` to `lib/screens/splash_screen.dart` and updated the startup check to only enforce `emailVerified` when the user has a `password` provider (i.e. email/password accounts). 
- This prevents Google (and other non-password) sign-ins from being treated as unverified and force-signed-out on app launch.

### Testing
- Attempted to run `dart format` and `flutter analyze` but the Dart/Flutter CLIs are not available in this environment so formatting/analysis could not be executed (failed). 
- Verified the code change with `git diff` and committed the update to `lib/screens/splash_screen.dart` successfully (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e806e00274832fadcd710f40dfb1df)