### PR TITLE
Rendre l'initialisation Firestore robuste aux échecs de persistance

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,13 +43,34 @@ class _CivExamAppState extends State<CivExamApp> {
       await Firebase.initializeApp(
         options: DefaultFirebaseOptions.currentPlatform,
       );
-      FirebaseFirestore.instance.settings =
-          const Settings(persistenceEnabled: true);
+      await _configureFirestore();
       final cfg = await DesignPrefs.load();
       DesignBus.push(cfg);
     } catch (error, stackTrace) {
       debugPrint('App initialization failed: $error\n$stackTrace');
       rethrow;
+    }
+  }
+
+  Future<void> _configureFirestore() async {
+    try {
+      FirebaseFirestore.instance.settings =
+          const Settings(persistenceEnabled: true);
+    } catch (error, stackTrace) {
+      debugPrint(
+        'Firestore persistence unavailable, fallback to default settings: '
+        '$error\n$stackTrace',
+      );
+      try {
+        FirebaseFirestore.instance.settings = const Settings(
+          persistenceEnabled: false,
+        );
+      } catch (fallbackError, fallbackStackTrace) {
+        debugPrint(
+          'Firestore fallback settings failed: '
+          '$fallbackError\n$fallbackStackTrace',
+        );
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- L'activation directe de la persistance Firestore pendant le démarrage peut échouer (p.ex. onglets/sessions multiples, contexte admin/dashboard) et bloquer l'initialisation, donnant l'impression que l'app ne se connecte plus à la base de données.
- Le but est d'empêcher qu'un seul point de configuration casse tout le démarrage de l'application.

### Description
- Remplacement de l'appel direct `FirebaseFirestore.instance.settings = const Settings(persistenceEnabled: true);` par un appel à une nouvelle méthode `await _configureFirestore()` dans `lib/main.dart`.
- Ajout de la méthode `Future<void> _configureFirestore()` qui tente d'activer la persistance locale et, en cas d'exception, enregistre l'erreur et retente avec `persistenceEnabled: false` pour garantir la continuité de l'initialisation.
- Les erreurs sont loggées via `debugPrint` pour faciliter le diagnostic sans arrêter le flux d'initialisation (`DesignPrefs` / `DesignBus` restent exécutés normalement).

### Testing
- Tentative d'analyse statique avec `flutter analyze` échouée car `flutter` n'est pas disponible dans l'environnement (`flutter: command not found`).
- Vérifications locales de code (recherche et revue statique) et confirmation que seul `lib/main.dart` a été modifié.
- Commit effectué: change enregistré avec le message `Fix Firestore init fallback when persistence fails`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86eeee0e0832f8051148e35363ec1)