### PR TITLE
Add Firestore composite index config and README CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,16 @@ un index composite pour ce type de requête :
 
 > ℹ️ L'index doit être créé dans chaque projet Firebase utilisé par
 > l'application (dev, staging, prod, …).
+
+
+### Déployer l'index avec Firebase CLI (recommandé)
+
+Pour éviter l'erreur `cloud_firestore/failed-precondition` ("The query requires an index"),
+le dépôt inclut maintenant `firestore.indexes.json`. Vous pouvez publier l'index avec :
+
+```bash
+firebase deploy --only firestore:indexes
+```
+
+Assurez-vous d'être connecté au bon projet Firebase (`firebase use <project-id>`).
+

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,23 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "competition_scores",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "mode",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "percent",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "durationSec",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
### Motivation
- Prevent runtime `cloud_firestore/failed-precondition` errors and make the required composite index for `competition_scores` queries reproducible across Firebase environments by shipping the index configuration in-repo.

### Description
- Add `firestore.indexes.json` containing a composite index for collection `competition_scores` with fields `mode` (ASC), `percent` (DESC) and `durationSec` (ASC), and update `README.md` to document deploying the index via `firebase deploy --only firestore:indexes` and to remind to use the correct Firebase project with `firebase use <project-id>`.

### Testing
- Ran local validation commands (`rg`, `nl`, `git diff`, and file creation checks) to verify that `firestore.indexes.json` was created and `README.md` was updated, and these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1d71e53e0832f97844f22d1e08e4f)